### PR TITLE
fix(coral): Connector details:  Render only connector config, add header

### DIFF
--- a/coral/src/app/features/connectors/details/overview/ConnectorOverview.test.tsx
+++ b/coral/src/app/features/connectors/details/overview/ConnectorOverview.test.tsx
@@ -51,10 +51,18 @@ describe("ConnectorOverview", () => {
     render(<ConnectorOverview />);
   });
 
+  it("shows the correct header", () => {
+    const header = screen.getByText("Connector configuration");
+
+    expect(header).toBeVisible();
+  });
+
   it("shows an editor with preview of the connector info", () => {
     const previewEditor = screen.getByTestId("topic-connector");
 
     expect(previewEditor).toBeVisible();
-    expect(previewEditor).toHaveTextContent(`"connectorId": 1003`);
+    expect(previewEditor).toHaveTextContent(
+      `"connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector"`
+    );
   });
 });

--- a/coral/src/app/features/connectors/details/overview/ConnectorOverview.tsx
+++ b/coral/src/app/features/connectors/details/overview/ConnectorOverview.tsx
@@ -1,26 +1,21 @@
-import { Box, Label } from "@aivenio/aquarium";
+import { Box, PageHeader } from "@aivenio/aquarium";
 import MonacoEditor from "@monaco-editor/react";
 import { useConnectorDetails } from "src/app/features/connectors/details/ConnectorDetails";
 
 const ConnectorOverview = () => {
   const { connectorOverview } = useConnectorDetails();
-  // This is necessary to format the JSON renderd in MonacoEditor instead of rendering all in one line
-  const parsedConnectorInfo = JSON.stringify(
-    connectorOverview.connectorInfo,
-    null,
-    2
-  );
 
   return (
-    <Box marginTop={"l3"} marginBottom={"l2"}>
-      <Label>Connector</Label>
+    <>
+      <PageHeader title={"Connector configuration"} />
+
       <Box borderColor={"grey-20"} borderWidth={"1px"}>
         <MonacoEditor
           data-testid="topic-connector"
           height="300px"
           language="json"
           theme={"light"}
-          value={parsedConnectorInfo}
+          value={connectorOverview.connectorInfo.connectorConfig}
           loading={"Loading preview"}
           options={{
             ariaLabel: "Connector preview",
@@ -34,7 +29,7 @@ const ConnectorOverview = () => {
           }}
         />
       </Box>
-    </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
## About this change - What it does

Before, we were erroneously rendering the whole Connector entity in the Connector overview (the Klaw entity):
<img width="1499" alt="Screenshot 2023-07-31 at 10 09 47" src="https://github.com/Aiven-Open/klaw/assets/20607294/54d64856-3c29-4787-8346-cb614b8f49bf">


This PR make it so that only the connector config is rendered:
<img width="755" alt="Screenshot 2023-07-31 at 10 09 33" src="https://github.com/Aiven-Open/klaw/assets/20607294/3238cc74-cbc9-485a-b03e-d475b3d1430f">



Resolves: #1529
