### PR TITLE
Rename Kafkawize to Klaw in UI copy

### DIFF
--- a/src/main/resources/templates/addCluster.html
+++ b/src/main/resources/templates/addCluster.html
@@ -593,14 +593,14 @@
 										</div>
 										<div class="col-md-6">
 											<div ng-show="sslparams=='true'">
-												<label>Copy this command and execute on your kafka broker. This gives the authorization for Kafkawize to create topics on your Kafka brokers.</label>
+												<label>Copy this command and execute on your kafka broker. This gives the authorization for Klaw to create topics on your Kafka brokers.</label>
 												<br>
 												<blockquote>
 													{{ aclCommandSsl }}
 												</blockquote>
 											</div>
 											<div ng-show="plaintextparams=='true'">
-												<label>Copy this command and execute on your kafka broker. This gives the authorization for Kafkawize to create topics on your Kafka brokers.</label>
+												<label>Copy this command and execute on your kafka broker. This gives the authorization for Klaw to create topics on your Kafka brokers.</label>
 												<br>
 												<blockquote>
 													{{ aclCommandPlaintext }}
@@ -619,7 +619,7 @@
 										</div>
 										<div class="col-md-6" ng-show="sslparams=='true' && dashboardDetails.saasEnabled == 'saas'">
 											<div class="form-group">
-												<label>Download Kafkawize public key</label>
+												<label>Download Klaw public key</label>
 												<button type="button" ng-click="downloadPubKey()"
 														class="btn waves-effect waves-light btn-block btn-success" style="float:right">Download PublicKey</button>
 											</div>

--- a/src/main/resources/templates/docs.html
+++ b/src/main/resources/templates/docs.html
@@ -576,7 +576,7 @@
 										After selecting <a href="topics">topics</a> all the topics are displayed from all Kafka <a href="envs">environments</a>.
 										<br>You can search for topics with topic name or selecting a team., or can be searched based on the available documentation.
 										<br><br>
-										If you do not see the topics, there could be multiple reasons. No topics have been requested through Kafkawize, or no topics are synchronized, or there is a database connection issue. Please check with your administrator for Help from tp right.
+										If you do not see the topics, there could be multiple reasons. No topics have been requested through Klaw, or no topics are synchronized, or there is a database connection issue. Please check with your administrator for Help from tp right.
 										<br><h4 class="card-title mt-4">Topic Overview</h4><br>
 										To see the details of a topic, click on any of the topics from <a href="topics">topics</a> page. Topic details are shown.
 										<br>In topic details, all topic partitions and replication factor per each environment are shown.
@@ -612,7 +612,7 @@
 										In the topic overview page, there is a Subscribe button which opens a page to request for a new subscription.
 										<br> After selecting an environment, you can select Producer or Consumer.
 										<br>If you select Producer, you would see two options. You can choose between LITERAL or PREFIXED. Optionally you can mention a transactionalId.
-										<br><b>Note:</b>For prefixed acls, it is mandatory to have atleast one topic existing in Kafkawize with that prefix.
+										<br><b>Note:</b>For prefixed acls, it is mandatory to have atleast one topic existing in Klaw with that prefix.
 										<br>If you select Consumer, consumer group should be mentioned.
 										<br>Acl can be of IP address or Principle based.
 										<br><br><b>Note</b>: Only users with REQUEST_CREATE_SUBSCRIPTIONS can submit new subscription requests. <br>
@@ -677,11 +677,11 @@
 									</div>
 									<div ng-show="synctocluster=='true'" class="card-body">
 										<h3 class="card-title mt-4">Synchronize To Cluster</h3>
-										Synchronize is available in the main menu. Topics and Subscriptions can be recreated back on Kafka cluster with data available on Kafkawize.
+										Synchronize is available in the main menu. Topics and Subscriptions can be recreated back on Kafka cluster with data available on Klaw.
 										<br>If you have any issues with Kafka cluster, and lost all your topics and acls, you can recreate all of them with one single click from here.
 										<br><h4 class="card-title mt-4">Topics to cluster</h4>
