### PR TITLE
fix: Remove check for changes in openapi from coral pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 FRONTEND_ROOT="coral"
-OPENAPI_SPECS='openapi.yaml'
+
 GIT_ROOT=$(git rev-parse --show-toplevel)
 STAGED_FILES=$(git diff --staged --name-only)
 
-if echo "$STAGED_FILES" | grep -q -e "$FRONTEND_ROOT" -e "$OPENAPI_SPECS";
+if echo "$STAGED_FILES" | grep -q -e "$FRONTEND_ROOT";
 then
   
     pnpm --prefix="$GIT_ROOT"/"$FRONTEND_ROOT" lint-staged


### PR DESCRIPTION
# About this change - What it does

We checked for changes in the `openapi.yaml` file in the pre-commit hook that is currently only used by Frontend. 
If changes in that file where detected, the linter / formatter did run. 

Since this file is now auto-generated from Backend, this is not useful anymore!

