### PR TITLE
refactor(coral): Add (read-only) to labels for readonly elements

### DIFF
--- a/coral/src/app/features/connectors/request/ConnectorEditRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorEditRequest.test.tsx
@@ -105,24 +105,23 @@ describe("<ConnectorEditRequest />", () => {
     });
 
     describe("Renders readOnly fields with correct values", () => {
-      it("shows a readOnly required select element for 'Environment' with correct value", async () => {
+      it("shows a readOnly select element for 'Environment' with correct value", async () => {
         const select = await screen.findByRole("combobox", {
-          name: "Environment *",
+          name: "Environment (read-only)",
         });
+
         expect(select).toBeDisabled();
-        expect(select).toBeRequired();
         expect(select).toHaveAttribute("aria-readonly", "true");
         expect(select).toHaveDisplayValue(
           testConnectorDetailsPerEnvResponse.connectorContents.environmentName
         );
       });
 
-      it("shows a readOnly required input element for 'Connector name' with correct value", async () => {
+      it("shows a readOnly input element for 'Connector name' with correct value", async () => {
         const input = await screen.findByRole("textbox", {
-          name: "Connector name *",
+          name: "Connector name (read-only)",
         });
         expect(input).toHaveAttribute("readonly");
-        expect(input).toBeRequired();
         expect(input).toHaveDisplayValue(CONNECTOR_NAME);
       });
     });

--- a/coral/src/app/features/connectors/request/ConnectorEditRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorEditRequest.tsx
@@ -189,8 +189,7 @@ function ConnectorEditRequest() {
           {environmentName !== undefined ? (
             <NativeSelect
               name="environment"
-              labelText={"Environment"}
-              required
+              labelText={"Environment (read-only)"}
               readOnly
             >
               <Option key={environmentName} value={environmentName}>
@@ -202,8 +201,7 @@ function ConnectorEditRequest() {
           )}
           <TextInput<ConnectorRequestFormSchema>
             name={"connectorName"}
-            labelText={"Connector name"}
-            required
+            labelText={"Connector name (read-only)"}
             readOnly
           />
 

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -81,7 +81,7 @@ const assertSkeleton = async () => {
 
 const selectTestEnvironment = async () => {
   const environmentField = screen.getByRole("combobox", {
-    name: "Environment *",
+    name: /Environment/,
   });
   const option = screen.getByRole("option", { name: "TST" });
   await userEvent.selectOptions(environmentField, option);

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
@@ -58,6 +58,24 @@ describe("EnvironmentField", () => {
     expect(select).toBeRequired();
   });
 
+  it("renders a readOnly NativeSelect component", () => {
+    renderForm(
+      <EnvironmentField environments={mockedEnvironments} readOnly={true} />,
+      {
+        schema,
+        onSubmit,
+        onError,
+      }
+    );
+    const select = screen.getByRole("combobox", {
+      name: "Environment (read-only)",
+    });
+
+    expect(select).toBeVisible();
+    expect(select).toBeDisabled();
+    expect(select).toHaveAttribute("aria-readonly", "true");
+  });
+
   it("renders NativeSelect with a placeholder option", () => {
     renderForm(<EnvironmentField environments={mockedEnvironments} />, {
       schema,

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.tsx
@@ -53,12 +53,13 @@ const EnvironmentField = ({
   prefixed = false,
   readOnly = false,
 }: EnvironmentFieldProps) => {
+  const labelText = readOnly ? "Environment (read-only)" : "Environment";
   return (
     <NativeSelect
       name="environment"
-      labelText="Environment"
+      labelText={labelText}
       placeholder={"-- Please select --"}
-      required
+      required={!readOnly}
       readOnly={readOnly}
     >
       {getOptions(environments, prefixed, selectedTopic)}

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameField.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen } from "@testing-library/react";
+import { cleanup, screen, within } from "@testing-library/react";
 import TopicNameField from "src/app/features/topics/acl-request/fields/TopicNameField";
 import { topicname } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-shared-fields";
 import { renderForm } from "src/services/test-utils/render-form";
@@ -14,36 +14,37 @@ describe("TopicNameField", () => {
   const onSubmit = jest.fn();
   const onError = jest.fn();
 
-  beforeAll(() => {
-    renderForm(<TopicNameField topicNames={mockedTopicNames} />, {
-      schema,
-      onSubmit,
-      onError,
-    });
-  });
-
-  afterAll(() => {
+  afterEach(() => {
     cleanup();
     onSubmit.mockClear();
     onError.mockClear();
   });
 
-  it("renders NativeSelect component", () => {
-    const select = screen.getByRole("combobox");
+  it("renders a required NativeSelect component", () => {
+    renderForm(<TopicNameField topicNames={mockedTopicNames} />, {
+      schema,
+      onSubmit,
+      onError,
+    });
+    const select = screen.getByRole("combobox", { name: "Topic name *" });
 
-    expect(select).toBeVisible();
     expect(select).toBeEnabled();
+    expect(select).toBeRequired();
   });
 
   it("renders NativeSelect with a placeholder option", () => {
-    const options = screen.getAllByRole("option");
+    renderForm(<TopicNameField topicNames={mockedTopicNames} />, {
+      schema,
+      onSubmit,
+      onError,
+    });
+    const select = screen.getByRole("combobox", { name: "Topic name *" });
+    const options = within(select).getAllByRole("option");
 
     expect(options).toHaveLength(mockedTopicNames.length + 1);
   });
 
-  it("renders readonly NativeSelect when readOnly prop is true", () => {
-    cleanup();
-
+  it("renders a readOnly NativeSelect when readOnly prop is true", () => {
     renderForm(
       <TopicNameField topicNames={mockedTopicNames} readOnly={true} />,
       {
@@ -53,7 +54,9 @@ describe("TopicNameField", () => {
       }
     );
 
-    const select = screen.getByRole("combobox");
+    const select = screen.getByRole("combobox", {
+      name: "Topic name (read-only)",
+    });
 
     expect(select).toBeDisabled();
     expect(select).toHaveAttribute("aria-readonly", "true");

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
@@ -10,13 +10,14 @@ const TopicNameField = ({
   topicNames,
   readOnly = false,
 }: TopicNameFieldProps) => {
+  const labelText = readOnly ? "Topic name (read-only)" : "Topic name";
   return (
     <NativeSelect
       name="topicname"
-      labelText="Topic name"
+      labelText={labelText}
       placeholder={"-- Select Topic --"}
       readOnly={readOnly}
-      required
+      required={!readOnly}
     >
       {topicNames.map((name) => (
         <Option key={name} value={name}>

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameOrPrefixField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameOrPrefixField.test.tsx
@@ -25,7 +25,7 @@ describe("TopicNameOrPrefixField", () => {
     onError.mockClear();
   });
 
-  it("renders a readonly field with information when no pattern type is chosen", () => {
+  it("renders a readOnly field with information when no pattern type is chosen", () => {
     const result = renderForm(
       <TopicNameOrPrefixField
         topicNames={mockedTopicNames}
@@ -65,7 +65,7 @@ describe("TopicNameOrPrefixField", () => {
     expect(options).toHaveLength(mockedTopicNames.length + 1);
   });
 
-  it("renders a readonly TopicNameField (producer form)", () => {
+  it("renders a readOnly TopicNameField (producer form)", () => {
     const result = renderForm(
       <TopicNameOrPrefixField
         topicNames={mockedTopicNames}
@@ -78,7 +78,9 @@ describe("TopicNameOrPrefixField", () => {
         onError,
       }
     );
-    const field = result.getByRole("combobox");
+    const field = result.getByRole("combobox", {
+      name: "Topic name (read-only)",
+    });
 
     expect(field).toBeVisible();
     expect(field).toBeDisabled();

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameOrPrefixField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameOrPrefixField.tsx
@@ -23,11 +23,15 @@ const TopicNameOrPrefixField = ({
   }
 
   return (
+    // This is not really a readOnly field but
+    // a placeholder until the user can select value
+    // from a list, so I didn't change the label
     <Input
       labelText="Topic name or prefix"
       defaultValue="Select environment and topic pattern type first"
       height={45}
       readOnly
+      required={true}
     />
   );
 };

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -116,11 +116,14 @@ describe("<TopicConsumerForm />", () => {
       expect(environmentField).toBeRequired();
     });
 
-    it("renders a readonly field with information when no environment  is chosen", () => {
-      const field = screen.getByRole("textbox", { name: "Topic name" });
-      expect(field).toBeVisible();
+    it("renders a readOnly field with information when no environment is chosen", () => {
+      const field = screen.getByRole("textbox", {
+        name: "Topic name *",
+      });
+
+      expect(field).toBeRequired();
       expect(field).toHaveAttribute("readonly");
-      expect(field).toHaveValue("Select environment first");
+      expect(field).toHaveDisplayValue("Select environment first");
     });
 
     it("does not render consumergroup field", () => {
@@ -468,18 +471,19 @@ describe("<TopicConsumerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders disabled required EnvironmentField", () => {
+    it("renders readOnly EnvironmentField", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
 
       expect(environmentField).toBeVisible();
       expect(environmentField).toBeDisabled();
-      expect(environmentField).toBeRequired();
+      expect(environmentField).toHaveAttribute("aria-readonly", "true");
     });
 
-    it("renders a readonly field with information when no environment  is chosen", () => {
-      const field = screen.getByRole("textbox", { name: "Topic name" });
+    it("renders a readonly field with information when no environment is chosen", () => {
+      const field = screen.getByRole("textbox", { name: "Topic name *" });
+
       expect(field).toBeVisible();
       expect(field).toHaveAttribute("readonly");
       expect(field).toHaveValue("Select environment first");
@@ -584,24 +588,23 @@ describe("<TopicConsumerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders disabled EnvironmentField with DEV selected", () => {
+    it("renders readOnly EnvironmentField with DEV selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
 
-      expect(environmentField).toBeVisible();
       expect(environmentField).toBeDisabled();
+      expect(environmentField).toHaveAttribute("aria-readonly", "true");
       expect(environmentField).toHaveDisplayValue("DEV");
     });
 
-    it("renders TopicNameField", () => {
+    it("renders readOnly TopicNameField", () => {
       const topicNameField = screen.getByRole("combobox", {
-        name: "Topic name *",
+        name: "Topic name (read-only)",
       });
 
       expect(topicNameField).toBeVisible();
       expect(topicNameField).toHaveAttribute("aria-readOnly", "true");
-      expect(topicNameField).toBeRequired();
       expect(topicNameField).toHaveValue("hello");
     });
 
@@ -704,24 +707,23 @@ describe("<TopicConsumerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders disabled EnvironmentField with TST selected", () => {
+    it("renders readOnly EnvironmentField with TST selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
 
-      expect(environmentField).toBeVisible();
       expect(environmentField).toBeDisabled();
+      expect(environmentField).toHaveAttribute("aria-readonly", "true");
       expect(environmentField).toHaveDisplayValue("TST");
     });
 
-    it("renders TopicNameField", () => {
+    it("renders readOnly TopicNameField", () => {
       const topicNameField = screen.getByRole("combobox", {
-        name: "Topic name *",
+        name: "Topic name (read-only)",
       });
 
-      expect(topicNameField).toBeVisible();
+      expect(topicNameField).toBeDisabled();
       expect(topicNameField).toHaveAttribute("aria-readOnly", "true");
-      expect(topicNameField).toBeRequired();
       expect(topicNameField).toHaveValue("hello");
     });
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -141,10 +141,14 @@ const TopicConsumerForm = ({
           <GridItem>
             {environment === undefined ? (
               <Input
+                // This is not really a readOnly field but
+                // a placeholder until the user can select value
+                // from a list, so I didn't change the label
                 labelText="Topic name"
                 defaultValue="Select environment first"
                 height={45}
                 readOnly
+                required={true}
               />
             ) : (
               <TopicNameField

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -520,15 +520,15 @@ describe("<TopicProducerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders required and disabled EnvironmentField", () => {
+    it("renders readOnly EnvironmentField", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
 
       expect(environmentField).toBeVisible();
       expect(environmentField).toBeDisabled();
-      expect(environmentField).toBeRequired();
       expect(environmentField).toHaveValue("1");
+      expect(environmentField).toHaveAttribute("aria-readonly", "true");
     });
 
     it("renders aclPatternType disabled field with Literal checked", () => {
@@ -544,9 +544,9 @@ describe("<TopicProducerForm isSubscription />", () => {
       expect(prefixedField).toBeDisabled();
     });
 
-    it("renders readonly Topic name field", () => {
+    it("renders readOnly Topic name field", () => {
       const topicNameField = screen.queryByRole("combobox", {
-        name: "Topic name *",
+        name: "Topic name (read-only)",
       });
       const prefixField = screen.queryByRole("textbox", {
         name: "Prefix",
@@ -657,13 +657,14 @@ describe("<TopicProducerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders disabled EnvironmentField with DEV selected", () => {
+    it("renders readOnly EnvironmentField with DEV selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
 
       expect(environmentField).toBeVisible();
       expect(environmentField).toBeDisabled();
+      expect(environmentField).toHaveAttribute("aria-readonly", "true");
       expect(environmentField).toHaveDisplayValue("DEV");
     });
 
@@ -790,13 +791,14 @@ describe("<TopicProducerForm isSubscription />", () => {
       expect(consumerField).toBeEnabled();
     });
 
-    it("renders disabled EnvironmentField with TST selected", () => {
+    it("renders readOnly EnvironmentField with TST selected", () => {
       const environmentField = screen.getByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
 
       expect(environmentField).toBeVisible();
       expect(environmentField).toBeDisabled();
+      expect(environmentField).toHaveAttribute("aria-readonly", "true");
       expect(environmentField).toHaveDisplayValue("TST");
     });
 
@@ -815,7 +817,7 @@ describe("<TopicProducerForm isSubscription />", () => {
 
     it("does not render TopicNameOrPrefixField", () => {
       const topicNameField = screen.queryByRole("combobox", {
-        name: "Topic name *",
+        name: "Topic name (read-only)",
       });
       const prefixField = screen.queryByRole("textbox", {
         name: "Prefix",

--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -445,7 +445,10 @@ describe("TopicDetails", () => {
   });
 
   describe("allows users to claim a topic when they are not topic owner", () => {
+    const originalConsoleError = console.error;
+
     beforeEach(() => {
+      console.error = jest.fn();
       mockMatches.mockImplementation(() => [
         {
           id: "TOPIC_OVERVIEW_TAB_ENUM_overview",
@@ -468,6 +471,7 @@ describe("TopicDetails", () => {
     });
 
     afterEach(() => {
+      console.error = originalConsoleError;
       cleanup();
       jest.clearAllMocks();
     });
@@ -484,6 +488,7 @@ describe("TopicDetails", () => {
       const modal = screen.getByRole("dialog");
 
       expect(modal).toBeVisible();
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("sends a request when clicking the submit button without entering a message", async () => {
@@ -509,6 +514,7 @@ describe("TopicDetails", () => {
         topicName: testTopicOverview.topicInfo.topicName,
         env: testTopicOverview.topicInfo.envId,
       });
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("sends a request when clicking the submit button with the message entered by the user", async () => {
@@ -538,6 +544,7 @@ describe("TopicDetails", () => {
         env: testTopicOverview.topicInfo.envId,
         remark: "hello",
       });
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("closes the modal and renders a toast when request was successful", async () => {
@@ -568,12 +575,14 @@ describe("TopicDetails", () => {
           variant: "default",
         })
       );
+      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("closes the modal displays an alert when request was not successful", async () => {
+      const mockErrorMessage = "There was an error";
       await waitForElementToBeRemoved(screen.getByPlaceholderText("Loading"));
 
-      mockClaimTopic.mockRejectedValue("There was an error");
+      mockClaimTopic.mockRejectedValue(mockErrorMessage);
 
       const button = await waitFor(() =>
         screen.getByRole("button", { name: "Claim topic" })
@@ -596,6 +605,7 @@ describe("TopicDetails", () => {
       const alert = screen.getByRole("alert");
 
       expect(alert).toBeVisible();
+      expect(console.error).toHaveBeenCalledWith(mockErrorMessage);
     });
   });
 });

--- a/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
@@ -331,21 +331,20 @@ describe("<TopicEditRequest />", () => {
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
-    it("shows a disabled select element for 'Environment' with correct default value", async () => {
+    it("shows a readOnly select element for 'Environment' with correct default value", async () => {
       const select = await screen.findByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
       expect(select).toBeDisabled();
-      expect(select).toBeRequired();
+      expect(select).toHaveAttribute("aria-readonly", "true");
       expect(select).toHaveDisplayValue("DEV");
     });
 
     it("shows a readOnly text input element for 'Topic name' with correct default value", async () => {
       const input = await screen.findByRole("textbox", {
-        name: "Topic name *",
+        name: "Topic name (read-only)",
       });
       expect(input).toHaveAttribute("readonly");
-      expect(input).toBeRequired();
       expect(input).toHaveDisplayValue(TOPIC_NAME);
     });
 

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -212,8 +212,7 @@ function TopicEditRequest() {
           {currentEnvironment !== undefined ? (
             <NativeSelect
               name="environment"
-              labelText={"Environment"}
-              required
+              labelText={"Environment (read-only)"}
               readOnly
             >
               <Option
@@ -232,9 +231,8 @@ function TopicEditRequest() {
         </Box>
         <TextInput<Schema>
           name={"topicname"}
-          labelText="Topic name"
+          labelText="Topic name (read-only)"
           placeholder={generateTopicNameDescription(currentEnvironment?.params)}
-          required={true}
           readOnly
         />
         <Box.Flex gap={"l1"}>

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
@@ -329,21 +329,21 @@ describe("<TopicPromotionRequest />", () => {
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
-    it("shows a disabled select element for 'Environment' with correct default value", async () => {
+    it("shows a readOnly select element for 'Environment' with correct default value", async () => {
       const select = await screen.findByRole("combobox", {
-        name: "Environment *",
+        name: "Environment (read-only)",
       });
       expect(select).toBeDisabled();
-      expect(select).toBeRequired();
+      expect(select).toHaveAttribute("aria-readonly", "true");
       expect(select).toHaveDisplayValue("TST");
     });
 
     it("shows a readOnly text input element for 'Topic name' with correct default value", async () => {
       const input = await screen.findByRole("textbox", {
-        name: "Topic name *",
+        name: "Topic name (read-only)",
       });
+
       expect(input).toHaveAttribute("readonly");
-      expect(input).toBeRequired();
       expect(input).toHaveDisplayValue("test-topic-name");
     });
 
@@ -378,12 +378,11 @@ describe("<TopicPromotionRequest />", () => {
 
     it("shows a readOnly text input element for 'Description' with correct default value", async () => {
       const input = await screen.findByRole("textbox", {
-        name: "Description *",
+        name: "Description (read-only)",
       });
       const description = mockTopicDetails.topicContents?.description as string;
 
       expect(input).toHaveAttribute("readonly");
-      expect(input).toBeRequired();
       await waitFor(() => expect(input).toHaveDisplayValue(description));
     });
 

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
@@ -200,8 +200,7 @@ function TopicPromotionRequest() {
           {targetEnvironment !== undefined ? (
             <NativeSelect
               name="environment"
-              labelText={"Environment"}
-              required
+              labelText={"Environment (read-only)"}
               readOnly
             >
               <Option
@@ -220,9 +219,8 @@ function TopicPromotionRequest() {
         </Box>
         <TextInput<Schema>
           name={"topicname"}
-          labelText="Topic name"
+          labelText="Topic name (read-only)"
           placeholder={generateTopicNameDescription(targetEnvironment?.params)}
-          required={true}
           readOnly
         />
         <Box.Flex gap={"l1"}>
@@ -264,9 +262,8 @@ function TopicPromotionRequest() {
           <Box grow={1} width={"1/2"}>
             <Textarea<Schema>
               name="description"
-              labelText="Description"
+              labelText="Description (read-only)"
               rows={5}
-              required={true}
               readOnly
             />
           </Box>

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -374,7 +374,9 @@ describe("TopicSchemaRequest", () => {
 
     it("shows readonly select element for the topic name", () => {
       const form = getForm();
-      const select = within(form).getByRole("combobox", { name: "Topic name" });
+      const select = within(form).getByRole("combobox", {
+        name: "Topic name (read-only)",
+      });
 
       expect(select).toBeVisible();
       expect(select).toBeDisabled();
@@ -383,7 +385,9 @@ describe("TopicSchemaRequest", () => {
 
     it("sets the value for readonly select for topic name", () => {
       const form = getForm();
-      const select = within(form).getByRole("combobox", { name: "Topic name" });
+      const select = within(form).getByRole("combobox", {
+        name: "Topic name (read-only)",
+      });
 
       expect(select).toHaveValue(testTopicName);
     });

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -46,6 +46,12 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
   const navigate = useNavigate();
   const toast = useToast();
 
+  const hasPresetTopicName = topicName !== undefined;
+  const hasPresetEnvironment =
+    presetEnvironment !== null &&
+    presetEnvironment !== undefined &&
+    presetEnvironment.length > 0;
+
   const form = useForm<TopicRequestFormSchema>({
     schema: topicRequestFormSchema,
     defaultValues: {
@@ -155,8 +161,11 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
           ) : (
             <NativeSelect<TopicRequestFormSchema>
               name={"topicname"}
-              labelText={"Topic name"}
-              readOnly={topicName !== undefined}
+              labelText={
+                hasPresetTopicName ? "Topic name (read-only)" : "Topic name"
+              }
+              required={!hasPresetTopicName}
+              readOnly={hasPresetTopicName}
             >
               {topicNames.map((topic) => {
                 return (
@@ -167,7 +176,6 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
               })}
             </NativeSelect>
           )}
-
           {environmentsIsLoading || environments === undefined ? (
             <div data-testid={"environments-select-loading"}>
               <NativeSelect.Skeleton />
@@ -175,10 +183,12 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
           ) : (
             <NativeSelect<TopicRequestFormSchema>
               name={"environment"}
-              labelText={"Environment"}
+              labelText={
+                hasPresetEnvironment ? "Environment (read-only)" : "Environment"
+              }
               placeholder={"-- Please select --"}
-              readOnly={Boolean(presetEnvironment)}
-              required={true}
+              readOnly={hasPresetEnvironment}
+              required={!presetEnvironment}
             >
               {environments.map((env) => {
                 return (
@@ -189,17 +199,14 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
               })}
             </NativeSelect>
           )}
-
           <TopicSchema
             name={"schemafull"}
             required={!props.schemafullValueForTest}
           />
-
           <Textarea
             name={"remarks"}
             labelText={"Enter a message for approval"}
           />
-
           <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
             <SubmitButton>Submit request</SubmitButton>
             <Button

--- a/coral/src/app/features/topics/schema-request/components/TopicSchema.test.tsx
+++ b/coral/src/app/features/topics/schema-request/components/TopicSchema.test.tsx
@@ -52,7 +52,7 @@ describe("TopicSchema", () => {
     });
 
     it("shows a label like text for the preview", () => {
-      const fakeLabel = screen.getByText("Schema preview (read only)");
+      const fakeLabel = screen.getByText("Schema preview (read-only)");
       expect(fakeLabel).toBeVisible();
     });
 

--- a/coral/src/app/features/topics/schema-request/components/TopicSchema.tsx
+++ b/coral/src/app/features/topics/schema-request/components/TopicSchema.tsx
@@ -90,7 +90,7 @@ function TopicSchema(props: TopicSchemaProps) {
             />
             <Typography.Caption htmlTag={"label"}>
               <span className={error?.message && "text-error-50"}>
-                Schema preview (read only)
+                Schema preview (read-only)
               </span>
             </Typography.Caption>
             <BorderBox

--- a/coral/src/app/pages/topics/schema-request.test.tsx
+++ b/coral/src/app/pages/topics/schema-request.test.tsx
@@ -75,7 +75,7 @@ describe("SchemaRequest", () => {
 
     it("shows the form for this specific topic", async () => {
       const input = await screen.findByRole("combobox", {
-        name: "Topic name",
+        name: "Topic name (read-only)",
       });
 
       expect(input).toBeVisible();


### PR DESCRIPTION
# About this change - What it does

- adds `read-only` to all labels to make it more clear for useres
- remove `required` from readOnly elements, otherwise the visual and AT feedback is a bit confusing (marking a form element as "required" is a information for the user that they need to fill this one out, but they don't, because it already has a value

Resolves: #1532 
