### PR TITLE
Add a boolean response to the TopicInfo when not the owner of the topic

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -220,6 +220,15 @@ public class TopicOverviewService extends BaseOverviewService {
             || topicInfo.isHasOpenClaimRequest());
   }
 
+  private void setHasOpenRequestOnly(
+      TopicOverviewInfo topicInfo, String topicName, String envId, int tenantId) {
+    topicInfo.setHasOpenRequest(
+        isACLRequestOpen(topicName, envId, tenantId)
+            || isSchemaRequestOpen(topicName, envId, tenantId)
+            || isTopicRequestOpen(topicName, envId, tenantId)
+            || isClaimTopicRequestOpen(topicName, tenantId));
+  }
+
   private void setHasSchema(
       TopicOverviewInfo topicInfo, String topicName, String envId, int tenantId) {
     topicInfo.setHasSchema(commonUtilsService.existsSchemaForTopic(topicName, envId, tenantId));
@@ -337,6 +346,14 @@ public class TopicOverviewService extends BaseOverviewService {
           topicInfoList
               .get(0)
               .setHasOpenClaimRequest(isClaimTopicRequestOpen(topicNameSearch, tenantId));
+
+          if (topicInfoList.get(0).isHasOpenClaimRequest()) {
+            log.info("SET THIS THING TO TRUE");
+            topicInfoList.get(0).setHasOpenRequest(true);
+          } else {
+            // only make call to db if it is required.
+            setHasOpenRequestOnly(topicInfoList.get(0), topicNameSearch, environmentId, tenantId);
+          }
         }
       }
     } catch (Exception e) {

--- a/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicOverviewServiceTest.java
@@ -808,16 +808,13 @@ public class TopicOverviewServiceTest {
     verify(handleDbRequests, times(0)).existsTopicRequest(any(), any(), any(), anyInt());
     verify(handleDbRequests, times(0)).existsAclRequest(any(), any(), any(), anyInt());
     verify(handleDbRequests, times(0)).existsSchemaRequest(any(), any(), any(), anyInt());
-    assertThat(topicOverview.getTopicInfoList().get(0).isHasACL()).isFalse(); // topic hasAcl
+    assertThat(topicOverview.getTopicInfoList().get(0).isHasACL()).isFalse(); // topic claim
 
     assertThat(topicOverview.getTopicInfoList().get(0).isHasOpenClaimRequest()).isTrue();
-    assertThat(topicOverview.getTopicInfoList().get(0).isHasOpenACLRequest())
-        .isFalse(); // topic hasAcl
-    assertThat(topicOverview.getTopicInfoList().get(0).isHasOpenTopicRequest())
-        .isFalse(); // topic hasAcl
-    assertThat(topicOverview.getTopicInfoList().get(0).isHasOpenRequest())
-        .isFalse(); // topic hasAcl
-    assertThat(topicOverview.getTopicInfoList().get(0).isHasSchema()).isFalse(); // topic hasAcl
+    assertThat(topicOverview.getTopicInfoList().get(0).isHasOpenACLRequest()).isFalse();
+    assertThat(topicOverview.getTopicInfoList().get(0).isHasOpenTopicRequest()).isFalse();
+    assertThat(topicOverview.getTopicInfoList().get(0).isHasOpenRequest()).isTrue();
+    assertThat(topicOverview.getTopicInfoList().get(0).isHasSchema()).isFalse();
   }
 
   private static Map<Integer, KwClusters> getKwClusterMap() {


### PR DESCRIPTION
Minor update so that if a request is open we let the UI know without divulging the type of request.

About this change - What it does

Resolves: #xxxxx
Why this way
This allows the UI to know not to show the claim button and does not divulge any additional info as this was available anyway from the error response.