### PR TITLE
Improve naming of CI jobs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         java-version: [ 11, 17 ]
         runs-on: [ ubuntu-latest ]
-    name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
+    name: Jdk ${{ matrix.java-version }}, os ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
There is an issue with current ci job naming that it's impossible to get enough info from dropdown list without clicking on details...
See also picture
![image](https://user-images.githubusercontent.com/403174/189742472-15672665-8537-4294-adf3-5c5557ee0bd1.png)
The PR changes a bit naming to fix this behavior