### PR TITLE
Return error msg to the UI when making a call to the connectors.

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.controller;
 
+import io.aiven.klaw.error.KlawBadRequestException;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.error.KlawRestException;
 import io.aiven.klaw.model.ApiResponse;
@@ -220,7 +221,8 @@ public class KafkaConnectController {
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<ConnectorOverviewPerEnv> getConnectorDetailsPerEnv(
       @RequestParam("envSelected") String envId,
-      @RequestParam("connectorName") String connectorName) {
+      @RequestParam("connectorName") String connectorName)
+      throws KlawBadRequestException {
     return new ResponseEntity<>(
         kafkaConnectControllerService.getConnectorDetailsPerEnv(envId, connectorName),
         HttpStatus.OK);

--- a/core/src/main/java/io/aiven/klaw/error/KlawBadRequestException.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawBadRequestException.java
@@ -1,0 +1,7 @@
+package io.aiven.klaw.error;
+
+public class KlawBadRequestException extends Exception {
+  public KlawBadRequestException(String error) {
+    super(error);
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/error/KlawExceptionHandler.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawExceptionHandler.java
@@ -55,6 +55,15 @@ public class KlawExceptionHandler extends ResponseEntityExceptionHandler {
         ApiResponse.builder().success(false).message(ex.getMessage()).build(), HttpStatus.CONFLICT);
   }
 
+  @ExceptionHandler({KlawBadRequestException.class})
+  protected ResponseEntity<ApiResponse> handleKlawBadRequestException(
+      KlawBadRequestException ex, WebRequest request) {
+    log.error("KlawBadRequestException handler: ", ex);
+    return new ResponseEntity<>(
+        ApiResponse.builder().success(false).message(ex.getMessage()).build(),
+        HttpStatus.BAD_REQUEST);
+  }
+
   @Override
   protected ResponseEntity<Object> handleMethodArgumentNotValid(
       MethodArgumentNotValidException ex,

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -21,6 +21,7 @@ import io.aiven.klaw.dao.KafkaConnectorRequest;
 import io.aiven.klaw.dao.KwClusters;
 import io.aiven.klaw.dao.KwKafkaConnector;
 import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.error.KlawBadRequestException;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.error.KlawRestException;
 import io.aiven.klaw.error.RestErrorResponse;
@@ -1264,7 +1265,8 @@ public class KafkaConnectControllerService {
     return overview;
   }
 
-  public ConnectorOverviewPerEnv getConnectorDetailsPerEnv(String envId, String connectorName) {
+  public ConnectorOverviewPerEnv getConnectorDetailsPerEnv(String envId, String connectorName)
+      throws KlawBadRequestException {
     ConnectorOverviewPerEnv connectorOverviewPerEnv = new ConnectorOverviewPerEnv();
     connectorOverviewPerEnv.setConnectorExists(false);
     String userName = getUserName();
@@ -1284,7 +1286,8 @@ public class KafkaConnectControllerService {
     String topicDescription = "";
     if (connectors.size() == 0) {
       connectorOverviewPerEnv.setError("Connector does not exist.");
-      return connectorOverviewPerEnv;
+      throw new KlawBadRequestException(
+          String.format("Connector %s does not exist.", connectorName));
     } else {
       Optional<KwKafkaConnector> topicDescFound =
           connectors.stream()
@@ -1319,8 +1322,7 @@ public class KafkaConnectControllerService {
             .get(0)
             .getTeamname();
     if (!Objects.equals(loggedInUserTeam, connectorModel.getTeamName())) {
-      connectorOverviewPerEnv.setError(KAFKA_CONNECT_ERR_119);
-      return connectorOverviewPerEnv;
+      throw new KlawBadRequestException(KAFKA_CONNECT_ERR_119);
     }
 
     if (connectorModel.getConnectorConfig() != null) {

--- a/core/src/main/resources/static/js/requestConnector.js
+++ b/core/src/main/resources/static/js/requestConnector.js
@@ -100,7 +100,7 @@ app.controller("requestConnectorCtrl", function($scope, $http, $location, $windo
                 }).error(
                     function(error)
                     {
-                        $scope.alert = error;
+                        $scope.alert = error.message;
                     }
                 );
         }

--- a/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
@@ -847,39 +847,38 @@ public class KafkaConnectControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-            .thenReturn(generateKafkaConnectors(2));
+        .thenReturn(generateKafkaConnectors(2));
     when(commonUtilsService.getEnvsFromUserId(eq(USERNAME))).thenReturn(Set.of("0", "1", "2", "3"));
     when(commonUtilsService.getEnvProperty(
             eq(TENANT_ID), eq("REQUEST_CONNECTORS_OF_KAFKA_CONNECT_ENVS")))
-            .thenReturn("0,1,2,3");
+        .thenReturn("0,1,2,3");
     when(commonUtilsService.getEnvProperty(eq(TENANT_ID), eq(ORDER_OF_KAFKA_CONNECT_ENVS)))
-            .thenReturn("0,1,2");
+        .thenReturn("0,1,2");
     when(manageDatabase.getKafkaConnectEnvList(commonUtilsService.getTenantId(eq(USERNAME))))
-            .thenReturn(generateEnvironments());
+        .thenReturn(generateEnvironments());
     when(manageDatabase
             .getHandleDbRequests()
             .getConnectorsFromName(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-            .thenReturn(generateKafkaConnectors(2));
+        .thenReturn(generateKafkaConnectors(2));
     when(manageDatabase
             .getHandleDbRequests()
             .existsConnectorRequest(
-                    eq(CONNECTOR_NAME), eq(RequestStatus.CREATED.value), eq("1"), eq(101)))
-            .thenReturn(false);
+                eq(CONNECTOR_NAME), eq(RequestStatus.CREATED.value), eq("1"), eq(101)))
+        .thenReturn(false);
     ConnectorOverview response =
-            kafkaConnectControllerService.getConnectorOverview(CONNECTOR_NAME, "1");
+        kafkaConnectControllerService.getConnectorOverview(CONNECTOR_NAME, "1");
 
     assertThat(response.getConnectorInfoList().get(0).isHighestEnv()).isTrue();
     assertThat(response.getConnectorInfoList().get(0).isConnectorOwner()).isTrue();
     assertThat(response.getConnectorInfoList().get(0).isHasOpenRequest()).isFalse();
     assertThat(response.getPromotionDetails().get("status"))
-            .isEqualTo(PromotionStatusType.SUCCESS.value);
+        .isEqualTo(PromotionStatusType.SUCCESS.value);
     assertThat(response.getAvailableEnvironments()).hasSize(2);
   }
 
-
   @Test
   @Order(21)
-  public void getConnectorOverviewPerEnv_ConnectorDoesNotExist()   {
+  public void getConnectorOverviewPerEnv_ConnectorDoesNotExist() {
     // A promotion is available for the tst connector but we are checking for the dev one and that
     // has already been promoted to tst.
     Set<String> envListIds = new HashSet<>();
@@ -889,24 +888,21 @@ public class KafkaConnectControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-            .thenReturn(generateKafkaConnectors(2));
+        .thenReturn(generateKafkaConnectors(2));
     when(commonUtilsService.getEnvsFromUserId(eq(USERNAME))).thenReturn(Set.of("0", "1", "2", "3"));
 
-    when(manageDatabase
-            .getHandleDbRequests()
-            .getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-            .thenReturn(generateKafkaConnectors(0));
+    when(manageDatabase.getHandleDbRequests().getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
+        .thenReturn(generateKafkaConnectors(0));
 
-    assertThatThrownBy(() -> kafkaConnectControllerService.getConnectorDetailsPerEnv("1",CONNECTOR_NAME)).isInstanceOf(KlawBadRequestException.class).hasMessage("Connector conn1 does not exist.");
-
-
+    assertThatThrownBy(
+            () -> kafkaConnectControllerService.getConnectorDetailsPerEnv("1", CONNECTOR_NAME))
+        .isInstanceOf(KlawBadRequestException.class)
+        .hasMessage("Connector conn1 does not exist.");
   }
-
-
 
   @Test
   @Order(22)
-  public void getConnectorOverviewPerEnv_ConnectorOwnedByDifferentTeam()   {
+  public void getConnectorOverviewPerEnv_ConnectorOwnedByDifferentTeam() {
     // A promotion is available for the tst connector but we are checking for the dev one and that
     // has already been promoted to tst.
     Set<String> envListIds = new HashSet<>();
@@ -916,23 +912,20 @@ public class KafkaConnectControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-            .thenReturn(generateKafkaConnectors(2));
+        .thenReturn(generateKafkaConnectors(2));
     when(commonUtilsService.getEnvsFromUserId(eq(USERNAME))).thenReturn(Set.of("0", "1", "2", "3"));
 
-    when(manageDatabase
-            .getHandleDbRequests()
-            .getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-            .thenReturn(generateKafkaConnectors(2));
+    when(manageDatabase.getHandleDbRequests().getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
+        .thenReturn(generateKafkaConnectors(2));
 
-    when(manageDatabase
-            .getHandleDbRequests()
-            .getAllTeamsOfUsers(eq(USERNAME), eq(101))).thenReturn(List.of(createTeam("Natto",23)));
+    when(manageDatabase.getHandleDbRequests().getAllTeamsOfUsers(eq(USERNAME), eq(101)))
+        .thenReturn(List.of(createTeam("Natto", 23)));
 
-    assertThatThrownBy(() -> kafkaConnectControllerService.getConnectorDetailsPerEnv("1",CONNECTOR_NAME)).isInstanceOf(KlawBadRequestException.class).hasMessage("Sorry, your team does not own the connector !!");
-
-
+    assertThatThrownBy(
+            () -> kafkaConnectControllerService.getConnectorDetailsPerEnv("1", CONNECTOR_NAME))
+        .isInstanceOf(KlawBadRequestException.class)
+        .hasMessage("Sorry, your team does not own the connector !!");
   }
-
 
   private static Team createTeam(String teamName, int teamId) {
     Team t = new Team();
@@ -941,7 +934,6 @@ public class KafkaConnectControllerServiceTest {
     t.setTeamname(teamName);
     return t;
   }
-
 
   private List<KwKafkaConnector> generateKafkaConnectors(int number) {
     List<KwKafkaConnector> connectors = new ArrayList<>();

--- a/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
@@ -3,6 +3,7 @@ package io.aiven.klaw.service;
 import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_KAFKA_CONNECT_ENVS;
 import static io.aiven.klaw.service.KafkaConnectControllerService.OBJECT_MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -17,7 +18,9 @@ import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.dao.KafkaConnectorRequest;
 import io.aiven.klaw.dao.KwKafkaConnector;
+import io.aiven.klaw.dao.Team;
 import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.error.KlawBadRequestException;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
 import io.aiven.klaw.model.ApiResponse;
@@ -844,34 +847,101 @@ public class KafkaConnectControllerServiceTest {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-        .thenReturn(generateKafkaConnectors(2));
+            .thenReturn(generateKafkaConnectors(2));
     when(commonUtilsService.getEnvsFromUserId(eq(USERNAME))).thenReturn(Set.of("0", "1", "2", "3"));
     when(commonUtilsService.getEnvProperty(
             eq(TENANT_ID), eq("REQUEST_CONNECTORS_OF_KAFKA_CONNECT_ENVS")))
-        .thenReturn("0,1,2,3");
+            .thenReturn("0,1,2,3");
     when(commonUtilsService.getEnvProperty(eq(TENANT_ID), eq(ORDER_OF_KAFKA_CONNECT_ENVS)))
-        .thenReturn("0,1,2");
+            .thenReturn("0,1,2");
     when(manageDatabase.getKafkaConnectEnvList(commonUtilsService.getTenantId(eq(USERNAME))))
-        .thenReturn(generateEnvironments());
+            .thenReturn(generateEnvironments());
     when(manageDatabase
             .getHandleDbRequests()
             .getConnectorsFromName(eq(CONNECTOR_NAME), eq(TENANT_ID)))
-        .thenReturn(generateKafkaConnectors(2));
+            .thenReturn(generateKafkaConnectors(2));
     when(manageDatabase
             .getHandleDbRequests()
             .existsConnectorRequest(
-                eq(CONNECTOR_NAME), eq(RequestStatus.CREATED.value), eq("1"), eq(101)))
-        .thenReturn(false);
+                    eq(CONNECTOR_NAME), eq(RequestStatus.CREATED.value), eq("1"), eq(101)))
+            .thenReturn(false);
     ConnectorOverview response =
-        kafkaConnectControllerService.getConnectorOverview(CONNECTOR_NAME, "1");
+            kafkaConnectControllerService.getConnectorOverview(CONNECTOR_NAME, "1");
 
     assertThat(response.getConnectorInfoList().get(0).isHighestEnv()).isTrue();
     assertThat(response.getConnectorInfoList().get(0).isConnectorOwner()).isTrue();
     assertThat(response.getConnectorInfoList().get(0).isHasOpenRequest()).isFalse();
     assertThat(response.getPromotionDetails().get("status"))
-        .isEqualTo(PromotionStatusType.SUCCESS.value);
+            .isEqualTo(PromotionStatusType.SUCCESS.value);
     assertThat(response.getAvailableEnvironments()).hasSize(2);
   }
+
+
+  @Test
+  @Order(21)
+  public void getConnectorOverviewPerEnv_ConnectorDoesNotExist()   {
+    // A promotion is available for the tst connector but we are checking for the dev one and that
+    // has already been promoted to tst.
+    Set<String> envListIds = new HashSet<>();
+    envListIds.add("DEV");
+    stubUserInfo();
+    when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
+    when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
+            .thenReturn(generateKafkaConnectors(2));
+    when(commonUtilsService.getEnvsFromUserId(eq(USERNAME))).thenReturn(Set.of("0", "1", "2", "3"));
+
+    when(manageDatabase
+            .getHandleDbRequests()
+            .getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
+            .thenReturn(generateKafkaConnectors(0));
+
+    assertThatThrownBy(() -> kafkaConnectControllerService.getConnectorDetailsPerEnv("1",CONNECTOR_NAME)).isInstanceOf(KlawBadRequestException.class).hasMessage("Connector conn1 does not exist.");
+
+
+  }
+
+
+
+  @Test
+  @Order(22)
+  public void getConnectorOverviewPerEnv_ConnectorOwnedByDifferentTeam()   {
+    // A promotion is available for the tst connector but we are checking for the dev one and that
+    // has already been promoted to tst.
+    Set<String> envListIds = new HashSet<>();
+    envListIds.add("DEV");
+    stubUserInfo();
+    when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
+    when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
+            .thenReturn(generateKafkaConnectors(2));
+    when(commonUtilsService.getEnvsFromUserId(eq(USERNAME))).thenReturn(Set.of("0", "1", "2", "3"));
+
+    when(manageDatabase
+            .getHandleDbRequests()
+            .getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
+            .thenReturn(generateKafkaConnectors(2));
+
+    when(manageDatabase
+            .getHandleDbRequests()
+            .getAllTeamsOfUsers(eq(USERNAME), eq(101))).thenReturn(List.of(createTeam("Natto",23)));
+
+    assertThatThrownBy(() -> kafkaConnectControllerService.getConnectorDetailsPerEnv("1",CONNECTOR_NAME)).isInstanceOf(KlawBadRequestException.class).hasMessage("Sorry, your team does not own the connector !!");
+
+
+  }
+
+
+  private static Team createTeam(String teamName, int teamId) {
+    Team t = new Team();
+    t.setTeamId(teamId);
+    t.setTeammail(teamName + ".klaw@mailid");
+    t.setTeamname(teamName);
+    return t;
+  }
+
 
   private List<KwKafkaConnector> generateKafkaConnectors(int number) {
     List<KwKafkaConnector> connectors = new ArrayList<>();


### PR DESCRIPTION
About this change - What it does
This updates the error response to use a proper error response code and returns just the message as an alert to the user.
Resolves: #xxxxx
Why this way
Simplifies the behaviour for the UI and is a better method for handling errors.