-										From <a href="syncBackTopics">here</a>, you can retrieve all the topics from selected Kafka environment from within Kafkawize (not Kafka clsuter).
-										<br>After selecting and environment, topics from that environment availablein Kafkawize are displayed. You can select a few or there is an option to select all the topics of source environment.
+										From <a href="syncBackTopics">here</a>, you can retrieve all the topics from selected Kafka environment from within Klaw (not Kafka clsuter).
+										<br>After selecting and environment, topics from that environment availablein Klaw are displayed. You can select a few or there is an option to select all the topics of source environment.
 										<br>You need select a target environment and hit the Create button, which will start to create topics on the target environment.
 										<br>A full log is displayed at the bottom of the page.
 									</div>
@@ -692,7 +692,7 @@
                                         <br>- Email Notifications content for all notifications
                                         <br>- Cluster Api connection parameters. Connection can be tested.
                                         <br>- Temporay location for downloading reports Ex : /tmp
-                                        <br>- Email id of Super admin (kafkawize.superuser.mailid), for kafkawize users to contact in caes of any issues
+                                        <br>- Email id of Super admin (kafkawize.superuser.mailid), for Klaw users to contact in caes of any issues
                                         <br>- Retrieve Avro schemas (kafkawize.getschemas.enable) true/false
                                         <br>- Names of environments (kafkawize.envs.standardnames) DEV/TST..
                                         <br>- Allowed roles when adding a new user
@@ -703,8 +703,8 @@
                                         <br><h4 class="card-title mt-4">Cache reset</h4>
                                         When a new property or server configuration is added or updated directly from Database, you can reset the cache from this page, to reflect the changes.
 
-                                        <br><h4 class="card-title mt-4">Stop Kafkawize</h4>
-                                        Kafkawize can be stopped from this page. User who has SHUTDOWN_KAFKAWIZE permission can stop.
+                                        <br><h4 class="card-title mt-4">Stop Klaw</h4>
+                                        Klaw can be stopped from this page. User who has SHUTDOWN_KAFKAWIZE permission can stop.
 
                                     </div>
 									<div ng-show="tenants=='true'" class="card-body">

--- a/src/main/resources/templates/feedback.html
+++ b/src/main/resources/templates/feedback.html
@@ -20,7 +20,7 @@
 
     <!-- Favicon icon -->
     <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon.png">
-    <title>Registration Review | Kafkawize</title>
+    <title>Registration Review | Klaw</title>
     <link rel="canonical" href="https://www.wrappixel.com/templates/materialpro/" />
 
     <link href="assets/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/helpwizard.html
+++ b/src/main/resources/templates/helpwizard.html
@@ -436,7 +436,7 @@
 				<div class="col-12">
 					<div class="card">
 						<div class="card-body wizard-content">
-							<h4 class="card-title">Configure Kafkawize Wizard</h4>
+							<h4 class="card-title">Configure Klaw Wizard</h4>
 
 							<form action="#" class="tab-wizard wizard-circle">
 								<!-- Step 0 -->
@@ -446,7 +446,7 @@
 										<div class="col-md-12">
 											<div class="form-group">
 												<h2 class="text-success">Congratulations !!</h2><br>
-												<h5>Kafkawize can be configured easily if you follow the next steps from here</h5><br>
+												<h5>Klaw can be configured easily if you follow the next steps from here</h5><br>
 												<h5>In these steps we are going to configure kafka clusters, environments, teams, users, roles and permissions</h5>
 												<h5>For any questions or support, please click the Help button on the top right.</h5>
 												<br>
@@ -463,7 +463,7 @@
 												<h2 class="text-success">Configure Kafka clusters !!</h2><br>
 												<h5>Configure your kafka clusters from <a class="text-primary" href="clusters">here</a>. You can add any number of clusters. Only users with SUPERADMIN roles can add.</h5><br>
 												<h5>After adding the cluster, if you have selected SSL as the protocol, download the public key and import to your kafka broker certificates.</h5><br>
