### PR TITLE
refactor(coral): Use correct property for promote schema banner

### DIFF
--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -447,7 +447,7 @@ describe("PromotionBanner", () => {
       await user.click(button);
 
       expect(mockedNavigate).toHaveBeenCalledWith(
-        "/requests/schemas?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1"
+        "/requests/schemas?search=my-test-topic&requestType=CREATE&status=CREATED&page=1"
       );
     });
 

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -3,6 +3,7 @@ import illustration from "src/app/images/topic-details-schema-Illustration.svg";
 import { ReactElement } from "react";
 import { useNavigate } from "react-router-dom";
 import { PromotionStatus } from "src/domain/promotion";
+import { RequestOperationType } from "src/domain/requests/requests-types";
 
 interface PromotionBannerProps {
   // `entityName` is only optional on
@@ -73,6 +74,9 @@ const PromotionBanner = ({
   }
 
   if (hasOpenPromotionRequest) {
+    // Schema currently shows all types as "CREATE"
+    const requestType: RequestOperationType =
+      type === "topic" ? "PROMOTE" : "CREATE";
     return (
       <Banner image={illustration} layout="vertical" title={""}>
         <Box component={"p"} marginBottom={"l1"}>
@@ -86,7 +90,7 @@ const PromotionBanner = ({
         <Button.Primary
           onClick={() =>
             navigate(
-              `/requests/${type}s?search=${entityName}&requestType=PROMOTE&status=CREATED&page=1`
+              `/requests/${type}s?search=${entityName}&requestType=${requestType}&status=CREATED&page=1`
             )
           }
         >

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -270,9 +270,7 @@ describe("TopicDetailsSchema", () => {
           topicOverview: {
             topicInfo: {
               topicOwner: true,
-              hasOpenTopicRequest: false,
-              hasOpenACLRequest: false,
-              hasOpenRequest: true,
+              hasOpenSchemaRequest: true,
             },
           },
         });

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -48,8 +48,7 @@ function TopicDetailsSchema() {
 
   const toast = useToast();
 
-  const { topicOwner, hasOpenTopicRequest, hasOpenRequest, hasOpenACLRequest } =
-    topicOverview.topicInfo;
+  const { topicOwner, hasOpenSchemaRequest } = topicOverview.topicInfo;
   const isTopicOwner = topicOwner;
   const noSchema =
     allSchemaVersions.length === 0 ||
@@ -181,17 +180,7 @@ function TopicDetailsSchema() {
       {!topicSchemasIsRefetching && isTopicOwner && (
         <SchemaPromotionBanner
           schemaPromotionDetails={schemaPromotionDetails}
-          // @TODO backend will implement the property
-          // `hasOpenSchemaRequests`, should be updated
-          // here then, too
-          // until then: `hasOpenRequest` means there is an
-          // open request for topic, acl or schema
-          // if that's true but `hasOpenAclRequest` and
-          // `hasOpenTopicRequest` is false, the open
-          // request has to be a schema request
-          hasOpenSchemaRequest={
-            hasOpenRequest && !hasOpenACLRequest && !hasOpenTopicRequest
-          }
+          hasOpenSchemaRequest={hasOpenSchemaRequest}
           topicName={topicName}
           setShowSchemaPromotionModal={() =>
             setShowSchemaPromotionModal(!showSchemaPromotionModal)

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -14,7 +14,7 @@ import {
 import add from "@aivenio/aquarium/icons/add";
 import gitNewBranch from "@aivenio/aquarium/icons/gitNewBranch";
 import MonacoEditor from "@monaco-editor/react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
@@ -29,7 +29,9 @@ import { parseErrorMsg } from "src/services/mutation-utils";
 import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
 
 function TopicDetailsSchema() {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
+
   const {
     topicName,
     topicSchemas: {
@@ -88,11 +90,13 @@ function TopicDetailsSchema() {
         },
         onSuccess: () => {
           setErrorMessage("");
-          setShowSchemaPromotionModal(false);
-          toast({
-            message: "Schema promotion request successfully sent",
-            position: "bottom-left",
-            variant: "default",
+          queryClient.refetchQueries(["schema-overview"]).then(() => {
+            setShowSchemaPromotionModal(false);
+            toast({
+              message: "Schema promotion request successfully sent",
+              position: "bottom-left",
+              variant: "default",
+            });
           });
         },
       }

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
@@ -148,7 +148,7 @@ describe("SchemaPromotionBanner", () => {
     await user.click(button);
 
     expect(mockedNavigate).toHaveBeenCalledWith(
-      `/requests/schemas?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1`
+      `/requests/schemas?search=my-test-topic&requestType=CREATE&status=CREATED&page=1`
     );
   });
 

--- a/coral/src/domain/schema-request/schema-request-api.ts
+++ b/coral/src/domain/schema-request/schema-request-api.ts
@@ -99,7 +99,9 @@ const getSchemaRequests = (
     ...(args.requestStatus && { requestStatus: args.requestStatus }),
     ...(args.search && args.search !== "" && { search: args.search }),
     ...(args.env && args.env !== "ALL" && { env: args.env }),
-    ...(args.operationType !== undefined && { env: args.operationType }),
+    ...(args.operationType !== undefined && {
+      operationType: args.operationType,
+    }),
     ...(args.isMyRequest && { isMyRequest: String(Boolean(args.isMyRequest)) }),
   };
 


### PR DESCRIPTION
# About this change - What it does

- uses `hasOpenSchemaRequest` for `SchemaPromotionBanner` since it's now added in backend
- links the correct location for seeing requests for schemas (type is always `CREATE` and not `PROMOTE` as for topics)
- 🐛  little bug fix, wrong property for operationType was used in api call 

