### PR TITLE
Simplify and optimize ManageDatabase#getTeamNameFromTeamId

### DIFF
--- a/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -313,12 +313,9 @@ public class ManageDatabase implements ApplicationContextAware {
   }
 
   public String getTeamNameFromTeamId(int tenantId, int teamId) {
-    Optional<Map.Entry<Integer, String>> optionalTeam =
-        teamIdAndNamePerTenant.get(tenantId).entrySet().stream()
-            .filter(a -> a.getKey() == teamId)
-            .findFirst();
-    if (optionalTeam.isPresent()) return optionalTeam.get().getValue();
-    else return ""; // unknown team
+    return teamIdAndNamePerTenant
+        .getOrDefault(tenantId, Collections.emptyMap())
+        .getOrDefault(teamId, ""); // empty string in case of unknown team
   }
 
   public Map<Integer, List<String>> getEnvsOfTenantsMap() {


### PR DESCRIPTION
The idea is pretty straightforward
since there is a map `<tenantId<teamId, teamName>>` then we could use it to get teamName for O(1) by get/getOrDefault instead of searching through the entire set consuming O(n).