-												<h5>Execute the command provided which authorizes Kafkawize to create Kafka Topis, subscriptions (acls), etc</h5>
+												<h5>Execute the command provided which authorizes Klaw to create Kafka Topis, subscriptions (acls), etc</h5>
 											</div>
 										</div>
 									</div>
@@ -507,7 +507,7 @@
 												<h2 class="text-success">Test Kafka connectivity !!</h2><br>
 												<h5>After configuring kafka environments,
 													<br>1. Upload the public key of your broker keystore
-													<br>2. Import public key of kafkawize to your truststore
+													<br>2. Import public key of Klaw to your truststore
 													<br>3. Execute provided acl command.
 													<br>Now you can test the connectivity with the button provided at <a class="text-primary" href="envs">here</a>.</h5><br>
 											</div>
@@ -522,7 +522,7 @@
 										<div class="col-md-12">
 											<div class="form-group">
 												<h2 class="text-success">Synchronize Topics and Acls !!</h2><br>
-												<h5>If you already have topics on your brokers, you can synchronize the topics and Producer and Consumer acls with Kafkawize.</h5><br>
+												<h5>If you already have topics on your brokers, you can synchronize the topics and Producer and Consumer acls with Klaw.</h5><br>
 												<h5>Synchronize Topics from <a class="text-primary" href="synchronizeTopics">here</a>.</h5><br>
 												<h5>Synchronize Acls from <a class="text-primary" href="synchronizeAcls">here</a>.</h5><br>
 											</div>
@@ -651,7 +651,7 @@
                 finish: "Submit"
             },
             onFinished: function (event, currentIndex) {
-                swal("Congratulations!", "You have a full setup of running Kafkawize !!");
+                swal("Congratulations!", "You have a full setup of running Klaw !!");
 
             }
         });

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -21,7 +21,7 @@
 
     <!-- Favicon icon -->
     <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon.png">
-    <title>Kafkawize | Kafka Self-service Topic Management Portal</title>
+    <title>Klaw | Kafka Self-service Topic Management Portal</title>
     <link rel="canonical" href="https://www.wrappixel.com/templates/materialpro/" />
 
     <link href="assets/css/style.css" rel="stylesheet">
@@ -135,7 +135,7 @@
                             <h3>
                                 <p class="text-warning">
                                     <i class="mdi mdi-chart-bubble"></i>
-                                    Kafkawize connects to your Kafka clusters creating topics & more
+                                    Klaw connects to your Kafka clusters creating topics & more
                                 </p>
                             </h3>
                             <h3>

--- a/src/main/resources/templates/loginSaas.html
+++ b/src/main/resources/templates/loginSaas.html
@@ -21,7 +21,7 @@
 
     <!-- Favicon icon -->
     <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon.png">
-    <title>Kafkawize | Kafka Self-service Topic Management Portal</title>
+    <title>Klaw | Kafka Self-service Topic Management Portal</title>
     <link rel="canonical" href="https://www.wrappixel.com/templates/materialpro/" />
 
     <link href="assets/css/style.css" rel="stylesheet">
@@ -136,7 +136,7 @@
                             <h3>
                                 <p class="text-warning">
                                     <i class="mdi mdi-chart-bubble"></i>
-                                    Kafkawize Cloud connects to your Kafka clusters creating topics & more
+                                    Klaw Cloud connects to your Kafka clusters creating topics & more
                                 </p>
                             </h3>
                             <h3>

--- a/src/main/resources/templates/newADUser.html
+++ b/src/main/resources/templates/newADUser.html
@@ -123,7 +123,7 @@
 							<h3>
 								<p class="text-warning">
 									<i class="mdi mdi-chart-bubble"></i>
-									Kafkawize connects to your Kafka clusters creating topics & more
+									Klaw connects to your Kafka clusters creating topics & more
 								</p>
 							</h3>
 							<h3>
