### PR TITLE
feat(coral): Add missing states for Claim topic banner

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -1,4 +1,4 @@
-import { useToast } from "@aivenio/aquarium";
+import { Box, useToast } from "@aivenio/aquarium";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import {
@@ -68,6 +68,7 @@ function TopicDetails(props: TopicOverviewProps) {
     error: topicError,
     isLoading: topicIsLoading,
     isRefetching: topicIsRefetching,
+    refetch: refetchTopic,
   } = useQuery(["topic-overview", topicName, environmentId], {
     queryFn: () => getTopicOverview({ topicName, environmentId }),
   });
@@ -104,11 +105,13 @@ function TopicDetails(props: TopicOverviewProps) {
       }),
     {
       onSuccess: () => {
-        setShowClaimModal(false);
-        toast({
-          message: "Topic claim request successfully created",
-          position: "bottom-left",
-          variant: "default",
+        refetchTopic().then(() => {
+          setShowClaimModal(false);
+          toast({
+            message: "Topic claim request successfully created",
+            position: "bottom-left",
+            variant: "default",
+          });
         });
       },
       onError: (error: HTTPError) => {
@@ -155,11 +158,16 @@ function TopicDetails(props: TopicOverviewProps) {
       />
       {topicData?.topicInfo !== undefined &&
         !topicData.topicInfo.topicOwner && (
-          <TopicClaimBanner
-            setShowClaimModal={setShowClaimModal}
-            isError={createClaimTopicRequestIsError}
-            errorMessage={claimErrorMessage}
-          />
+          <Box marginBottom={"l1"}>
+            <TopicClaimBanner
+              topicName={topicName}
+              hasOpenClaimRequest={topicData?.topicInfo.hasOpenClaimRequest}
+              hasOpenRequest={topicData?.topicInfo.hasOpenRequest}
+              setShowClaimModal={setShowClaimModal}
+              isError={createClaimTopicRequestIsError}
+              errorMessage={claimErrorMessage}
+            />
+          </Box>
         )}
       <TopicOverviewResourcesTabs
         isLoading={topicIsLoading || schemaIsLoading}

--- a/coral/src/app/features/topics/details/components/TopicClaimBanner.tsx
+++ b/coral/src/app/features/topics/details/components/TopicClaimBanner.tsx
@@ -1,43 +1,69 @@
-import {
-  Alert,
-  Banner,
-  Box,
-  Button,
-  GridItem,
-  Spacing,
-} from "@aivenio/aquarium";
+import { Alert, Banner, Box, Button, Spacing } from "@aivenio/aquarium";
 import { Dispatch, SetStateAction } from "react";
+import { InternalLinkButton } from "src/app/components/InternalLinkButton";
 
 interface TopicClaimBannerProps {
+  topicName: string;
+  hasOpenRequest: boolean;
+  hasOpenClaimRequest: boolean;
   setShowClaimModal: Dispatch<SetStateAction<boolean>>;
   isError: boolean;
   errorMessage?: string;
 }
 
 const TopicClaimBanner = ({
+  topicName,
+  hasOpenClaimRequest,
+  hasOpenRequest,
   setShowClaimModal,
   isError,
   errorMessage,
 }: TopicClaimBannerProps) => {
-  return (
-    <GridItem colSpan={"span-2"} marginBottom={"l1"}>
+  if (hasOpenRequest) {
+    // We do not render an InternalLinkButton to the Requests page for this state...
+    // .. because a user cannot see the requests opened by members of other teams
+    return (
       <Banner layout="vertical" title={""}>
-        <Spacing gap={"l1"}>
-          {isError && (
-            <div role="alert">
-              <Alert type="error">{errorMessage}</Alert>
-            </div>
-          )}
-          <Box component={"p"} marginBottom={"l1"}>
-            Your team is not the owner of this topic. Click below to create a
-            claim request for this topic.
-          </Box>
-        </Spacing>
-        <Button.Primary onClick={() => setShowClaimModal(true)}>
-          Claim topic
-        </Button.Primary>
+        <Box component={"p"}>
+          There is an open request for {topicName} by the owners of this topic.
+          Your team cannot claim ownership at this time.
+        </Box>
       </Banner>
-    </GridItem>
+    );
+  }
+
+  if (hasOpenClaimRequest) {
+    return (
+      <Banner layout="vertical" title={""}>
+        <Box component={"p"} marginBottom={"l1"}>
+          There is already an open claim request for {topicName}.
+        </Box>
+        <InternalLinkButton
+          to={`/requests/topics?search=${topicName}&requestType=CLAIM&status=CREATED&page=1`}
+        >
+          See the request
+        </InternalLinkButton>
+      </Banner>
+    );
+  }
+
+  return (
+    <Banner layout="vertical" title={""}>
+      <Spacing gap={"l1"}>
+        {isError && (
+          <div role="alert">
+            <Alert type="error">{errorMessage}</Alert>
+          </div>
+        )}
+        <Box component={"p"} marginBottom={"l1"}>
+          Your team is not the owner of this topic. Click below to create a
+          claim request for this topic.
+        </Box>
+      </Spacing>
+      <Button.Primary onClick={() => setShowClaimModal(true)}>
+        Claim topic
+      </Button.Primary>
+    </Banner>
   );
 };
 


### PR DESCRIPTION
## About this change - What it does

This PR introduces two new states to the Claim topic banner:
1. if a claim request already is opened:

https://github.com/Aiven-Open/klaw/assets/20607294/8de796ec-f030-45f3-82ea-491f5b7b8fea

2. [NOT CURRENTLY IMPLEMENTED BY THE BACKEND] if the current owners have a pending request for the topic:
<img width="1323" alt="Screenshot 2023-07-28 at 16 00 50" src="https://github.com/Aiven-Open/klaw/assets/20607294/492f6333-1b75-4dfa-bce7-1298a37fea42">

The state 2. is not currently visible, as `hasOpenRequest` is currently not aware of the requests opened by other teams than the user's own team. This will however be changed by this PR https://github.com/Aiven-Open/klaw/pull/1543

Resolves: #1504