@@ -173,7 +173,7 @@
 				<div class="col-md-4">
 					<div ng-show="userNotFoundinKwDb == 'true'" class="row" style="align:center;padding-left:30%">
 						<p class="text-warning font-weight-bold">
-							User does not exist in Kafkawize. Please register with the below form.
+							User does not exist in Klaw. Please register with the below form.
 						</p>
 					</div>
 					<div class="login-box card">

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -123,7 +123,7 @@
                             <h3>
                                 <p class="text-warning">
                                     <i class="mdi mdi-chart-bubble"></i>
-                                    Kafkawize connects to your Kafka clusters creating topics & more
+                                    Klaw connects to your Kafka clusters creating topics & more
                                 </p>
                             </h3>
                             <h3>

--- a/src/main/resources/templates/registerLdap.html
+++ b/src/main/resources/templates/registerLdap.html
@@ -123,7 +123,7 @@
                             <h3>
                                 <p class="text-warning">
                                     <i class="mdi mdi-chart-bubble"></i>
-                                    Kafkawize connects to your Kafka clusters creating topics & more
+                                    Klaw connects to your Kafka clusters creating topics & more
                                 </p>
                             </h3>
                             <h3>
@@ -173,7 +173,7 @@
                 <div class="col-md-4">
                     <div ng-show="userNotFoundinKwDb == 'true'" class="row" style="align:center;padding-left:30%">
                         <p class="text-warning font-weight-bold">
-                            Dear {{registerUser.username}}, your record does not exist in Kafkawize. Please register with the below form.
+                            Dear {{registerUser.username}}, your record does not exist in Klaw. Please register with the below form.
                         </p>
                     </div>
                     <div class="login-box card">

--- a/src/main/resources/templates/registerSaas.html
+++ b/src/main/resources/templates/registerSaas.html
@@ -124,7 +124,7 @@
                             <h3>
                                 <p class="text-warning">
                                     <i class="mdi mdi-chart-bubble"></i>
-                                    Kafkawize Cloud connects to your Kafka clusters creating topics & more
+                                    Klaw Cloud connects to your Kafka clusters creating topics & more
                                 </p>
                             </h3>
                             <h3>

--- a/src/main/resources/templates/registrationReview.html
+++ b/src/main/resources/templates/registrationReview.html
@@ -20,7 +20,7 @@
 
     <!-- Favicon icon -->
     <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon.png">
-    <title>Registration Review | Kafkawize</title>
+    <title>Registration Review | Klaw</title>
     <link rel="canonical" href="https://www.wrappixel.com/templates/materialpro/" />
 
     <link href="assets/css/style.css" rel="stylesheet">
@@ -103,7 +103,7 @@
                 <div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >
                     <div class="ribbon-wrapper card">
                         <div class="ribbon ribbon-warning">Registration status : Success</div>
-                        <p class="ribbon-content">Thankyou for registering in Kafkawize. An email is sent to Administrator for registration activation. You will be notified soon.</p>
+                        <p class="ribbon-content">Thankyou for registering in Klaw. An email is sent to Administrator for registration activation. You will be notified soon.</p>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/registrationReviewSaas.html
+++ b/src/main/resources/templates/registrationReviewSaas.html
@@ -20,7 +20,7 @@
 
     <!-- Favicon icon -->
     <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon.png">
-    <title>Registration Review | Kafkawize</title>
+    <title>Registration Review | Klaw</title>
     <link rel="canonical" href="https://www.wrappixel.com/templates/materialpro/" />
 
     <link href="assets/css/style.css" rel="stylesheet">
@@ -103,7 +103,7 @@
                 <div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >
                     <div class="ribbon-wrapper card">
                         <div class="ribbon ribbon-success">Registration status : Success</div>
-                        <p class="ribbon-content">Thankyou for registering in Kafkawize. An email is sent to you with login details. Please check your <b><u><font size="4">SPAM folder</font></u></b> too.</p>
+                        <p class="ribbon-content">Thankyou for registering in Klaw. An email is sent to you with login details. Please check your <b><u><font size="4">SPAM folder</font></u></b> too.</p>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/serverConfig.html
+++ b/src/main/resources/templates/serverConfig.html
@@ -438,7 +438,7 @@
 					<div class="card">
 						<div class="card-body">
 							<table class="table color-table success-table" width="100%"><tr>
-								<td width="70%"><h4 class="card-title">Stop Kafkawize</h4></td>
+								<td width="70%"><h4 class="card-title">Stop Klaw</h4></td>
 								<td align="right">
 									<i class="fas fa-arrow-alt-circle-left"></i>
 									<button type="button" ng-click="shutdownKw()"
@@ -458,7 +458,7 @@
 						<div class="card-body">
 
 							<table class="table color-table success-table" width="100%"><tr>
-								<td width="70%"><h4 class="card-title">Kafkawize Settings</h4></td>
+								<td width="70%"><h4 class="card-title">Klaw Settings</h4></td>
 								<td align="right">
 									<i class="fas fa-arrow-alt-circle-left"></i>
 									<button type="button" ng-click="resetCache()"
@@ -528,7 +528,7 @@
 				<div class="col-lg-12" ng-init="getAllServerProperties();">
 					<div class="card">
 						<div class="card-body">
-							<h4 class="card-title">Kafkawize Server Config</h4>
+							<h4 class="card-title">Klaw Server Config</h4>
 							<hr size="1" color="black">
 							<div>
 								<table width="100%" class="table table-hover color-table success-table" style="table-layout:fixed;">

--- a/src/main/resources/templates/synchronizeConnectors.html
+++ b/src/main/resources/templates/synchronizeConnectors.html
@@ -598,7 +598,7 @@
 											<td ng-show="resultBrowset.remarks == 'DELETED'">
 												<a class="mytooltip" href="javascript:void(0)" style="color:red;">
 													<i class="fas fa-stopwatch"></i>
-													<span class="tooltip-content3">Connector deleted on cluster. Select REMOVE-FROM-KAFKAWIZE team to delete from Kafkawize.</span>
+													<span class="tooltip-content3">Connector deleted on cluster. Select REMOVE-FROM-KAFKAWIZE team to delete from Klaw.</span>
 												</a>
 											</td>
 											<td ng-show="resultBrowset.remarks != 'DELETED' && resultBrowset.remarks != 'ADDED'">

--- a/src/main/resources/templates/synchronizeTopics.html
+++ b/src/main/resources/templates/synchronizeTopics.html
@@ -583,7 +583,7 @@
 											<td ng-show="resultBrowset.remarks == 'DELETED'">
 												<a class="mytooltip" href="javascript:void(0)" style="color:red;">
 													<i class="fas fa-stopwatch"></i>
-													<span class="tooltip-content3">Topic deleted on cluster. Select REMOVE-FROM-KAFKAWIZE team to delete from Kafkawize.</span>
+													<span class="tooltip-content3">Topic deleted on cluster. Select REMOVE-FROM-KAFKAWIZE team to delete from Klaw.</span>
 												</a>
 											</td>
 											<td ng-show="resultBrowset.remarks != 'DELETED' && resultBrowset.remarks != 'ADDED'">

--- a/src/main/resources/templates/userActivation.html
+++ b/src/main/resources/templates/userActivation.html
@@ -20,7 +20,7 @@
 
     <!-- Favicon icon -->
     <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon.png">
-    <title>User Activation | Kafkawize</title>
+    <title>User Activation | Klaw</title>
     <link rel="canonical" href="https://www.wrappixel.com/templates/materialpro/" />
 
     <link href="assets/css/style.css" rel="stylesheet">


### PR DESCRIPTION
Leave configuration keys, contact information email and permission names out of the scope. Those need to be addressed separately.

Closes #31