### PR TITLE
housekeeping(coral): Update `aquarium` -> 1.33.0

### DIFF
--- a/coral/package.json
+++ b/coral/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@aivenio/aquarium": "^1.20.0",
+    "@aivenio/aquarium": "^1.33.0",
     "@hookform/resolvers": "^2.9.10",
     "@monaco-editor/react": "^4.5.0",
     "@tanstack/react-query": "^4.29.5",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@aivenio/aquarium': ^1.20.0
+  '@aivenio/aquarium': ^1.33.0
   '@hookform/resolvers': ^2.9.10
   '@monaco-editor/react': ^4.5.0
   '@peculiar/webcrypto': ^1.4.3
@@ -65,7 +65,7 @@ specifiers:
   zod: ^3.19.1
 
 dependencies:
-  '@aivenio/aquarium': 1.20.0_pvnihi4muhoy7kenlmiyxwzuqy
+  '@aivenio/aquarium': 1.33.0_pvnihi4muhoy7kenlmiyxwzuqy
   '@hookform/resolvers': 2.9.10_react-hook-form@7.43.9
   '@monaco-editor/react': 4.5.0_bp43pgihi2cxclx2bm2cvm6q7a
   '@tanstack/react-query': 4.29.5_biqbaboplfbrettd7655fr4n2y
@@ -136,26 +136,24 @@ packages:
     resolution: {integrity: sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==}
     dev: true
 
-  /@aivenio/aquarium/1.20.0_pvnihi4muhoy7kenlmiyxwzuqy:
-    resolution: {integrity: sha512-4DC0kC1DAaDXxGuVPuN5CXWAuweBSVM2TDRCXMRSPDjU0dLWL4dyUcCnllUEHjFqBQMovySif4IC5wVNoxtqAw==}
+  /@aivenio/aquarium/1.33.0_pvnihi4muhoy7kenlmiyxwzuqy:
+    resolution: {integrity: sha512-+Xc5tfq6xv870bJh/x7/Qe4NfzTgYBCJI3Ji5vJSIqOG+RQZImW64r4+J61t+toF4upLhHfIX8TQInoYnbbHDw==}
     peerDependencies:
       lodash: 4.x
-      react: 16.x || 17.x
-      react-dom: 16.x || 17.x
+      react: 16.x || 17.x || 18.x
+      react-dom: 16.x || 17.x || 18.x
     dependencies:
       '@iconify/react': 3.2.2_react@18.2.0
       '@iconify/types': 1.1.0
-      '@popperjs/core': 2.11.6
       '@react-spring/web': 9.7.2_biqbaboplfbrettd7655fr4n2y
       classnames: 2.3.2
       downshift: 7.1.0_react@18.2.0
       lodash: 4.17.21
       match-sorter: 6.3.1
       react: 18.2.0
-      react-aria: 3.23.1_biqbaboplfbrettd7655fr4n2y
+      react-aria: 3.26.0_biqbaboplfbrettd7655fr4n2y
       react-dom: 18.2.0_react@18.2.0
-      react-popper: 2.3.0_r6q5zrenym2zg7je7hgi674bti
-      react-stately: 3.22.0_react@18.2.0
+      react-stately: 3.24.0_react@18.2.0
       recharts: 2.6.2_biqbaboplfbrettd7655fr4n2y
     transitivePeerDependencies:
       - prop-types
@@ -946,35 +944,29 @@ packages:
     resolution: {integrity: sha512-Jh0llaK2LRXQoYsorIH8maClebsnzTcve+7U3rQUSnC11X4jtPnFuyatqFLvMxZ8MLG8dB4zfHsbPfuvxluONw==}
     dev: false
 
-  /@internationalized/date/3.1.0:
-    resolution: {integrity: sha512-wjeur7K4AecT+YwoBmBXQ/+n5lP69tuZc34hw09s44EozZK7FZHSyfPvRp5/xEb2D6abLboskDY4jG+Nt0TNUQ==}
+  /@internationalized/date/3.3.0:
+    resolution: {integrity: sha512-qfRd7jCIgUjabI8RxeAsxhLDRS1u8eUPX96GB5uBp1Tpm6YY6dVveE7YwsTEV6L4QOp5LKFirFHHGsL/XQwJIA==}
     dependencies:
-      '@swc/helpers': 0.4.14
+      '@swc/helpers': 0.5.1
     dev: false
 
-  /@internationalized/date/3.2.0:
-    resolution: {integrity: sha512-VDMHN1m33L4eqPs5BaihzgQJXyaORbMoHOtrapFxx179J8ucY5CRIHYsq5RRLKPHZWgjNfa5v6amWWDkkMFywA==}
+  /@internationalized/message/3.1.1:
+    resolution: {integrity: sha512-ZgHxf5HAPIaR0th+w0RUD62yF6vxitjlprSxmLJ1tam7FOekqRSDELMg4Cr/DdszG5YLsp5BG3FgHgqquQZbqw==}
     dependencies:
-      '@swc/helpers': 0.4.14
-    dev: false
-
-  /@internationalized/message/3.1.0:
-    resolution: {integrity: sha512-Oo5m70FcBdADf7G8NkUffVSfuCdeAYVfsvNjZDi9ELpjvkc4YNJVTHt/NyTI9K7FgAVoELxiP9YmN0sJ+HNHYQ==}
-    dependencies:
-      '@swc/helpers': 0.4.14
+      '@swc/helpers': 0.5.1
       intl-messageformat: 10.2.5
     dev: false
 
-  /@internationalized/number/3.2.0:
-    resolution: {integrity: sha512-GUXkhXSX1Ee2RURnzl+47uvbOxnlMnvP9Er+QePTjDjOPWuunmLKlEkYkEcLiiJp7y4l9QxGDLOlVr8m69LS5w==}
+  /@internationalized/number/3.2.1:
+    resolution: {integrity: sha512-hK30sfBlmB1aIe3/OwAPg9Ey0DjjXvHEiGVhNaOiBJl31G0B6wMaX8BN3ibzdlpyRNE9p7X+3EBONmxtJO9Yfg==}
     dependencies:
-      '@swc/helpers': 0.4.14
+      '@swc/helpers': 0.5.1
     dev: false
 
-  /@internationalized/string/3.1.0:
-    resolution: {integrity: sha512-TJQKiyUb+wyAfKF59UNeZ/kELMnkxyecnyPCnBI1ma4NaXReJW+7Cc2mObXAqraIBJUVv7rgI46RLKrLgi35ng==}
+  /@internationalized/string/3.1.1:
+    resolution: {integrity: sha512-fvSr6YRoVPgONiVIUhgCmIAlifMVCeej/snPZVzbzRPxGpHl3o1GRe+d/qh92D8KhgOciruDUH8I5mjdfdjzfA==}
     dependencies:
-      '@swc/helpers': 0.4.14
+      '@swc/helpers': 0.5.1
     dev: false
 
   /@istanbuljs/load-nyc-config/1.1.0:
@@ -1360,677 +1352,660 @@ packages:
       tslib: 2.5.0
     dev: true
 
-  /@popperjs/core/2.11.6:
-    resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
-    dev: false
-
-  /@react-aria/breadcrumbs/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-WiNMlk8COR+4zpJ8mFgTgWQqCxoFE6OMJ16anJzR8IgP1xMzUmIQ7l0s0Dv4D5qE+xVlgNF0ccDdw1x6A+WzPw==}
+  /@react-aria/breadcrumbs/3.5.3_react@18.2.0:
+    resolution: {integrity: sha512-rmkApAflZm7Finn3vxLGv7MbsMaPo5Bn7/lf8GBztNfzmLWP/dAA5bgvi1sj1T6sWJOuFJT8u04ImUwBCLh8cQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/link': 3.4.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/breadcrumbs': 3.5.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/link': 3.5.2_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/breadcrumbs': 3.6.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/button/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-4DSGXrAWflzT4cQe/x0KdrPzz7hv9vZgqYJuNXQkpmeIMs1EmUKuby2xC+W9GHuZ+8dMxjTWKy3XdwX2tCM42A==}
+  /@react-aria/button/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-QdvXTQgn+QEWOHoMbUIPXSBIN5P2r1zthRvqDJMTCzuT0I6LbNAq7RoojEbRrcn0DbTa/nZPzOOYsZXjgteRdw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/toggle': 3.5.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/toggle': 3.6.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/calendar/3.1.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-XWtoGMBTYpj5De2yfboAv60SMXa/T2BjPd0uSkiaPXAC0vPjdB0VPhGbSi6LKCYIiTAMs98mMP0P4WYhWyW4jA==}
+  /@react-aria/calendar/3.4.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-Ly+9KsOXWZTlOYDZeIYCWNuMZg7ZiJC497Z4U3SqaWmDsZaqwU8ZnLmZ1xUWq1cYvK9rnWPnnpby1JUgttY9RA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.1.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/live-announcer': 3.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/calendar': 3.1.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/calendar': 3.1.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/date': 3.3.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/calendar': 3.3.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/calendar': 3.3.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/checkbox/3.8.0_react@18.2.0:
-    resolution: {integrity: sha512-VjezmSfDx1/A+Yz5naZ9xCxkasmtsO7uK+Ur+Z6bKmHwvoazRK5cATdRG4mj++0JUBYn6bvBGBEXFZHTkkGahw==}
+  /@react-aria/checkbox/3.9.2_react@18.2.0:
+    resolution: {integrity: sha512-gpvC+EnrxcQ9wupnoXsIDUmhSeBpxWtfRIYYypn6Ta6NY9Ubkh4H/8xE9/27nhJltHf5rzEcLfKg4QlEftab/w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/toggle': 3.5.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/checkbox': 3.4.0_react@18.2.0
-      '@react-stately/toggle': 3.5.0_react@18.2.0
-      '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/toggle': 3.6.2_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/checkbox': 3.4.3_react@18.2.0
+      '@react-stately/toggle': 3.6.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/combobox/3.5.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-HyBX98TvQe8IscJlRz6TxgvMlYcwy9iTA/GWjy3bMNjUfxPaRZh5r69aG8JlTRvVDLE13cUSh0mKsTSjo8evvQ==}
+  /@react-aria/combobox/3.6.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-SWbA2vH26zcrZDbXdPJtZNR6ywYPdf4LU8/7IKLs1Iv7mrlICr9Cmeywiu2RuFRosuR1hGSy1hibBTgPO6V/sw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/listbox': 3.8.1_react@18.2.0
-      '@react-aria/live-announcer': 3.2.0
-      '@react-aria/menu': 3.8.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/overlays': 3.13.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/textfield': 3.9.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/collections': 3.6.0_react@18.2.0
-      '@react-stately/combobox': 3.4.0_react@18.2.0
-      '@react-stately/layout': 3.11.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/combobox': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/listbox': 3.10.0_react@18.2.0
+      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/menu': 3.10.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/overlays': 3.15.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/textfield': 3.10.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/combobox': 3.5.2_react@18.2.0
+      '@react-stately/layout': 3.12.2_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/combobox': 3.6.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/datepicker/3.3.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-76/5a2Dfe/SCcW0j4hqeSTnlh6SSW/AYPKPr5fNaiGnLFJ3oLsc9SAuUgTsOBglR/J3N/hqtH+UO2U8X1QC6Ng==}
+  /@react-aria/datepicker/3.5.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-oUfLbfFwe5XgS2Womx0t0gA8797mGQjjxZAGa9lGSNGFx26NOfhWBh24lAYQzQnZ5ot/DxDSJmzLjN6WEWv9pQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.1.0
-      '@internationalized/number': 3.2.0
-      '@internationalized/string': 3.1.0
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/spinbutton': 3.3.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/datepicker': 3.3.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/calendar': 3.1.0_react@18.2.0
-      '@react-types/datepicker': 3.2.0_react@18.2.0
-      '@react-types/dialog': 3.5.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/date': 3.3.0
+      '@internationalized/number': 3.2.1
+      '@internationalized/string': 3.1.1
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/spinbutton': 3.5.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/datepicker': 3.5.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/calendar': 3.3.0_react@18.2.0
+      '@react-types/datepicker': 3.4.0_react@18.2.0
+      '@react-types/dialog': 3.5.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/dialog/3.5.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-QcGwrNSn7hya6tcs0CTuYEMYBPk6YT1vaO6xMTfsSyRhJNCRvvtx/NJ3Bg26M7WvzbuC2aKaSDBw2c14ZeXr5g==}
+  /@react-aria/dialog/3.5.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-wXpAqnt6TtR4X/5Xk5HCTBM0qyPcF2bXFQ5z2gSwl1olgoQ5znZEgMqMLbMmwb4dsWGGtAueULs6fVZk766ygA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/overlays': 3.13.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/overlays': 3.5.0_react@18.2.0
-      '@react-types/dialog': 3.5.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/overlays': 3.15.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/overlays': 3.6.0_react@18.2.0
+      '@react-types/dialog': 3.5.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     transitivePeerDependencies:
       - react-dom
     dev: false
 
-  /@react-aria/dnd/3.1.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-SSkz9i7EcsoTrafDPpzlx+laYNfsUrCM7xX6yu68l9zO96kdoemZuv9OqbDBw2D1peqHT7kMoLreTLWsubb5bg==}
+  /@react-aria/dnd/3.3.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-rk46inb6XdVR5cIFzuMoqUfdqgqb+GHOIFGDiwhHYONeCdvQKD31ztQZ78yITORmPOmjrnn6r2V3GQ6Oz54WSQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/string': 3.1.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/live-announcer': 3.2.0
-      '@react-aria/overlays': 3.13.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-aria/visually-hidden': 3.7.0_react@18.2.0
-      '@react-stately/dnd': 3.1.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/string': 3.1.1
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/overlays': 3.15.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-aria/visually-hidden': 3.8.2_react@18.2.0
+      '@react-stately/dnd': 3.2.2_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/focus/3.11.0_react@18.2.0:
-    resolution: {integrity: sha512-yPuWs9bAR9CMfIwyOPm2oXLPF19gNkUqW+ozSPhWbLMTEa8Ma09eHW1br4xbN+4ONOm/dCJsIkxTNPUkiLdQoA==}
+  /@react-aria/focus/3.13.0_react@18.2.0:
+    resolution: {integrity: sha512-9DW7RqgbFWiImZmkmTIJGe9LrQBqEeLYwlKY+F1FTVXerIPiCCQ3JO3ESEa4lFMmkaHoueFLUrq2jkYjRNqoTw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.17.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       clsx: 1.2.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/grid/3.6.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-8u5oSqHrMNg4GVoOE21CEDcoAbTVpDUNg1mpJqM/ww2LrPZdEMQlU0Ro7Uq+zNg2tzVcdAtgPkh7EEErESIb4Q==}
+  /@react-aria/grid/3.8.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-7z1xFAbLPgUPROrXwuJk94STQPQ/K8rCLshhwTAg70uFVCPNnrm3jxQ6vE/lddPB+yss9Ee33GwSCrEXdzJkTw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.1_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/live-announcer': 3.2.0
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.16.0_react@18.2.0
-      '@react-stately/grid': 3.5.0_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-stately/virtualizer': 3.5.0_react@18.2.0
-      '@react-types/checkbox': 3.4.3_react@18.2.0
-      '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/grid': 3.7.0_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-stately/virtualizer': 3.6.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/grid': 3.1.8_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/gridlist/3.2.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-EQxtKs2c3+kzy6q4nbJoYF7sP33yTsP9NitneRLHNWuT9rdTqKCDps+e0VyXa9ynZkW9Dm5mek0n36mS8NW1zw==}
+  /@react-aria/gridlist/3.5.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-xBCWyTtJNdUKSSUWXPMEi4lTnM1NRUlEJNi0eTNPIQVZOwQ7AgkEOD6uI+C6mgBL8q0oJwyIAfhK3zdwUCQSPg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/grid': 3.6.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/grid': 3.8.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     transitivePeerDependencies:
       - react-dom
     dev: false
 
-  /@react-aria/i18n/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-PZCWmhO9mJvelwiYlsXLY6W4L2o+oza3xnDx0cZDVqp/Hf+OwMAPHWtZsFRTKdjk4TaOPB/ISc9HknWn6UpY4w==}
+  /@react-aria/i18n/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-zeohg7d66zPLnGQl1rJuVJJ/gP7GmUMxEKIFRwE+rg2u02ldKxJMSb8QKGo605QpFWqo7CuuWYvKJP5Mj+Em/w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.1.0
-      '@internationalized/message': 3.1.0
-      '@internationalized/number': 3.2.0
-      '@internationalized/string': 3.1.0
-      '@react-aria/ssr': 3.5.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/date': 3.3.0
+      '@internationalized/message': 3.1.1
+      '@internationalized/number': 3.2.1
+      '@internationalized/string': 3.1.1
+      '@react-aria/ssr': 3.7.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/i18n/3.7.1_react@18.2.0:
-    resolution: {integrity: sha512-2fu1cv8yD3V+rlhOqstTdGAubadoMFuPE7lA1FfYdaJNxXa09iWqvpipUPlxYJrahW0eazkesOPDKFwOEMF1iA==}
+  /@react-aria/interactions/3.16.0_react@18.2.0:
+    resolution: {integrity: sha512-vXANFKVd6ONqNw8U+ZWbSA8lrduCOXw7cWsYosTa5dZ24ZJfRfbhlvRe8CaAKMhB/rOOmvTLaAwdIPia6JtLDg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@internationalized/message': 3.1.0
-      '@internationalized/number': 3.2.0
-      '@internationalized/string': 3.1.0
-      '@react-aria/ssr': 3.6.0_react@18.2.0
-      '@react-aria/utils': 3.16.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/ssr': 3.7.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/interactions/3.14.0_react@18.2.0:
-    resolution: {integrity: sha512-e1Tkr0UTuYFpV21PJrXy7jEY542Vl+C2Fo70oukZ1fN+wtfQkzodsTIzyepXb7kVMGmC34wDisMJUrksVkfY2w==}
+  /@react-aria/label/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-o6Z9YAbvywj/b995HOl7fS9vf8FVmhWiJkKwFyCi/M1A7FXBqgtPcdPDNHaaKOhvQcwnLs4iMVMJwZdn/dLVDA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/label': 3.7.4_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/label/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-sNiPYiFg06s1zGuifEUeUqRiYje0lfHem+GIUh0Y5ZxfpqIyxEmyV9Aw+C7TTjjo8BAG4NZ4bR7iF9ujf9QvKQ==}
+  /@react-aria/link/3.5.2_react@18.2.0:
+    resolution: {integrity: sha512-CCFP11Uietro6TUZpWBoq3Ql/6qss/ODC5XM6oNxckj72IHruFIj8V7Y0tL5x0aE6h38hlKcDf8NCxkQqz2edg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/label': 3.7.2_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/link': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/link/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-d/h4y7SFO+KweMX5IRU99L1jz9AAwp6mNStkBjYGxCD29QYTVWClpZHjRlO1s6a9e2QTpk/LzsvjiytowzfHyA==}
+  /@react-aria/listbox/3.10.0_react@18.2.0:
+    resolution: {integrity: sha512-4NelMDZAPoy2W4uoKZsMpdrC6XJQiZU+vpuhnzUT1eWTneDsEHKHSHQFtymoe8VrUEPrCV16EeMk1vRVvjCfAw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/link': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-types/listbox': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/listbox/3.8.1_react@18.2.0:
-    resolution: {integrity: sha512-kTIQWms6nS//GWr63gSVcNgZv7uf5RULLTKH3DIpmaftS3Kf4Sds6rspWGYQ9PAeS1EqcuHozsXXlKBo1upYgg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  /@react-aria/live-announcer/3.3.1:
+    resolution: {integrity: sha512-hsc77U7S16trM86d+peqJCOCQ7/smO1cybgdpOuzXyiwcHQw8RQ4GrXrS37P4Ux/44E9nMZkOwATQRT2aK8+Ew==}
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-types/listbox': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
-      react: 18.2.0
+      '@swc/helpers': 0.5.1
     dev: false
 
-  /@react-aria/live-announcer/3.2.0:
-    resolution: {integrity: sha512-uSqDDy+9CbmNTZh0Roi4dvWKWcbuMTYKh3RnUw3XBPw0aYxSkcFQeWGfxFoOwXCDcXez02cFJtAxpR2bShkrsw==}
-    dependencies:
-      '@swc/helpers': 0.4.14
-    dev: false
-
-  /@react-aria/menu/3.8.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-p8DF/muxbTr/SOZh3FDFPcWUcnXvpwMKyR+xKXQQPbCV/LAiSjVtwxbNVvubqvzR0Qk6/XV4/HUY2r+4tnT8tQ==}
+  /@react-aria/menu/3.10.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-zOOOXvx21aGSxZsXvLa3NV48hLk0jBC/zu5WZHT0Mo/wAe0+43f8p/U3AT8Gc4WnxYbIestcdLaIwgeagSoLtQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/overlays': 3.13.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/menu': 3.5.1_react@18.2.0
-      '@react-stately/tree': 3.6.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/menu': 3.8.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/overlays': 3.15.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/menu': 3.5.3_react@18.2.0
+      '@react-stately/tree': 3.7.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/menu': 3.9.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/meter/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-2CqpTwkZ1Vnblqd+z+mP+3ZhQRg3oNkz7GxN9nRLTDrpxVLY+WtSeIGDK7x8EwmYrVo4q4wHl3DGa2VOLNNgVA==}
+  /@react-aria/meter/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-1RUr93cNfMqTfyGtQ+SqFYLqlOqza6TEmXmtdCExPuZVRUZRjQRkqPoYuL8CPwHKlU4sbSlLiNeUu/HhV6pyTg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/progress': 3.4.0_react@18.2.0
-      '@react-types/meter': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/progress': 3.4.3_react@18.2.0
+      '@react-types/meter': 3.3.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/numberfield/3.4.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-gZMZAjE+tcwtdDW5X5rlot7ihir1OCCEyzbIDFztte2h+I57b45ET9P4AmgrmqfOnyscPXI3kJn9eILNYHdZVw==}
+  /@react-aria/numberfield/3.6.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-LbtRS/JciPicYLjqAP87gufInzZ2rlOQlKu0tQK8l/Hwc2cPOWUldDXbrGgxrXwbMxfEASmfI6qYz8uhTGmIyw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/live-announcer': 3.2.0
-      '@react-aria/spinbutton': 3.3.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/textfield': 3.9.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/numberfield': 3.4.1_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/numberfield': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/textfield': 3.7.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/spinbutton': 3.5.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/textfield': 3.10.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/numberfield': 3.5.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/numberfield': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/textfield': 3.7.2_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/overlays/3.13.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-hRZyhAYzrlCcEWQ2k2jP24b0wc5/355Xl5w5FZHRmPeU1U4XlFwKX/eFlBs/li9Sprm1bTDXrCY480Kl6UsKDA==}
+  /@react-aria/overlays/3.15.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-MeLn74GvXZfi881NSx5sSd5eTduki/PMk4vPvMNp2Xm+9nGHm0FbGu2GMIGgarYy5JC7l/bOO7H01YrS4AozPg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/ssr': 3.5.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-aria/visually-hidden': 3.7.0_react@18.2.0
-      '@react-stately/overlays': 3.5.1_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/overlays': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/ssr': 3.7.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-aria/visually-hidden': 3.8.2_react@18.2.0
+      '@react-stately/overlays': 3.6.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/overlays': 3.8.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/progress/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-G8Wew/EjgzoBM6OOAtVinA0hEng/DXWZF7luCoMPuqSKOakFzzazHBMpmjcXku0GGoTGzLsqqOK1M5o3kDn4FA==}
+  /@react-aria/progress/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-u8aUrnnQGsRZWx5vBfBhf70TeGeN/gEJzcthef5YDUQZG8O2IDhzR1GLqBmn1RvdcSDvBdhRSpMXd+6bL1WzGw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/progress': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/progress': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/radio/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-d/Hxdu+jUdi3wmyaWYRLTyN16vZxr2MOdkmw8tojTOIMLQj7zTaCFc0D4LR4KZEn3E0F5buGCUHL6o4CTqBeBA==}
+  /@react-aria/radio/3.6.2_react@18.2.0:
+    resolution: {integrity: sha512-R7vyh0G2HaUe0+SGa/LDMYuGnNC/15L6yfuljpP8ZUDPw9bR/6BuE1BDCI0ov1EXQ1lQ/vcvZMbf78OC72vPrg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/radio': 3.8.0_react@18.2.0
-      '@react-types/radio': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/radio': 3.8.2_react@18.2.0
+      '@react-types/radio': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/searchfield/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-eAsOiTBUeD8OiRyXUbU6fWzkEO5ERAODZJtv4yGcMdTjtKJW4jxeRwc6GXMKF3hDvdz7Y9NV6YfMCICSiVSFYg==}
+  /@react-aria/searchfield/3.5.3_react@18.2.0:
+    resolution: {integrity: sha512-OqkXTZrjesqRxBR0WIOh0cezwmuXDQpsdua9nnGj0+8BIGCHuxvUOpw1HA3eTsf4AbZfygngC7pMT1lOR21upg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/textfield': 3.9.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/searchfield': 3.4.1_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/searchfield': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/textfield': 3.10.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/searchfield': 3.4.3_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/searchfield': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/select/3.9.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-SL+OZHhNLXAyX4FPP2uYj1+igB7t+pxoccO4qfrewbwPG8ext3bYx/gRQKc5A+chCY1ERIG9EQQo1vU/bZRQVA==}
+  /@react-aria/select/3.11.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-UEYhw7wK4XoPMVbTa3UykPcri9GIV777WvXeKEykS1nMbJzu1I1LUE5py4ymhaI7DbpZ+gWZPTA0iot8IYQOWQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/listbox': 3.8.1_react@18.2.0
-      '@react-aria/menu': 3.8.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-aria/visually-hidden': 3.7.0_react@18.2.0
-      '@react-stately/select': 3.5.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/select': 3.7.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/listbox': 3.10.0_react@18.2.0
+      '@react-aria/menu': 3.10.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-aria/visually-hidden': 3.8.2_react@18.2.0
+      '@react-stately/select': 3.5.2_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/select': 3.8.1_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/selection/3.13.1_react@18.2.0:
-    resolution: {integrity: sha512-YI5mFkk3JI3Ec01SzyBFGrdPInkoW5B0AavwLkN5QtehBUgdw9A1gPKADW4tiLfKUOl0rkqstP13n+v/GcBoTg==}
+  /@react-aria/selection/3.16.0_react@18.2.0:
+    resolution: {integrity: sha512-qQ4X0+wtLz0+qjsoj1T0hVehA0CbZdu0Ax+lCzWmj+ZDivtdeNpVQl+K0yj9p95MnzLgIbnY7zU2zDQrYqKDOQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/separator/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-AR3Pbik83dygOvmfBiCTRAHz+B13yyGz8nKyw521toT69RMtJTi8ha8qB6Iw1QP3YZWRv+Fn6WWrfGIvR+f2XQ==}
+  /@react-aria/separator/3.3.3_react@18.2.0:
+    resolution: {integrity: sha512-kBGEXSSUiJLPS9foS5/7jgzpdp3/Yb1aMvVuvRGuNxDUsPAmvaYUT3qZ44Zf3hoxKfRFb4452KcoZ03w3Jfcvg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/slider/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-UgR2XEI3vrJAQU1RVC+1uHVr/vFcVh+Cjt/kaFUO7fdj8usqa4JOnIuX+QKCysiVLJc7IEXw4RCJBJYBSUYK6A==}
+  /@react-aria/slider/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-7qvzWZzwSww/+kLiSC8UJo4csHo8ndFzpzE2jUOom+hKMFomg5gIF4vqJI3ieWwF6rm6bbLmhxN4GvmNebVMwA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/radio': 3.8.0_react@18.2.0
-      '@react-stately/slider': 3.3.1_react@18.2.0
-      '@react-types/radio': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/slider': 3.4.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/radio': 3.8.2_react@18.2.0
+      '@react-stately/slider': 3.4.0_react@18.2.0
+      '@react-types/radio': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/slider': 3.5.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/spinbutton/3.3.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-FXTFNz2RFClqGxQzMIHYdsjkm6fcWRObqelY+lXP5udk7Q8T9aQn+28QhqVpbOFXotLE2PltElbziJeuhkVgNA==}
+  /@react-aria/spinbutton/3.5.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-WWLPiJd2nbv17dSbcbOm+TXlLO9ZIEA86ft/CTkvRYRG48kDn++4f16QcA0Gr+7dKdLQGbKkCf61jMJ3q8t5Hw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.1_react@18.2.0
-      '@react-aria/live-announcer': 3.2.0
-      '@react-aria/utils': 3.16.0_react@18.2.0
-      '@react-types/button': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/ssr/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-h0MJdSWOd1qObLnJ8mprU31wI8tmKFJMuwT22MpWq6psisOOZaga6Ml4u6Ee6M6duWWISjXvqO4Sb/J0PBA+nQ==}
+  /@react-aria/ssr/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-bfufjg4ESE5giN+Fxj1XIzS5f/YIhqcGc+Ve+vUUKU8xZ8t/Xtjlv8F3kjqDBQdk//n3mluFY7xG1wQVB9rMLQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@swc/helpers': 0.4.14
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/ssr/3.6.0_react@18.2.0:
-    resolution: {integrity: sha512-OFiYQdv+Yk7AO7IsQu/fAEPijbeTwrrEYvdNoJ3sblBBedD5j5fBTNWrUPNVlwC4XWWnWTCMaRIVsJujsFiWXg==}
+  /@react-aria/switch/3.5.2_react@18.2.0:
+    resolution: {integrity: sha512-mhV4Ip3t241s7gp4ETDe61AsSDox5TZXkiWt8add65p/LMESYBju9hGtbrxkMNCW62AuYCTAIadHoEOpy9HIIg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@swc/helpers': 0.4.14
+      '@react-aria/toggle': 3.6.2_react@18.2.0
+      '@react-stately/toggle': 3.6.0_react@18.2.0
+      '@react-types/switch': 3.3.2_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/switch/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-FWbjqNcY+fAjRNXVQTvOx93udhaySgXLsMNLRAVUcFm45FqTaxAhHhNGtRnVhDvzHTJY/Y+kpcGzCcW2rXzPxg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-aria/toggle': 3.5.0_react@18.2.0
-      '@react-stately/toggle': 3.5.1_react@18.2.0
-      '@react-types/switch': 3.3.0_react@18.2.0
-      '@swc/helpers': 0.4.14
-      react: 18.2.0
-    dev: false
-
-  /@react-aria/table/3.8.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-21cewiqA7Wmco6baAZKHEIXTmmtwAAPkmdXnua+Ysc+18ry3Sd1GaIvFkDRSwqIH43xWtXJhlHkWhJcKxle+Xg==}
+  /@react-aria/table/3.10.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-N42Ill9fdjeWKC/516fPMpPa79B0c+teFJ/fhcROLFrlwotgLKwndIG/InkE1L6FKeiJ8JL33FgUnxfRGafa8Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/grid': 3.6.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/live-announcer': 3.2.0
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/table': 3.9.0_react@18.2.0
-      '@react-stately/virtualizer': 3.5.0_react@18.2.0
-      '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/table': 3.5.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/grid': 3.8.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-aria/visually-hidden': 3.8.2_react@18.2.0
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/table': 3.10.0_react@18.2.0
+      '@react-stately/virtualizer': 3.6.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/grid': 3.1.8_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/table': 3.7.0_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/tabs/3.4.1_react@18.2.0:
-    resolution: {integrity: sha512-0dS26zcmNq1ERKy3kHOD465UegOBCZEHsM3+jxrMBONyG76tACyNNRyMOm0sk5h3XLravBJR/uySRhAtvBEi0w==}
+  /@react-aria/tabs/3.6.1_react@18.2.0:
+    resolution: {integrity: sha512-P/P3HA+b1Q917hVvXn1kzFl3dQnMTwYR8JKY5gjfjLQsAAEfJzSO3wLR0vNSp6Cz2FTAVCH4yzwP1G+bRLZVnw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-stately/tabs': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/tabs': 3.2.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-stately/tabs': 3.5.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/tabs': 3.3.0_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/textfield/3.9.0_react@18.2.0:
-    resolution: {integrity: sha512-plX+/RDidTpz4kfQni2mnH10g9iARC5P7oi4XBXqwrVCIqpTUNoyGLUH952wObYOI9k7lG2QG0+b+3GyrV159g==}
+  /@react-aria/tag/3.1.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-N3h34k23jK7xuMh4eMDJoUG1xsNUw6zz+r9mmSMMLCxU38w+RH27ywEpKheW25M7LhfggqTjbjnPOpPpBnrENQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/textfield': 3.7.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/gridlist': 3.5.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-types/button': 3.7.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+    dev: false
+
+  /@react-aria/textfield/3.10.0_react@18.2.0:
+    resolution: {integrity: sha512-TYFgDTlxrljakD0TGOkoSCvot9BfVCZSrTKy3+/PICSTkPIzXThLIQmpX6yObLMXQSNW6SvBCl6CMetJMJHcbw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/textfield': 3.7.2_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/toggle/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-K49OmHBmYW8pk0rXJU1TNRzR+PxLVvfL/ni6ifV5gcxoxV6DmFsNFj+5B/U3AMnCEQeyKQeiY6z9X7EBVX6j9Q==}
+  /@react-aria/toggle/3.6.2_react@18.2.0:
+    resolution: {integrity: sha512-bRz/ybajeLEsJLt1ARRL7CtWs6bwvkNLWy/wpJnH2TJ3+lMpH+EKbWBVJoAP7wQ5jIVVpxKJLhpf6w6x8ZLtdw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.16.0_react@18.2.0
-      '@react-stately/toggle': 3.5.1_react@18.2.0
-      '@react-types/checkbox': 3.4.3_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/switch': 3.3.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/toggle': 3.6.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/switch': 3.3.2_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/tooltip/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-b1E9m6WIPNV0TNRn9VNBnDn1FFt/pwKGtIGDDablLArEmSkkz0HJjwlUqC4+vL0U2dCaQA4TxWl9GDQE7Wzl8w==}
+  /@react-aria/tooltip/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-D38C7M58ZXWmY2+TXDczbbYRj9/KhIDyE/rLI0KhZR/iXDOJvmB9DT8HZuZLPsntq4Wl6mpmfPggT/R91nvR2Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-stately/tooltip': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/tooltip': 3.3.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/tooltip': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/tooltip': 3.4.2_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/utils/3.15.0_react@18.2.0:
-    resolution: {integrity: sha512-aJZBG++iz1UwTW5gXFaHicKju4p0MPhAyBTcf2awHYWeTUUslDjJcEnNg7kjBYZBOrOSlA2rAt7/7C5CCURQPg==}
+  /@react-aria/utils/3.18.0_react@18.2.0:
+    resolution: {integrity: sha512-eLs0ExzXx/D3P9qe6ophJ87ZFcI1oRTyRa51M59pCad7grrpk0gWcYrBjMwcR457YWOQQWCeLuq8QJl2QxCW6Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/ssr': 3.5.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/ssr': 3.7.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       clsx: 1.2.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/utils/3.16.0_react@18.2.0:
-    resolution: {integrity: sha512-BumpgENDlXuoRPQm1OfVUYRcxY9vwuXw1AmUpwF61v55gAZT3LvJWsfF8jgfQNzLJr5jtr7xvUx7pXuEyFpJMA==}
+  /@react-aria/visually-hidden/3.8.2_react@18.2.0:
+    resolution: {integrity: sha512-MFTqqSvPfc8u3YlzNfQ3ITX4eVQpZDiSqLPKj3Zyr86CKlba5iG8WGqjiJhD2GNHlvmcF/mITXTsNzm0KxFE7g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/ssr': 3.6.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
-      clsx: 1.2.1
-      react: 18.2.0
-    dev: false
-
-  /@react-aria/visually-hidden/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-v/0ujJ67H6LjwY8J7mIGPVB1K8suBArLV+w8UGdX/wFXRL7H4r2fiqlrwAElWSmNbhDQl5BDm/Zh/ub9jB9yzA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       clsx: 1.2.1
       react: 18.2.0
     dev: false
@@ -2089,837 +2064,567 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-stately/calendar/3.1.0_react@18.2.0:
-    resolution: {integrity: sha512-PZXXHyrLoYEUAUL8oFoxHNc7mKrQXLxnYQkY9v3a6SxgST3J4tYoqIXrie0uqpm1LI+1JfKb2lyRGlVPRTBuNQ==}
+  /@react-stately/calendar/3.3.0_react@18.2.0:
+    resolution: {integrity: sha512-fnqdxCTlkikgldEyW8ciPNUWhqaUsQKTx6X6XGob6VCwK59k0LmdlgZX+dXj0q2ezC+w4lnvz8TzpoRQ7GY8lw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/calendar': 3.2.0_react@18.2.0
-      '@react-types/datepicker': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/date': 3.3.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/calendar': 3.3.0_react@18.2.0
+      '@react-types/datepicker': 3.4.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/calendar/3.2.0_react@18.2.0:
-    resolution: {integrity: sha512-A13QSmlzLI5rtpIu2QIkij4ST29MWkCJd1kM6WFDS/1if8lSzfPL3kI4tdFDaFzFCwmv2Hb2cIfv9soIG8KASQ==}
+  /@react-stately/checkbox/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-TEd50vrUTHZWt8qO7ySLG2MlWJbsCvyx+pA1VhLJw6hRfjqorAjmCcpV2sEdu3EkLG7hA/Jw+7iBmGPlxmBN6A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/calendar': 3.2.0_react@18.2.0
-      '@react-types/datepicker': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/toggle': 3.6.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/checkbox/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-zqwHMmlzza1exS6Bbqj4Mom3ygtG8pLguHweZ9OO7BFQLwBmzJsrFNqDcj7xh8iEWxXKQfZ2YOuhkaGvu4GRjA==}
+  /@react-stately/collections/3.9.0_react@18.2.0:
+    resolution: {integrity: sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/toggle': 3.5.1_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/checkbox': 3.4.3_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/checkbox/3.4.1_react@18.2.0:
-    resolution: {integrity: sha512-Ju1EBuIE/JJbuhd8xMkgqf3KuSNpRrwXsgtI+Ur42F+lAedZH7vqy+5bZPo0Q3u0yHcNJzexZXOxHZNqq1ij8w==}
+  /@react-stately/combobox/3.5.2_react@18.2.0:
+    resolution: {integrity: sha512-vMp3/xWv9a3DglTvvcQsJup3zZkmIANbf799j21Kc6Z4DXs+ohU81Qg5q9Z/5QuTEPsJFFv7vKXtb+VlP/TK2g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/toggle': 3.5.1_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/checkbox': 3.4.3_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-stately/menu': 3.5.3_react@18.2.0
+      '@react-stately/select': 3.5.2_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/combobox': 3.6.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/collections/3.6.0_react@18.2.0:
-    resolution: {integrity: sha512-znkaqCPo7F1yyzEKDAB5MpX1Vw5UHcUQhDNrys5YOqAkX6/G/AChnBz0B63UxS3fjyqgnuJylRRmUp9nTqO21w==}
+  /@react-stately/data/3.10.0_react@18.2.0:
+    resolution: {integrity: sha512-B5GqSNvvgTxVziR2nJW84HhvLOEI9AYPm/cyEdkumams7BFP8XEQStSS/SiRCMuufdHe4pnzHAQr5ynfRObwkg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/collections/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-xZHJxjGXFe3LUbuNgR1yATBVSIQnm+ItLq2DJZo3JzTtRu3gEwLoRRoapPsBQnC5VsjcaimgoqvT05P0AlvCTQ==}
+  /@react-stately/datepicker/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-GPscIz4jP9hDa1ChgMAWAt8g8mCpjILmSgfyuIZXegPZfa3ryKuQutYU/JGJrBom1xablAgeHIN1AWpve+4f1w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/date': 3.3.0
+      '@internationalized/string': 3.1.1
+      '@react-stately/overlays': 3.6.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/datepicker': 3.4.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/combobox/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-QVKNosNqSS7PnjrNVrGat9KKlCcv7e3nTehQuIu18ZE2JVH7Jdf/73zkSMurrnQfbPVeiHkGK1deWqrzoNzYQQ==}
+  /@react-stately/dnd/3.2.2_react@18.2.0:
+    resolution: {integrity: sha512-1Eb4ZGh2xzTLDBV/Y+c/UoOvd2A9rglj+5o1Vo7HuIVWWc8tDJXq499B7rp/5JPcfQspF5OI4h08OWZFlPd/Ig==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-stately/menu': 3.5.1_react@18.2.0
-      '@react-stately/select': 3.5.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/combobox': 3.6.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/combobox/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-1klrkm1q1awoPUIXt0kKRrUu+rISLQkHRkStjLupXgGOnJUyYP0XWPYHCnRV+IR2K2RnWYiEY5kOi7TEp/F7Fw==}
+  /@react-stately/grid/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-3eb7+7p9Xh/+luUOyieY2bM4CsARA8WnRB7c2++gh4dh9AEpZV4VGICGTe35+dJYr+9pbYQqVMEcEFUOaJJzZw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-stately/menu': 3.5.1_react@18.2.0
-      '@react-stately/select': 3.5.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/combobox': 3.6.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-types/grid': 3.1.8_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/data/3.9.1_react@18.2.0:
-    resolution: {integrity: sha512-UClgI8jQTF3hVR/WLa2ht7Gjd2x2PRnYycDmfY+mfbd+ONBD7rX/m3KWGgrR8AvO05qSpQoSlab8D+cfLXvgWA==}
+  /@react-stately/layout/3.12.2_react@18.2.0:
+    resolution: {integrity: sha512-9AGA11G5+Uo/mQoJR90lbqTR4+UFSl13jQMtqom/BYxkFGrHh3gWSUWEmg2h+n1Qa1q+oJjgaeQ9bxqlrR/wpQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/table': 3.10.0_react@18.2.0
+      '@react-stately/virtualizer': 3.6.0_react@18.2.0
+      '@react-types/grid': 3.1.8_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/table': 3.7.0_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/datepicker/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-HH/WPAMXwULyBKHICxTLGDk3cPGf9Yhf8sX2DES935aupd+6YqzQrh97buOedKsF5WKZfzMMtUVqy8uepo6S6g==}
+  /@react-stately/list/3.9.0_react@18.2.0:
+    resolution: {integrity: sha512-9DNV02zFEkJG38AtHyhvGMfpJQGwV0KMyMObs+KEujzCh+rmHdTu1rWdjzLw1ve+ecESK8UMsF4Kt6wwO0Qi6g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@internationalized/string': 3.1.0
-      '@react-stately/overlays': 3.5.1_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/datepicker': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/datepicker/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-JiRQBQYDXOQDdJl5YUGob10aVYp2N/F5rSSkRt7MrBJhC87bkDW0ARfs83gnl398WOJ6d9rJp0f+CJa1mjtzUw==}
+  /@react-stately/menu/3.5.3_react@18.2.0:
+    resolution: {integrity: sha512-RFgwVD/4BgTtJkexi1WaHpAEkQWZPvpyri0LQUgXWVqBf9PpjB8wigF3XBLMDNkL+YXE0QtzQZBNS1nJECf7rg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@internationalized/string': 3.1.0
-      '@react-stately/overlays': 3.5.1_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/datepicker': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/overlays': 3.6.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/menu': 3.9.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/dnd/3.1.0_react@18.2.0:
-    resolution: {integrity: sha512-PctHJqRm37vdKs91vB18lfdas4CypStbgj6ENApUXSDLd8XrVgthH4sYrX1BX/RbZyCr7u+TG7qVKGcRfsvbTw==}
+  /@react-stately/numberfield/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-2R39hXQpQzoVDl1r3TZDKUEKf6lHbhiOpcBOYTPOne+YJOyMXQ6PnXAOTVuIcgTNdagukhXQVoDYH2B/1FvJOA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/number': 3.2.1
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/numberfield': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/dnd/3.2.0_react@18.2.0:
-    resolution: {integrity: sha512-e+f5lBiBBHmgqwcKKPxJBpCSx08iuNacNUFQ5/yIWm/enpjwTQhCMyfOFCLM1DfSllM/19GlqV/GiDRM7xjEAQ==}
+  /@react-stately/overlays/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-0Bgy4xwCXKM+jkHAGJMN19ZFXNgKstf6qJozfH79j3E5erY30ZStwT7gbAnwv112zFUQLHBKo+3wJTGWuHgs8Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/overlays': 3.8.0_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/grid/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-kCmO2KyHoIJWiCqUXJTD0I/4q/6h3pXGdyD4tWmqWdysxf+x09K/Mx/JwwFqee5LICZgt8MtBrfV+ijLZ8mQAg==}
+  /@react-stately/radio/3.8.2_react@18.2.0:
+    resolution: {integrity: sha512-tjlXask1IEGzzXwdc495K+wsHhyVhtaMhAeTbrdTD1a1fdg2g/jA0vWhN/KGO/CpnZT4vXGjJcY686Rmlrt9EQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-types/grid': 3.1.7_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/radio': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/grid/3.6.0_react@18.2.0:
-    resolution: {integrity: sha512-Sq/ivfq9Kskghoe6rYh2PfhB9/jBGfoj8wUZ4bqHcalTrBjfUvkcWMSFosibYPNZFDkA7r00bbJPDJVf1VLhuw==}
+  /@react-stately/searchfield/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-mTdbWGpOA7foZJwkiR0AP5beh66I1feHMQ9/7/3lR4ETqLQ29vVXte+jc3+RrlFy+Adup0Ziwzs3DMfMZ0rN8Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-types/grid': 3.1.7_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/searchfield': 3.4.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/layout/3.11.0_react@18.2.0:
-    resolution: {integrity: sha512-QNupEFgIv5hqYEbLxDQfHgBkfk6t1VTTxWftBZMXXJEVCC1GH8vUJ35BJGO7hQNhPoTp3xc3X7yEcBlXy1ZmlA==}
+  /@react-stately/select/3.5.2_react@18.2.0:
+    resolution: {integrity: sha512-hIDAXFNg+q8rGQy5YKEaOz4NoWsckoQoi18vY8u6VsFUIhfYaYL76x6zKbTwekZLYuroifH7Fv81tBvRZmXikQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/table': 3.9.0_react@18.2.0
-      '@react-stately/virtualizer': 3.5.0_react@18.2.0
-      '@react-types/grid': 3.1.6_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/table': 3.5.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-stately/menu': 3.5.3_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/select': 3.8.1_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/list/3.8.0_react@18.2.0:
-    resolution: {integrity: sha512-eJ1iUFnXPZi5MGW2h/RdNTrKtq4HLoAlFAQbC4eSPlET6VDeFsX9NkKhE/A111ia24DnWCqJB5zH20EvNbOxxA==}
+  /@react-stately/selection/3.13.2_react@18.2.0:
+    resolution: {integrity: sha512-rVnseneG9XWuS0+JEsa0EhRfTZsupm9JiEuZHZ19YeLewjVdFpjgBMDZb8ZYoyilNXVjyUwaoq94FsOXotsg9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/menu/3.5.1_react@18.2.0:
-    resolution: {integrity: sha512-nnuZlDBFIc3gB34kofbKDStFg9r8rijY+7ez2VWQmss72I9D7+JTn7OXJxV0oQt2lBYmNfS5W6bC9uXk3Z4dLg==}
+  /@react-stately/slider/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-VvGJ1XkFIIEXP0eg9xqK/NztimBCSRmEqLgqlwzeDJAtuFXZzPRgJGrodGnqGmhoLsTFaY8YleLh/1hgf6rO0g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/overlays': 3.5.1_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/menu': 3.9.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/slider': 3.5.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/numberfield/3.4.1_react@18.2.0:
-    resolution: {integrity: sha512-fpIyk3Wf9HN/fY/T2y4q9mA/9z4no8QMY4tEIn/tkumjU6QGzxCSRO0qb3RFE8sU0etsVAZOkPi+97DeQVLExw==}
+  /@react-stately/table/3.10.0_react@18.2.0:
+    resolution: {integrity: sha512-LDF97lZIkCDYNFw5Yz1eREedO9QerPDchxXUXlPVyjwLiZ4ADlhz6W/NTq6gm2PgrHljY/0+Kd5zEgVySLMTEw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/number': 3.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/numberfield': 3.4.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/grid': 3.7.0_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-types/grid': 3.1.8_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/table': 3.7.0_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/overlays/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-r+U/G0Y4tCfI5wyBeIu+hmcZVRN8ChoK2zM1srPH9nDKsijQard2goX+9YmKng2LJ01Re/P6F8S8jYbpfEdLfQ==}
+  /@react-stately/tabs/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-N6B0+ZyW6mbmY/kHl0GKGj/i7MtA141A7yYJFSLDdvq1Hb2x7V1Y6gfl40FkSW4W9y3oQtKU+rTxV0EyjEJMWQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/tabs': 3.3.0_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/overlays/3.5.1_react@18.2.0:
-    resolution: {integrity: sha512-lDKqqpdaIQdJb8DS4+tT7p0TLyCeaUaFpEtWZNjyv1/nguoqYtSeRwnyPR4p/YM4AW7SJspNiTJSLQxkTMIa8w==}
+  /@react-stately/toggle/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-w+Aqh78H9MLs0FDUYTjAzYhrHQWaDJ2zWjyg2oYcSvERES0+D0obmPvtJLWsFrJ8fHJrTmxd7ezVFBY9BbPeFQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/radio/3.8.0_react@18.2.0:
-    resolution: {integrity: sha512-3xNocZ8jlS8JcQtlS+pGhGLmrTA/P6zWs7Xi3Cx/I6ialFVL7IE0W37Z0XTYrvpNhE9hmG4+j63ZqQDNj2nu6A==}
+  /@react-stately/tooltip/3.4.2_react@18.2.0:
+    resolution: {integrity: sha512-tDkoYyEfdo44a3CoeiF794TFTs36d9faX0QvbR1QZ2KksjCMceOL5+26MlQjnhjEydYqw1X1YlTZbtMeor4uQw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/radio': 3.4.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/overlays': 3.6.0_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/tooltip': 3.4.2_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/searchfield/3.4.1_react@18.2.0:
-    resolution: {integrity: sha512-iEMcT2hH15TSoONi6FyFa9mh+H/UyNneYFzaUgl7kEClfL38Dq/y0zF18N9T8PJ0GvXN2Yj9Fc0AvycNy3DQ8g==}
+  /@react-stately/tree/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-oXOjJwy/o3XSJyBkudiEvnjWzto2jy48kmGjHCJ+B7Hv+WcbN9o7iAaHv11lOqMXRSpuF9gqox4ZZCASG+smIQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/searchfield': 3.4.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-stately/utils': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/select/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-65gCPkIcyhGBDlWKYQY+Xvx38r7dtZ/GMp09LFZqqZTYSe29EgY45Owv4+EQ2ZSoZxb3cEvG/sv+hLL0VSGjgQ==}
+  /@react-stately/utils/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-VbApRiUV2rhozOfk0Qj9xt0qjVbQfLTgAzXLdrfeZSBnyIgo1bFRnjDpnDZKZUUCeGQcJJI03I9niaUtY+kwJQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-stately/menu': 3.5.1_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/select': 3.8.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/selection/3.13.0_react@18.2.0:
-    resolution: {integrity: sha512-F6FiB5GIS6wdmDDJtD2ofr+y6ysLHcvHVyUZHm00aEup2hcNjtNx3x4MlFIc3tO1LvxDSIIWXJhPXdB4sb32uw==}
+  /@react-stately/virtualizer/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-f78BQT9ZSD5Hpqf6axRoNQJFqV+JjMSV2VixMfhIAcqi/fn8rEN2j3g4SPdFzTtFf2FR3+AKdBFu5tsgtk1Tgw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@swc/helpers': 0.5.1
       react: 18.2.0
     dev: false
 
-  /@react-stately/slider/3.3.1_react@18.2.0:
-    resolution: {integrity: sha512-d38VY/jAvDzohYvqsdwsegcRCmzO1Ed4N3cdSGqYNTkr/nLTye/NZGpzt8kGbPUsc4UzOH7GoycqG6x6hFlyuw==}
+  /@react-types/breadcrumbs/3.6.0_react@18.2.0:
+    resolution: {integrity: sha512-EnZk/f59yMQUmH2DW21uo3ajQ7nLEZ/sIMSfEZYP69CFe1by0RKi9aFRjJSrYjxRC0PSHTVPTjIG72KeBSsUGA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.7.1_react@18.2.0
-      '@react-aria/utils': 3.16.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/slider': 3.5.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/link': 3.4.3_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/table/3.9.0_react@18.2.0:
-    resolution: {integrity: sha512-Cl0jmC5eCEhWBAhCjhGklsgYluziNZHF34lHnc99T/DPP+OxwrgwS9rJKTW7L6UOvHU/ADKjEwkE/fZuqVBohg==}
+  /@react-types/button/3.7.3_react@18.2.0:
+    resolution: {integrity: sha512-Fz1t/kYinHDunmct3tADD2h3UDBPZUfRE+zCzYiymz0g+v/zYHTAqnkWToTF9ptf8HIB5L2Z2VFYpeUHFfpWzg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/grid': 3.6.0_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-types/grid': 3.1.7_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/table': 3.6.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/tabs/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-GeU0cykAEsyTf2tWC7JZqqLrgxPT1WriCmu9QAswJ7Dev1PkPvwDy3CEhJ3QDklTlhiLXLZOooyHh37lZTjRdg==}
+  /@react-types/calendar/3.3.0_react@18.2.0:
+    resolution: {integrity: sha512-5Qga+eixj+PembMwzcJmQlxif4XhSJJ54JcoyYHVf6mYLw3aE81Jc52OBi1FEWBJOW9YVOTk7VbWPFFF/oBI8A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/tabs': 3.2.1_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/date': 3.3.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/toggle/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-vKwLLkFsiIve4pXIQC/dqLAz7Z+qtzJ8+D00EXXO1Nf8YHcyIMDkTmi3NTM8Qtvmt4xX2hbJFiPDF6WvF6mBIg==}
+  /@react-types/checkbox/3.4.4_react@18.2.0:
+    resolution: {integrity: sha512-rJNhbW4R9HTvdbF2oTZmqGiZ/WVP3/XsU4gae7tfdhSYjG+5T5h9zau1vRhz++zwKn57wfcyNn6a83GDhhgkVw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/checkbox': 3.4.3_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/toggle/3.5.1_react@18.2.0:
-    resolution: {integrity: sha512-PF4ZaATpXWu7DkneGSZ2/PA6LJ1MrhKNiaENTZlbojXMRr5kK33wPzaDW7I8O25IUm0+rvQicv7A6QkEOxgOPg==}
+  /@react-types/combobox/3.6.2_react@18.2.0:
+    resolution: {integrity: sha512-qitu/W3Z3/ihyqocy+8n4HZKRXF5JTMHl1ug3rKps5yCNnVdkWwjPFPM6w180c9QjquThNY3o947LZ1v59qJ4A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/checkbox': 3.4.3_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/tooltip/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-TQyDIcugRah4eGmbK6UsyrtJrKJKte+xKv8X7kgdiGVMWiENiMG5h+3pGa8OT07FJzg7FvQHkMH+hrIuAqXT2g==}
+  /@react-types/datepicker/3.4.0_react@18.2.0:
+    resolution: {integrity: sha512-gQmbeNdVPXpaX8XsvxQb6nRLQZNlsMnDLVVpagVno7bifz2cdbthLfMe124nNT/Xr+JXolP+BtlYlZ7IRQVxdA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/overlays': 3.5.1_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/tooltip': 3.4.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@internationalized/date': 3.3.0
+      '@react-types/calendar': 3.3.0_react@18.2.0
+      '@react-types/overlays': 3.8.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/tree/3.6.0_react@18.2.0:
-    resolution: {integrity: sha512-9ekYGaebgMmd2p6PGRzsvr8KsDsDnrJF2uLV1GMq9hBaMxOLN5/dpxgfZGdHWoF3MXgeHeLloqrleMNfO6g64Q==}
+  /@react-types/dialog/3.5.3_react@18.2.0:
+    resolution: {integrity: sha512-iTdg+UZiJpJe7Rnu9eILf8Hcd9li0Kg2eg8ba8dIc1O++ymqPmrdPWj9wj1JB9cl94E2Yg4w3W5YINiLXkdoeA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-stately/utils': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/overlays': 3.8.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/utils/3.6.0_react@18.2.0:
-    resolution: {integrity: sha512-rptF7iUWDrquaYvBAS4QQhOBQyLBncDeHF03WnHXAxnuPJXNcr9cXJtjJPGCs036ZB8Q2hc9BGG5wNyMkF5v+Q==}
+  /@react-types/grid/3.1.8_react@18.2.0:
+    resolution: {integrity: sha512-NKk4pDbW2QXJOYnDSAYhta81CGwXOc/9tVw2WFs+1wacvxeKmh1Q+n36uAFcIdQOvVRqeGTJaYiqLFmF3fC3tA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@swc/helpers': 0.4.14
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-stately/virtualizer/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-Jjk7V2T9uJ2+1EaVY+v1SJYeKb9dvZKayP35bcUq8/y9+I41kNE+qmgnkr5/SVzkExu4YeZTFxtuOm4l8UX5jg==}
+  /@react-types/label/3.7.4_react@18.2.0:
+    resolution: {integrity: sha512-SfTqPRI39GE3GFD5ZGYEeX9jXQrNqDeaaI36PJhnbgGVFz96oVVkhy9t9c2bMHcbhLLENYIHMzxrvVqXS07e7A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/utils': 3.16.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@swc/helpers': 0.4.14
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/breadcrumbs/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-Nd95NnLhrSw8Eaf2nsgAz23BT/ww6m2d2GS/gT7NxkCcqWK8Dpv8+e+JSbO7CUkHJApm76FtRz16JCdltj4CeQ==}
+  /@react-types/link/3.4.3_react@18.2.0:
+    resolution: {integrity: sha512-opKfkcaeV0cir64jPcy7DS0BrmdfuWMjua+MSeNv7FfT/b65rFgPfAOKZcvLWDsaxT5HYb7pivYPBfjKqHsQKw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/link': 3.4.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/button/3.7.1_react@18.2.0:
-    resolution: {integrity: sha512-c+8xjmqWSjI5/mEHVLbVSp0eh/z2UU8Ga+wqjbEUZUjm8uopYj1PaCAwZ7YgcAebyQrL/21GyjK6tFHKzuUdJQ==}
+  /@react-types/listbox/3.4.2_react@18.2.0:
+    resolution: {integrity: sha512-qg980T+tl15pqgfuK8V6z+vsvsIrJEEPxcupQXP3T1O0LxWxJDakZHF0lV9qwfyB9XlnVSMZfkjDiZp9Wgf8QQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/calendar/3.1.0_react@18.2.0:
-    resolution: {integrity: sha512-6VKBxG27cLKti8Ik+T2N1y6FqJSgIXuQPMehOA1ASqPQLtnRBEoSgLjuN5qj7RTWgmdTvQmofqVznVFoUe5ozQ==}
+  /@react-types/menu/3.9.2_react@18.2.0:
+    resolution: {integrity: sha512-OIuEOGqo8gHaP4k3Ua+RvuPN2/3Sgcl30dNFIGaK7hra4eWxOUu8TTC+/Quy6xozR/SvFhqCLCoMKixy6MblWQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/overlays': 3.8.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/calendar/3.2.0_react@18.2.0:
-    resolution: {integrity: sha512-MunGx/lQgf/Lf9v2MrWoqKTZhJJcyAhUno2MewytdMQNXwtY2FB1X4fUufMMrKHwhVnFVkGfEQJCh4FAm5P9JA==}
+  /@react-types/meter/3.3.2_react@18.2.0:
+    resolution: {integrity: sha512-o21Zz+3LNjvBueMap+q2otGp5t2Xeb/lIMM4Y+v8j5XO+bLcHaAjdQB/TgKRe8iYFm3IqwpVtV9A38IWDtpLRQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/progress': 3.4.1_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/checkbox/3.4.2_react@18.2.0:
-    resolution: {integrity: sha512-/NWFCEQLvVgo25afPt2jv4syxYvZeY/D/n2Y92IGtoNV4akdz4AuQ65+1X+JOhQc/ZbAblWw5fFWUZoQs3CLZg==}
+  /@react-types/numberfield/3.4.2_react@18.2.0:
+    resolution: {integrity: sha512-SGzuuFf5wCSRPvpV+bnykiXSIt8pkpBBVp8tlygB66pQSBV7VLdUvWGohaayPSM+3Z+WkU+osgzYtGq5wh+C3Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/checkbox/3.4.3_react@18.2.0:
-    resolution: {integrity: sha512-kn2f8mK88yvRrCfh8jYCDL2xpPhSApFWk9+qjWGsX/bnGGob7D5n71YYQ4cS58117YK2nrLc/AyQJXcZnJiA7Q==}
+  /@react-types/overlays/3.8.0_react@18.2.0:
+    resolution: {integrity: sha512-0JxwUW3xwXjsT+nVI5dVE1KUm8QKxnQj9vjqgsazX213+klRd/QdeuFJgcbxzCVFOS/mLkP4o/ATjxt4+1eQsA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/combobox/3.6.0_react@18.2.0:
-    resolution: {integrity: sha512-tfZtZ12Kf2bKt3EcFKWcUxrLNc61Y1CGynsOQ/KvHTFwlLTTtKnt/wWuf4kxdqlTK7dDqJzWRGWKlWx6eKlx3w==}
+  /@react-types/progress/3.4.1_react@18.2.0:
+    resolution: {integrity: sha512-Y6cTvvJjbfFBeB7Zb3PizhhO3+YLWXpIP8opto15RWu11ktgZVMUgsnlsJgE3dFeoZ7UHwXdCYf8JOzBw5VPHA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/combobox/3.6.1_react@18.2.0:
-    resolution: {integrity: sha512-CydRYMc80d4Wi6HeXUhmVPrVUnvQm60WJUaX2hM71tkKFo9ZOM6oW02YuOicjkNr7gpM7PLUxvM4Poc9EvDQTw==}
+  /@react-types/radio/3.4.2_react@18.2.0:
+    resolution: {integrity: sha512-SE6sjZjZbyuJMJNNdlhoutVr+QFRt1Vz7DZj4UaOswW5SD/Xb+xFdW8i6ETKdRN17am/5SC89ltWe0R3q0pVkA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/datepicker/3.2.0_react@18.2.0:
-    resolution: {integrity: sha512-wcxLI6aW+r6nO2bsypxMIaWJHG5YYAD7WtJmhR5n5GK5juUCu/hzKBhdwxE1qtD3kMvIKTDJkMXLVNGmJP0mFw==}
+  /@react-types/searchfield/3.4.2_react@18.2.0:
+    resolution: {integrity: sha512-HQm++hIXVfEbjbRey6hYV/5hLEO6gtwt4Mft3u5I5BiT7yoQqQAD/8z9S8aUXDUU9KTrAKfL1DwrFQSkOsCWJA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
+      '@react-types/textfield': 3.7.2_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/datepicker/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-dKhkpG3UhdwYqdpVjg5dCQgMefpr7sa4a6Ep6fvbyD/q7gv9+h0/1J5F3FJynW+CBL6uYhcZjNev2vjYVTDbEg==}
+  /@react-types/select/3.8.1_react@18.2.0:
+    resolution: {integrity: sha512-ByVKKwgpE3d08jI+Ibuom/qphlBiDKpVMwXgFgVZRAN2YvVrsix8arSo7kmXtzekz91qqDBqtt7DBCfT0E1WKw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.2.0
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/dialog/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-QsHqAK8zE4QSCQTJcRm/e6vweSE8S62o4GGvm+e+crMro/doA4it1Y4udE94Yy3WyDQEMFxyfd2P1Q6bI9JuyQ==}
+  /@react-types/shared/3.18.1_react@18.2.0:
+    resolution: {integrity: sha512-OpTYRFS607Ctfd6Tmhyk6t6cbFyDhO5K+etU35X50pMzpypo1b7vF0mkngEeTc0Xwl0e749ONZNPZskMyu5k8w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/grid/3.1.6_react@18.2.0:
-    resolution: {integrity: sha512-j6dO5KgkuIbIhEZYSxd86ZomohCyv3VNQhY2qBHlRoxZs0976komauEOjOpMOu0PxwsFGUgUFqlKOtc34f1SHQ==}
+  /@react-types/slider/3.5.1_react@18.2.0:
+    resolution: {integrity: sha512-8+AMNexx7q7DqfAtQKC5tgnZdG/tIwG2tcEbFCfAQA09Djrt/xiMNz+mc7SsV1PWoWwVuSDFH9QqKPodOrJHDg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/grid/3.1.7_react@18.2.0:
-    resolution: {integrity: sha512-YKo/AbJrgWErPmr5y0K4o6Ts9ModFv5+2FVujecIydu3zLuHsVcx//6uVeHSy2W+uTV9vU/dpMP+GGgg+vWQhw==}
+  /@react-types/switch/3.3.2_react@18.2.0:
+    resolution: {integrity: sha512-L0XF4J43Q7HCAJXqseAk6RMteK6k1jQ0zrG05r6lSCkxaS9fGUlgLTCiFUsf07x0ADH1Xyc7PwpfJjyEr5A4tA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/checkbox': 3.4.4_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/label/3.7.2_react@18.2.0:
-    resolution: {integrity: sha512-UlsIvxQjBMl9WwJw1bYoJMwiPvYwRsSLl2yoeeGfGr6IaYn5T/2kzBhDLwe5cpKrmi4Mehn1rbReFLGITOy8+g==}
+  /@react-types/table/3.7.0_react@18.2.0:
+    resolution: {integrity: sha512-tUSJPdU2eNjH/CRHs5pOCKDyQxzq8b1rJZHldvRK/GCW+B98debFOueYgw4+YGQ1E33IyzAwid+FXgY3wlZlHg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/grid': 3.1.8_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/link/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-eImWLzxwzSmjOLa0Ow3HJaguyDCz98191v2pb7nT/zPzGDnhHhDjxB023hrXVUoCbsWrCb5QLp91Ts+VjiCyTA==}
+  /@react-types/tabs/3.3.0_react@18.2.0:
+    resolution: {integrity: sha512-uXDVXBBppb+9S8bhxF7LZhgptrF5ll25SX8/jrpnXOR0jpihq6K3fkSe5M/OBnGsybuyVGN7+Np5v7UUYrM5SQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/listbox/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-OvHaX4EBRHxKrfFItdJXjY7dYomzejqJ87P5fTL1l1TbDX8gvEP014S3cI+VLQq+EsXeTZ8E/sx0tFUo7ilchA==}
+  /@react-types/textfield/3.7.2_react@18.2.0:
+    resolution: {integrity: sha512-TsZTf1+4Ve9QHm6mbXr26uLOA4QtZPgyjYgYclL2nHoOl67algeQIFxIVfdlNIKFFMOw5BtC6Mer0I3KUWtbOQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
-  /@react-types/menu/3.8.0_react@18.2.0:
-    resolution: {integrity: sha512-1nwGUwKNHJf60vOsg7p48NPQIzMsSprxw8VXfStr8eE5uU4vvKfVNQNUgvpkRmHmel8BrYdh1WnERXJJ3yKUgQ==}
+  /@react-types/tooltip/3.4.2_react@18.2.0:
+    resolution: {integrity: sha512-jkuhT4KsU3ePfVrLeQv3Z2Vt0SwZmFNUoVIlK6Q1QR8H/TuWG+SDKjbwNLcCdeVfAXcJLbEfPDT2zyGeQTwNEA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/menu/3.9.0_react@18.2.0:
-    resolution: {integrity: sha512-aalUYwOkzcHn8X59vllgtH96YLqZvAr4mTj5GEs8chv5JVlmArUzcDiOymNrYZ0p9JzshzSUqxxXyCFpnnxghw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/meter/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-/IAHquSb+tC/YjcXdcYinFTb7puakkQWzNwS4lkhisIoZ0K0Ym/3fat/nzjgG9s2+sqQrW6f3Ndp9GCfSzvHLg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/progress': 3.3.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/numberfield/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-3kKkCFJ9cqCHuoz2BWy3DZLg6SQzqjzbO3DvNTrORd2k7bsI0Ydlfsz1rkCU53GStqovgopX4jo6EZLeRfv05Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/numberfield/3.4.1_react@18.2.0:
-    resolution: {integrity: sha512-iS+s2BgOWUxYnMt+LG1OxlKZWeggKMBs55/NzVF5I2MCe1ju8ZUgM27g9A/gvUTdjt+fqx6VZu0MCipw0rVkIQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/overlays/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-LstucncZ8dM+xJYEijI1V6jGH20w5XO/T60r7JTrgQElMC86phPeoWkMTN4c2lsRikybolDbvXL6XsF76YO56A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/overlays/3.7.1_react@18.2.0:
-    resolution: {integrity: sha512-2AwYQkelr4p1uXR1KJIGQEbubOumzM853Hsyup2y/TaMbjvBWOVyzYWSrQURex667JZmpwUb0qjkEH+4z3Q74g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/progress/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-k4xivWiEYogsROLyNqVDVjl33rm+X9RKNbKQXg5pqjGikaC8T9hmIwE4tJr26XkMIIvQS6duEBCcuQN/U1+dGQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/radio/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-klgEU+987xVUCRqBoxXJiPJvy0upfo76dFnK5eF7U7BzcxhuiFeLDUcqUHtK92Cy5QOiDAF2ML0vUYGIabKMPA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/radio/3.4.1_react@18.2.0:
-    resolution: {integrity: sha512-8r7s+Zj0JoIpYgbuHjhE/eWUHKiptaFvYXMH986yKAg969VQlQiP9Dm4oWv2d+p26WbGK7oJDQJCt8NjASWl8g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/searchfield/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-rYupNbyBAjycx6SXCALjINj/nOx7lIq9f4Dk1xo1dd8X6yYU0EF4WlahNua7UV8JC5oYlxN40G7yi4lAS+CdWQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/textfield': 3.7.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/searchfield/3.4.1_react@18.2.0:
-    resolution: {integrity: sha512-JmIwylx88IYrntfw7vAWCL1Ip5okJIRtC8Ne6mr2IjT4oGA9BRF5LpoPdEZlXfVPwLt7jlwGLUwKphbkds+yUA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      '@react-types/textfield': 3.7.1_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/select/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-BaynMuW0dQ9ModFzW291+3n1D9bwKSFh03g3+1PvhRcBg1EXq1vFyfFBj4uuBymI0T7oCbnjGh19xo0vKIYRrA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/select/3.8.0_react@18.2.0:
-    resolution: {integrity: sha512-hdaB3CzK8GSip9oGahfnlwolRqdNow85CQwf5P0oEtIDdijihrG6hyphPu5HYGK687EF+lfhnWUYUMwckEwB8Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/shared/3.17.0_react@18.2.0:
-    resolution: {integrity: sha512-1SNZ/RhVrrQ1e6yE0bPV7d5Sfp+Uv0dfUEhwF9MAu2v5msu7AMewnsiojKNA0QA6Ing1gpDLjHCxtayQfuxqcg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-    dev: false
-
-  /@react-types/shared/3.18.0_react@18.2.0:
-    resolution: {integrity: sha512-WJj7RAPj7NLdR/VzFObgvCju9NMDktWSruSPJ3DrL5qyrrvJoyMW67L4YjNoVp2b7Y+k10E0q4fSMV0PlJoL0w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-    dev: false
-
-  /@react-types/slider/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-Kj+B6njpm4ltiu3gCBOPRnbzllV21IVr0bCQdNnWcf5DX8aN4VdI8EFkTz0DSwMm2WPCwZop0MDWDoRwXJK1ng==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/slider/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-ri0jGWt1x/+nWLLJmlRKaS0xyAjTE1UtsobEYotKkQjzG93WrsEZrb0tLmDnXyEfWi3NXyrReQcORveyv4EQ5g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/switch/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-6h+s//PwWf7/WJQOZKT6k1vdOQCcvPmMZW333AqyxtZX8WV8Q0illgcLMYo5qxT3IWsjYNuPIqMCY+tRbSeA2Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/checkbox': 3.4.3_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/table/3.5.0_react@18.2.0:
-    resolution: {integrity: sha512-/Mvn1MQbdnk7i6ivam8kdIh2PKF9GD3A7KC8v1E4JNAgsbOzOkt5JC4PMc1EtAK2eppMEKTN+B84oHKMl1F8Hg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/grid': 3.1.7_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/table/3.6.0_react@18.2.0:
-    resolution: {integrity: sha512-jUp8yTWJuJlqpJY+EIEppgjFsZ3oj4y9zg1oUO+l1rqRWEqmAdoq42g3dTZHmnz9hQJkUeo34I1HGaB9kxNqvg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/grid': 3.1.7_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/tabs/3.2.0_react@18.2.0:
-    resolution: {integrity: sha512-rOQm+JDYcGV+HE/EQ23vr6J3tqvXjFiDA107rU7n4B4mNjJ46k5gOhPdGTosv6wr1+Tp7XD5XMaFfqk+O0/ZZw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/tabs/3.2.1_react@18.2.0:
-    resolution: {integrity: sha512-KgvhrYvISQUq540iuNc3bRvOCfLvaeqpB5VwDYR8amG1FVWHklCW8xx8Uz63SVkOvNtExYCrlw63M/OnjRUzOw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/textfield/3.7.0_react@18.2.0:
-    resolution: {integrity: sha512-4Rqld8VZG324hecw6bqGY2gta1gm5sDhO48nyChfdmjVlFHXLDKazAcrgP76uSmUI6tffUPj3eYxQyTp5uLhyQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/textfield/3.7.1_react@18.2.0:
-    resolution: {integrity: sha512-6V5+6/VgDbmgN61pyVct1VrXb2hqq7Y43BFQ+/ZhFDlVaMpC5xKWKgW/gPbGLLc27gax8t2Brt7VHJj+d+yrUw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/tooltip/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-TMaKkjYbysZbMnY8zjI2Djh8QMHvB8LoN9EjOZX++3ZsO74CeCeOoGARh6+4c0Bu5rg4BXhNyi+y1JL3jtUEBg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
-      react: 18.2.0
-    dev: false
-
-  /@react-types/tooltip/3.4.0_react@18.2.0:
-    resolution: {integrity: sha512-dvMwX377uJAMTuditfvwWed53YjV62XWMqW29Fave4xg3A807VVK3H1iEgwCIGA9ve2XHF8cJbqSHD635qU+tQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/overlays': 3.7.1_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-types/overlays': 3.8.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -3079,8 +2784,8 @@ packages:
       - supports-color
     dev: true
 
-  /@swc/helpers/0.4.14:
-    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
+  /@swc/helpers/0.5.1:
+    resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.5.0
     dev: false
@@ -7585,46 +7290,48 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /react-aria/3.23.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-fptvkglL/HiX/llx2QCCt4WUJzuj6SLoyUJzF50kOLnX+sz5QhWQ+6dCEN/d3TWCRaXudC1nREUu8MgoV+lg7g==}
+  /react-aria/3.26.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-G+dh25hEdDLfAGbKyahzasnyxXhd99y6xlMZjNtHoWB7wXod/9M3P3W6mdANvCEogxU28ATRdV1bv6A2JbuSYg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/breadcrumbs': 3.5.0_react@18.2.0
-      '@react-aria/button': 3.7.0_react@18.2.0
-      '@react-aria/calendar': 3.1.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/checkbox': 3.8.0_react@18.2.0
-      '@react-aria/combobox': 3.5.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/datepicker': 3.3.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/dialog': 3.5.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/dnd': 3.1.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/focus': 3.11.0_react@18.2.0
-      '@react-aria/gridlist': 3.2.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/i18n': 3.7.0_react@18.2.0
-      '@react-aria/interactions': 3.14.0_react@18.2.0
-      '@react-aria/label': 3.5.0_react@18.2.0
-      '@react-aria/link': 3.4.0_react@18.2.0
-      '@react-aria/listbox': 3.8.1_react@18.2.0
-      '@react-aria/menu': 3.8.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/meter': 3.4.0_react@18.2.0
-      '@react-aria/numberfield': 3.4.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/overlays': 3.13.0_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/progress': 3.4.0_react@18.2.0
-      '@react-aria/radio': 3.5.0_react@18.2.0
-      '@react-aria/searchfield': 3.5.0_react@18.2.0
-      '@react-aria/select': 3.9.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/selection': 3.13.1_react@18.2.0
-      '@react-aria/separator': 3.3.0_react@18.2.0
-      '@react-aria/slider': 3.3.0_react@18.2.0
-      '@react-aria/ssr': 3.5.0_react@18.2.0
-      '@react-aria/switch': 3.4.0_react@18.2.0
-      '@react-aria/table': 3.8.1_biqbaboplfbrettd7655fr4n2y
-      '@react-aria/tabs': 3.4.1_react@18.2.0
-      '@react-aria/textfield': 3.9.0_react@18.2.0
-      '@react-aria/tooltip': 3.4.0_react@18.2.0
-      '@react-aria/utils': 3.15.0_react@18.2.0
-      '@react-aria/visually-hidden': 3.7.0_react@18.2.0
+      '@react-aria/breadcrumbs': 3.5.3_react@18.2.0
+      '@react-aria/button': 3.8.0_react@18.2.0
+      '@react-aria/calendar': 3.4.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/checkbox': 3.9.2_react@18.2.0
+      '@react-aria/combobox': 3.6.2_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/datepicker': 3.5.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/dialog': 3.5.3_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/dnd': 3.3.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/focus': 3.13.0_react@18.2.0
+      '@react-aria/gridlist': 3.5.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/i18n': 3.8.0_react@18.2.0
+      '@react-aria/interactions': 3.16.0_react@18.2.0
+      '@react-aria/label': 3.6.0_react@18.2.0
+      '@react-aria/link': 3.5.2_react@18.2.0
+      '@react-aria/listbox': 3.10.0_react@18.2.0
+      '@react-aria/menu': 3.10.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/meter': 3.4.3_react@18.2.0
+      '@react-aria/numberfield': 3.6.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/overlays': 3.15.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/progress': 3.4.3_react@18.2.0
+      '@react-aria/radio': 3.6.2_react@18.2.0
+      '@react-aria/searchfield': 3.5.3_react@18.2.0
+      '@react-aria/select': 3.11.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/selection': 3.16.0_react@18.2.0
+      '@react-aria/separator': 3.3.3_react@18.2.0
+      '@react-aria/slider': 3.5.0_react@18.2.0
+      '@react-aria/ssr': 3.7.0_react@18.2.0
+      '@react-aria/switch': 3.5.2_react@18.2.0
+      '@react-aria/table': 3.10.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/tabs': 3.6.1_react@18.2.0
+      '@react-aria/tag': 3.1.0_biqbaboplfbrettd7655fr4n2y
+      '@react-aria/textfield': 3.10.0_react@18.2.0
+      '@react-aria/tooltip': 3.6.0_react@18.2.0
+      '@react-aria/utils': 3.18.0_react@18.2.0
+      '@react-aria/visually-hidden': 3.8.2_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -7647,10 +7354,6 @@ packages:
       '@babel/runtime': 7.19.4
       react: 18.2.0
     dev: true
-
-  /react-fast-compare/3.2.0:
-    resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
-    dev: false
 
   /react-hook-form/7.43.9_react@18.2.0:
     resolution: {integrity: sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==}
@@ -7699,20 +7402,6 @@ packages:
       vfile: 5.3.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /react-popper/2.3.0_r6q5zrenym2zg7je7hgi674bti:
-    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
-    peerDependencies:
-      '@popperjs/core': ^2.0.0
-      react: ^16.8.0 || ^17 || ^18
-      react-dom: ^16.8.0 || ^17 || ^18
-    dependencies:
-      '@popperjs/core': 2.11.6
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-fast-compare: 3.2.0
-      warning: 4.0.3
     dev: false
 
   /react-refresh/0.14.0:
@@ -7777,33 +7466,33 @@ packages:
       react-transition-group: 2.9.0_biqbaboplfbrettd7655fr4n2y
     dev: false
 
-  /react-stately/3.22.0_react@18.2.0:
-    resolution: {integrity: sha512-w5itlPtjfUpxy+195LxRbaCNaGN1NVfPHelhYXuoPoKNgUvmy54uKXvP1Ek1ETZ9e55BaXuMs83yXv94wIMdpQ==}
+  /react-stately/3.24.0_react@18.2.0:
+    resolution: {integrity: sha512-4jNCR7rQBqvV8aKxm8giUWms/Wxlo9MMLUDDKfg75LEiCaqLcnxSC99HsEVKSao3RI0JCCj2ihewh6grRW/AgQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/calendar': 3.2.0_react@18.2.0
-      '@react-stately/checkbox': 3.4.1_react@18.2.0
-      '@react-stately/collections': 3.7.0_react@18.2.0
-      '@react-stately/combobox': 3.5.0_react@18.2.0
-      '@react-stately/data': 3.9.1_react@18.2.0
-      '@react-stately/datepicker': 3.4.0_react@18.2.0
-      '@react-stately/dnd': 3.2.0_react@18.2.0
-      '@react-stately/list': 3.8.0_react@18.2.0
-      '@react-stately/menu': 3.5.1_react@18.2.0
-      '@react-stately/numberfield': 3.4.1_react@18.2.0
-      '@react-stately/overlays': 3.5.1_react@18.2.0
-      '@react-stately/radio': 3.8.0_react@18.2.0
-      '@react-stately/searchfield': 3.4.1_react@18.2.0
-      '@react-stately/select': 3.5.0_react@18.2.0
-      '@react-stately/selection': 3.13.0_react@18.2.0
-      '@react-stately/slider': 3.3.1_react@18.2.0
-      '@react-stately/table': 3.9.0_react@18.2.0
-      '@react-stately/tabs': 3.4.0_react@18.2.0
-      '@react-stately/toggle': 3.5.1_react@18.2.0
-      '@react-stately/tooltip': 3.4.0_react@18.2.0
-      '@react-stately/tree': 3.6.0_react@18.2.0
-      '@react-types/shared': 3.18.0_react@18.2.0
+      '@react-stately/calendar': 3.3.0_react@18.2.0
+      '@react-stately/checkbox': 3.4.3_react@18.2.0
+      '@react-stately/collections': 3.9.0_react@18.2.0
+      '@react-stately/combobox': 3.5.2_react@18.2.0
+      '@react-stately/data': 3.10.0_react@18.2.0
+      '@react-stately/datepicker': 3.5.0_react@18.2.0
+      '@react-stately/dnd': 3.2.2_react@18.2.0
+      '@react-stately/list': 3.9.0_react@18.2.0
+      '@react-stately/menu': 3.5.3_react@18.2.0
+      '@react-stately/numberfield': 3.5.0_react@18.2.0
+      '@react-stately/overlays': 3.6.0_react@18.2.0
+      '@react-stately/radio': 3.8.2_react@18.2.0
+      '@react-stately/searchfield': 3.4.3_react@18.2.0
+      '@react-stately/select': 3.5.2_react@18.2.0
+      '@react-stately/selection': 3.13.2_react@18.2.0
+      '@react-stately/slider': 3.4.0_react@18.2.0
+      '@react-stately/table': 3.10.0_react@18.2.0
+      '@react-stately/tabs': 3.5.0_react@18.2.0
+      '@react-stately/toggle': 3.6.0_react@18.2.0
+      '@react-stately/tooltip': 3.4.2_react@18.2.0
+      '@react-stately/tree': 3.7.0_react@18.2.0
+      '@react-types/shared': 3.18.1_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -8950,12 +8639,6 @@ packages:
     dependencies:
       makeerror: 1.0.12
     dev: true
-
-  /warning/4.0.3:
-    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
   /wcwidth/1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}

--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -11,9 +11,15 @@
  *       or custom theme are covered
 */
 :root {
-  --main-navigation-active: var(--aquarium-colors-primary-80);
-  --main-navigation-hover: var(--aquarium-colors-primary-60);
-  --interactive-elements-focus: var(--aquarium-colors-primary-60);
+  /* Vars for navigation elements match the colour for
+    DS links links in navigation elements don't need
+    a colour but should have a hover colour*/
+  --navigation-elements-active: var(--aquarium-colors-primary-80);
+  --navigation-elements-hover: var(--aquarium-colors-primary-80);
+
+  /*the var matches the colour the DS sets for focus
+    via .focus\ classes */
+  --interactive-elements-focus: var(--aquarium-colors-info-70);
 }
 
 /************************************************
@@ -21,23 +27,22 @@
  ************************************************
 */
 
-button:focus-visible {
-  outline: 2px solid var(--interactive-elements-focus) !important;
-  outline-offset: 2px !important;
-}
+/* When we're using Router Links (or a elements)*/
+/* we need to match the styles to DS Links */
+/* This is covered by the selector*/
+/* a:global(:not(.Aquarium-Button)*/
 
 a:global(:not(.Aquarium-Button)) {
   color: var(--text-link-color);
 }
 
-a:global(:not(.Aquarium-Button)):hover,
-a:global(:not(.Aquarium-Button)):focus {
-  color: var(--text-link-color-hover);
+a:global(:not(.Aquarium-Button)):focus-visible,
+a:global(:not(.Aquarium-Button)):hover {
+  text-decoration: underline;
 }
 
 a:not(.Aquarium-Button):focus-visible {
   outline-offset: 1px !important;
-  box-shadow: 0 0 3px 0 transparent;
   outline: 2px solid var(--interactive-elements-focus);
 }
 
@@ -75,14 +80,29 @@ a:not(.Aquarium-Button):focus-visible {
  ****************************************
 */
 
-:root input:focus-visible,
-:root select:focus-visible,
-:root textarea:focus-visible {
+/*DS sets focus on elements via a .focus\ class (we can't select that)*/
+/*and changes the border color for elements with border. This is not */
+/*enough to match accessibility requirements (only 1 px border with low*/
+/*color contrast) so we're creating an outline of 2px */
+:root input:focus,
+:root select:focus,
+:root textarea:focus {
+  outline: 2px solid var(--interactive-elements-focus) !important;
+  outline-offset: 0 !important;
+}
+
+/* DS sets focus on button with .focus-visible\ and not .focus */
+/* so we're using this selector. Since the styles sets an */
+/* outline, we're only adding a px more to it to create */
+/* the same outline as for other elements */
+:root button:focus-visible {
   outline: 1px solid var(--interactive-elements-focus) !important;
   outline-offset: 0 !important;
 }
 
-:root button:focus {
+/* This is needed to create the same outline like above */
+/* for buttons that are not part of the DS*/
+:root button:not(.Aquarium-Button):focus-visible {
   outline: 2px solid var(--interactive-elements-focus) !important;
   outline-offset: 0 !important;
 }
@@ -106,6 +126,13 @@ a:not(.Aquarium-Button):focus-visible {
 :root [role="tablist"] [role="tab"]:focus-visible {
   /* The default outline was overflowing to the container. */
   outline-offset: -2px !important;
+  background-color: var(--aquarium-colors-grey-0);
+}
+
+:root [role="tablist"] [role="tab"]:hover > *,
+:root [role="tablist"] [role="tab"]:focus > *,
+:root [role="tablist"] [role="tab"]:focus-visible > * {
+  color: var(--aquarium-colors-primary-80) !important;
 }
 
 :root [role="tablist"] [role="tab"][aria-selected="true"] {

--- a/coral/src/app/accessibility.module.css
+++ b/coral/src/app/accessibility.module.css
@@ -21,12 +21,6 @@
  ************************************************
 */
 
-/*make border-radius and focus styles consistent for buttons that*/
-/*are used instead of DS (e.g. submenu)*/
-button {
-  border-radius: 0.125rem !important;
-}
-
 button:focus-visible {
   outline: 2px solid var(--interactive-elements-focus) !important;
   outline-offset: 2px !important;
@@ -42,10 +36,9 @@ a:global(:not(.Aquarium-Button)):focus {
 }
 
 a:not(.Aquarium-Button):focus-visible {
-  outline-offset: 2px;
-  /*represents info-70*/
-  outline-color: var(--interactive-elements-focus);
-  box-shadow: 0 0 3px 0 #ddd;
+  outline-offset: 1px !important;
+  box-shadow: 0 0 3px 0 transparent;
+  outline: 2px solid var(--interactive-elements-focus);
 }
 
 /****************************************

--- a/coral/src/app/components/PreviewBanner.tsx
+++ b/coral/src/app/components/PreviewBanner.tsx
@@ -1,55 +1,29 @@
-import { Box, Icon, Typography } from "@aivenio/aquarium";
-import infoSign from "@aivenio/aquarium/dist/module/icons/infoSign";
-
-function Link({
-  text,
-  target,
-  isRemote,
-}: {
-  text: string;
-  target: string;
-  isRemote: boolean;
-}) {
-  const remoteAttrs = isRemote && {
-    target: "_blank",
-    rel: "noreferrer",
-  };
-  return (
-    <a href={target} {...remoteAttrs}>
-      <Typography color="primary-80" variant={"body-small"} htmlTag="span">
-        {text}
-      </Typography>
-    </a>
-  );
-}
+import { Alert, Box, Link, Typography } from "@aivenio/aquarium";
 
 function PreviewBanner({ linkTarget }: { linkTarget: string }) {
   return (
     <Box
-      component={"section"}
-      display={"flex"}
-      gap={"l1"}
-      backgroundColor={"info-5"}
-      padding={"l1"}
       marginBottom={"l1"}
+      component={"section"}
       aria-label={"Preview disclaimer"}
     >
-      <Typography.SmallText>
-        <Icon icon={infoSign} color={"info-50"} style={{ marginTop: "5px" }} />
-      </Typography.SmallText>
-      <Typography.SmallText>
-        You are viewing a preview of the redesigned user interface. You are one
-        of our early reviewers, and your{" "}
-        <Link
-          text={"feedback"}
-          target={
-            "https://github.com/aiven/klaw/issues/new?template=03_feature.md"
-          }
-          isRemote={true}
-        />{" "}
-        will help us improve the product. You can always go back to the{" "}
-        <Link text={"old interface"} target={linkTarget} isRemote={false} />.
-      </Typography.SmallText>
+      <Alert type={"information"}>
+        <Typography.Small>
+          You are viewing a preview of the redesigned user interface. You are
+          one of our early reviewers, and your{" "}
+          <Link
+            href={
+              "https://github.com/aiven/klaw/issues/new?template=03_feature.md"
+            }
+            target={"_blank"}
+            rel="noreferrer"
+          >
+            feedback
+          </Link>{" "}
+          will help us improve the product. You can always go back to the{" "}
+          <Link href={linkTarget}>old interface</Link>.
+        </Typography.Small>
+      </Alert>
     </Box>
   );
 }

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -13,9 +13,13 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
         id="input-1198-label"
       >
         <span
-          class="inline-flex items-center mb-2 typography-small-strong text-grey-60"
+          class="block mb-2"
         >
-          PasswordInput
+          <span
+            class="inline-flex items-center typography-small-strong text-grey-60"
+          >
+            PasswordInput
+          </span>
         </span>
         <span
           class="Aquarium-InputBase relative block"
@@ -35,7 +39,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
       </p>
     </div>
     <button
-      class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
+      class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-90 disabled:bg-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
       title="Submit"
       type="submit"
     />
@@ -56,9 +60,13 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
         id="input-27-label"
       >
         <span
-          class="inline-flex items-center mb-2 typography-small-strong text-grey-60"
+          class="block mb-2"
         >
-          TextInput
+          <span
+            class="inline-flex items-center typography-small-strong text-grey-60"
+          >
+            TextInput
+          </span>
         </span>
         <span
           class="Aquarium-InputBase relative block"
@@ -78,7 +86,7 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
       </p>
     </div>
     <button
-      class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
+      class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-90 disabled:bg-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
       title="Submit"
       type="submit"
     />

--- a/coral/src/app/components/__snapshots__/InternalLinkButton.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/InternalLinkButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`InternalLinkButton renders different styles based on selected Aquarium's Button props shows a primary button by default 1`] = `
 <div>
   <a
-    class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
+    class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-90 disabled:bg-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
     href="/test/url"
   >
     My nice link
@@ -14,7 +14,7 @@ exports[`InternalLinkButton renders different styles based on selected Aquarium'
 exports[`InternalLinkButton renders different styles based on selected Aquarium's Button props shows a secondary button based on props 1`] = `
 <div>
   <a
-    class="Aquarium-Button Aquarium-Button.Secondary text-grey-60 bg-white ring-1 ring-grey-30 ring-inset active:bg-grey-5 active:ring-grey-50 active:text-grey-80 focus-visible:ring-2 focus-visible:ring-grey-50 focus-visible:text-grey-80 hover:ring-grey-50 hover:text-grey-80 disabled:text-grey-30 disabled:bg-grey-0 disabled:ring-grey-20 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
+    class="Aquarium-Button Aquarium-Button.Secondary text-primary-80 bg-white ring-1 ring-primary-80 ring-inset active:bg-primary-5 active:ring-primary-90 active:text-primary-90 focus-visible:ring-2 focus-visible:ring-primary-90 focus-visible:text-primary-80 hover:bg-primary-5 hover:ring-primary-90 hover:text-primary-90 disabled:bg-white disabled:text-primary-40 disabled:ring-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
     href="/test/url"
   >
     My nice link

--- a/coral/src/app/components/documentation/DocumentationEditor.tsx
+++ b/coral/src/app/components/documentation/DocumentationEditor.tsx
@@ -3,6 +3,7 @@ import { a11yLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import {
   Box,
   Button,
+  Link,
   SegmentedControl,
   SegmentedControlGroup,
   Typography,
@@ -47,14 +48,11 @@ function DocumentationEditor({
 
   return (
     <Box.Flex flexDirection={"column"} rowGap={"3"}>
-      <Box.Flex
-        alignSelf={"start"}
-        component={"section"}
-        aria-label={"Switch between edit and preview mode"}
-      >
+      <Box.Flex component={"section"} alignSelf={"start"}>
         <SegmentedControlGroup
           onChange={(value: ViewMode) => setViewMode(value)}
           value={viewMode}
+          ariaLabel={"Switch between edit and preview mode"}
         >
           <SegmentedControl<ViewMode>
             aria-pressed={viewMode === "edit"}
@@ -118,7 +116,8 @@ function DocumentationEditor({
           <Box.Flex justifyContent={"end"}>
             <Typography.SmallStrong id={"editor-markdown-description"}>
               We are supporting markdown following the{" "}
-              <a href={"https://commonmark.org/help/"}>CommonMark</a> standard.
+              <Link href={"https://commonmark.org/help/"}>CommonMark</Link>{" "}
+              standard.
             </Typography.SmallStrong>
           </Box.Flex>
         </>

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -232,11 +232,7 @@ function AclApprovals() {
           isLoading={declineIsLoading}
         />
       )}
-      {errorMessage !== "" && (
-        <div role="alert">
-          <Alert type="error">{errorMessage}</Alert>
-        </div>
-      )}
+      {errorMessage !== "" && <Alert type="error">{errorMessage}</Alert>}
 
       <TableLayout
         filters={[

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.tsx
@@ -261,11 +261,7 @@ function ConnectorApprovals() {
           isLoading={declineIsLoading || approveIsLoading}
         />
       )}
-      {errorQuickActions && (
-        <div role="alert">
-          <Alert type="error">{errorQuickActions}</Alert>
-        </div>
-      )}
+      {errorQuickActions && <Alert type="error">{errorQuickActions}</Alert>}
       <TableLayout
         filters={[
           <EnvironmentFilter

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.tsx
@@ -260,11 +260,7 @@ function SchemaApprovals() {
           isLoading={declineIsLoading || approveIsLoading}
         />
       )}
-      {errorQuickActions && (
-        <div role="alert">
-          <Alert type="error">{errorQuickActions}</Alert>
-        </div>
-      )}
+      {errorQuickActions && <Alert type="error">{errorQuickActions}</Alert>}
       <TableLayout
         filters={[
           <EnvironmentFilter

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -272,9 +272,7 @@ function TopicApprovals() {
         />
       )}
       {errorQuickActions !== "" && (
-        <div role="alert">
-          <Alert type="error">{errorQuickActions}</Alert>
-        </div>
+        <Alert type="error">{errorQuickActions}</Alert>
       )}
       <TableLayout
         filters={[

--- a/coral/src/app/features/components/layouts/TableLayout.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.tsx
@@ -48,11 +48,9 @@ function TableLayout(props: TableLayoutProps) {
       </Box>
       {isLoading && <SkeletonTable />}
       {isErrorLoading && (
-        <div role={"alert"}>
-          <Alert type={"error"}>
-            {parseErrorMsg(errorMessage)}. Please try again later!
-          </Alert>
-        </div>
+        <Alert type={"error"}>
+          {parseErrorMsg(errorMessage)}. Please try again later!
+        </Alert>
       )}
       {!isLoading && !isErrorLoading && (
         <>

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
@@ -71,7 +71,7 @@ function ConnectorOverviewResourcesTabs({
   function renderTabContent() {
     if (isError) {
       return (
-        <Box marginBottom={"l1"} marginTop={"l2"} role="alert">
+        <Box marginBottom={"l1"} marginTop={"l2"}>
           <Alert type="error">
             There was an error trying to load the connector details:{" "}
             {parseErrorMsg(error)}.
@@ -93,7 +93,7 @@ function ConnectorOverviewResourcesTabs({
 
     if (!connectorOverview?.connectorExists) {
       return (
-        <Box marginBottom={"l1"} marginTop={"l2"} role="alert">
+        <Box marginBottom={"l1"} marginTop={"l2"}>
           <Alert type="warning">
             Connector {connectorName} does not exist.
           </Alert>

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
@@ -68,7 +68,7 @@ function ConnectorDocumentation() {
         <PageHeader title={"Edit documentation"} />
         <>
           {isError && (
-            <Box marginBottom={"l1"} role="alert">
+            <Box marginBottom={"l1"}>
               <Alert type="error">
                 The documentation could not be saved, there was an error: <br />
                 {parseErrorMsg(error)}
@@ -104,12 +104,10 @@ function ConnectorDocumentation() {
     return (
       <>
         <PageHeader title={"Documentation"} />
-        <Box role="alert">
-          <Alert type="error">
-            Something went wrong while trying to transform the documentation
-            into the right format.
-          </Alert>
-        </Box>
+        <Alert type="error">
+          Something went wrong while trying to transform the documentation into
+          the right format.
+        </Alert>
       </>
     );
   }

--- a/coral/src/app/features/connectors/details/settings/ConnectorSettings.tsx
+++ b/coral/src/app/features/connectors/details/settings/ConnectorSettings.tsx
@@ -96,7 +96,7 @@ function ConnectorSettings() {
 
       <PageHeader title={"Settings"} />
       {errorMessage && (
-        <Box role="alert" marginBottom={"l2"}>
+        <Box marginBottom={"l2"}>
           <Alert type="error">{errorMessage}</Alert>
         </Box>
       )}

--- a/coral/src/app/features/connectors/request/ConnectorEditRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorEditRequest.tsx
@@ -177,7 +177,7 @@ function ConnectorEditRequest() {
     <>
       <Box>
         {editIsError && (
-          <Box marginBottom={"l1"} role="alert">
+          <Box marginBottom={"l1"}>
             <Alert type="error">{parseErrorMsg(editError)}</Alert>
           </Box>
         )}

--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -75,7 +75,7 @@ function ConnectorRequest() {
     <>
       <Box>
         {connectorRequestMutation.isError && (
-          <Box marginBottom={"l1"} role="alert">
+          <Box marginBottom={"l1"}>
             <Alert type="error">
               {parseErrorMsg(connectorRequestMutation.error)}
             </Alert>

--- a/coral/src/app/features/requests/acls/AclRequests.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.tsx
@@ -165,11 +165,7 @@ function AclRequests() {
           isLoading={deleteIsLoading || dataIsRefetching}
         />
       )}
-      {errorMessage !== "" && (
-        <div role="alert">
-          <Alert type="error">{errorMessage}</Alert>
-        </div>
-      )}
+      {errorMessage !== "" && <Alert type="error">{errorMessage}</Alert>}
       <TableLayout
         filters={[
           <EnvironmentFilter

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.tsx
@@ -147,11 +147,7 @@ function ConnectorRequests() {
           cancel={closeModal}
         />
       )}
-      {errorQuickActions && (
-        <div role="alert">
-          <Alert type="error">{errorQuickActions}</Alert>
-        </div>
-      )}
+      {errorQuickActions && <Alert type="error">{errorQuickActions}</Alert>}
       <TableLayout
         filters={[
           <EnvironmentFilter

--- a/coral/src/app/features/requests/schemas/SchemaRequests.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.tsx
@@ -157,11 +157,7 @@ function SchemaRequests() {
           cancel={closeModal}
         />
       )}
-      {errorQuickActions && (
-        <div role="alert">
-          <Alert type="error">{errorQuickActions}</Alert>
-        </div>
-      )}
+      {errorQuickActions && <Alert type="error">{errorQuickActions}</Alert>}
       <TableLayout
         filters={[
           <EnvironmentFilter

--- a/coral/src/app/features/requests/topics/TopicRequests.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.tsx
@@ -147,11 +147,7 @@ function TopicRequests() {
           cancel={closeModal}
         />
       )}
-      {errorQuickActions && (
-        <div role="alert">
-          <Alert type="error">{errorQuickActions}</Alert>
-        </div>
-      )}
+      {errorQuickActions && <Alert type="error">{errorQuickActions}</Alert>}
       <TableLayout
         filters={[
           <EnvironmentFilter

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -115,7 +115,7 @@ const TopicConsumerForm = ({
   return (
     <>
       {isError && (
-        <Box marginBottom={"l1"} role="alert">
+        <Box marginBottom={"l1"}>
           <Alert type="error">{parseErrorMsg(error)}</Alert>
         </Box>
       )}

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -113,7 +113,7 @@ const TopicProducerForm = ({
   return (
     <>
       {isError && (
-        <Box marginBottom={"l1"} role="alert">
+        <Box marginBottom={"l1"}>
           <Alert type="error">{parseErrorMsg(error)}</Alert>
         </Box>
       )}

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -85,11 +85,9 @@ const PromotionBanner = ({
     <Banner image={illustration} layout="vertical" title={""}>
       <Spacing gap={"l1"}>
         {hasError && (
-          <div role="alert">
-            <Alert type="error">
-              {errorMessage.length > 0 ? errorMessage : "Unexpected error."}
-            </Alert>
-          </div>
+          <Alert type="error">
+            {errorMessage.length > 0 ? errorMessage : "Unexpected error."}
+          </Alert>
         )}
 
         <Box component={"p"} marginBottom={"l1"}>

--- a/coral/src/app/features/topics/details/components/TopicClaimBanner.tsx
+++ b/coral/src/app/features/topics/details/components/TopicClaimBanner.tsx
@@ -53,11 +53,7 @@ const TopicClaimBanner = ({
   return (
     <Banner image={illustration} layout="vertical" title={""}>
       <Spacing gap={"l1"}>
-        {isError && (
-          <div role="alert">
-            <Alert type="error">{errorMessage}</Alert>
-          </div>
-        )}
+        {isError && <Alert type="error">{errorMessage}</Alert>}
         <Box component={"p"} marginBottom={"l1"}>
           Your team is not the owner of this topic. Click below to create a
           claim request for this topic.

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -90,7 +90,7 @@ function TopicOverviewResourcesTabs({
   const renderTabContent = () => {
     if (isError) {
       return (
-        <Box marginBottom={"l1"} marginTop={"l2"} role="alert">
+        <Box marginBottom={"l1"} marginTop={"l2"}>
           <Alert type="error">
             There was an error trying to load the topic details:{" "}
             {parseErrorMsg(error)}.
@@ -112,7 +112,7 @@ function TopicOverviewResourcesTabs({
 
     if (!topicOverview?.topicExists) {
       return (
-        <Box marginBottom={"l1"} marginTop={"l2"} role="alert">
+        <Box marginBottom={"l1"} marginTop={"l2"}>
           <Alert type="warning">Topic {topicName} does not exist.</Alert>
         </Box>
       );

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
@@ -67,7 +67,7 @@ function TopicDocumentation() {
         <PageHeader title={"Edit documentation"} />
         <>
           {isError && (
-            <Box marginBottom={"l1"} role="alert">
+            <Box marginBottom={"l1"}>
               <Alert type="error">
                 The documentation could not be saved, there was an error: <br />
                 {parseErrorMsg(error)}
@@ -101,12 +101,10 @@ function TopicDocumentation() {
     return (
       <>
         <PageHeader title={"Documentation"} />
-        <Box role="alert">
-          <Alert type="error">
-            Something went wrong while trying to transform the documentation
-            into the right format.
-          </Alert>
-        </Box>
+        <Alert type="error">
+          Something went wrong while trying to transform the documentation into
+          the right format.
+        </Alert>
       </>
     );
   }

--- a/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
+++ b/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
                 </p>
               </div>
               <a
-                class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-70 disabled:bg-primary-5 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Primary text-white bg-primary-80 active:bg-primary-90 active:ring-0 focus-visible:ring-2 focus-visible:ring-primary-100 focus-visible:ring-inset hover:bg-primary-90 disabled:bg-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 px-4 icon-stroke-2"
                 href="/topic/aivendemotopic/request-promotion?sourceEnv=1&targetEnv=2"
               >
                 Promote
@@ -291,7 +291,7 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
               href="/topic/aivendemotopic/subscribe?env=1"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
@@ -335,7 +335,7 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
               href="/topic/aivendemotopic/subscriptions"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   class="typography-small-strong text-primary-80"
@@ -383,7 +383,7 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
               href="/topic/aivendemotopic/request-schema"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
@@ -427,7 +427,7 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
               href="/topic/aivendemotopic/schema"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   class="typography-small-strong text-primary-80"
@@ -685,7 +685,7 @@ exports[`TopicOverview without promotion banner renders correct DOM according to
               href="/topic/aivendemotopic/subscribe?env=1"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
@@ -729,7 +729,7 @@ exports[`TopicOverview without promotion banner renders correct DOM according to
               href="/topic/aivendemotopic/subscriptions"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   class="typography-small-strong text-primary-80"
@@ -777,7 +777,7 @@ exports[`TopicOverview without promotion banner renders correct DOM according to
               href="/topic/aivendemotopic/request-schema"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   style="display: flex; justify-content: center; align-items: center; flex-direction: row; gap: 8px;"
@@ -821,7 +821,7 @@ exports[`TopicOverview without promotion banner renders correct DOM according to
               href="/topic/aivendemotopic/schema"
             >
               <button
-                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-70 focus-visible:text-grey-90 hover:text-primary-70 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
+                class="Aquarium-Button Aquarium-Button.Ghost text-primary-80 active:text-primary-90 focus-visible:text-primary-90 hover:text-primary-90 disabled:text-primary-40 inline-block border-0 rounded-sm transition whitespace-nowrap focus:outline-none relative text-center typography-default-strong py-3 icon-stroke-2"
               >
                 <div
                   class="typography-small-strong text-primary-80"

--- a/coral/src/app/features/topics/details/settings/TopicSettings.tsx
+++ b/coral/src/app/features/topics/details/settings/TopicSettings.tsx
@@ -97,7 +97,7 @@ function TopicSettings() {
 
       <PageHeader title={"Settings"} />
       {errorMessage && (
-        <Box role="alert" marginBottom={"l2"}>
+        <Box marginBottom={"l2"}>
           <Alert type="error">{errorMessage}</Alert>
         </Box>
       )}

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -191,7 +191,7 @@ const TopicSubscriptions = () => {
         }}
       />
       {errorMessage !== "" && (
-        <Box role="alert" marginBottom={"l2"}>
+        <Box marginBottom={"l2"}>
           <Alert type="error">{errorMessage}</Alert>
         </Box>
       )}

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.tsx
@@ -239,6 +239,9 @@ const TopicSubscriptions = () => {
               }
             }}
             value={selectedSubs}
+            ariaLabel={
+              "Switch between user subscriptions, prefixed subscriptions and transactional subscriptions"
+            }
           >
             <SegmentedControl name="User subscriptions" value="aclInfoList">
               User subs.

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -199,7 +199,7 @@ function TopicEditRequest() {
         </Dialog>
       )}
       {editIsError && (
-        <Box marginBottom={"l1"} role="alert">
+        <Box marginBottom={"l1"}>
           <Alert type="error">{parseErrorMsg(editError)}</Alert>
         </Box>
       )}

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
@@ -187,7 +187,7 @@ function TopicPromotionRequest() {
         </Dialog>
       )}
       {promoteIsError && (
-        <Box marginBottom={"l1"} role="alert">
+        <Box marginBottom={"l1"}>
           <Alert type="error">{parseErrorMsg(promoteError)}</Alert>
         </Box>
       )}

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -107,7 +107,7 @@ function TopicRequest() {
       )}
       <Box>
         {isError && (
-          <Box marginBottom={"l1"} role="alert">
+          <Box marginBottom={"l1"}>
             <Alert type="error">{parseErrorMsg(error)}</Alert>
           </Box>
         )}

--- a/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
+++ b/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
@@ -11,7 +11,7 @@ import { useEffect, useRef } from "react";
 import { getTopicAdvancedConfigOptions } from "src/domain/topic/topic-api";
 import { TopicAdvancedConfigurationOptions } from "src/domain/topic/topic-types";
 import { Schema } from "src/app/features/topics/request/form-schemas/topic-request-form";
-import { BorderBox, Box, Flexbox, Typography } from "@aivenio/aquarium";
+import { BorderBox, Box, Flexbox, Link, Typography } from "@aivenio/aquarium";
 
 type Props = {
   name: "advancedConfiguration";
@@ -73,13 +73,13 @@ function AdvancedConfiguration({ name }: Props) {
       </Typography.Subheading>
       <Typography.Caption>
         For advanced topic-level configurations, refer to the official{" "}
-        <a
+        <Link
           href="https://kafka.apache.org/documentation/#topicconfigs"
           target="_blank"
           rel="noreferrer"
         >
           Apache Kafka Documentation
-        </a>
+        </Link>
         .
       </Typography.Caption>
       <BorderBox borderColor="grey-20">

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -143,7 +143,7 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
       )}
       <Box>
         {schemaRequestMutation.isError && (
-          <Box marginBottom={"l1"} role="alert">
+          <Box marginBottom={"l1"}>
             <Alert type="error">
               {parseErrorMsg(schemaRequestMutation.error)}
             </Alert>

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
@@ -4,6 +4,7 @@
 
 .mainNavigationLink a {
   color: var(--body-text-color) !important;
+  display: block;
 }
 
 .mainNavigationLink a:hover,
@@ -12,8 +13,11 @@
 }
 
 .mainNavigationLinkActive a {
+  display: block;
   color: var(--main-navigation-active) !important;
 }
+
 .mainNavigationLinkActive {
   background-color: white !important;
 }
+

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
@@ -8,8 +8,10 @@
 }
 
 .mainNavigationLink a:hover,
+.mainNavigationLink a:focus-visible,
 .mainNavigationLink:focus-within {
   color: var(--main-navigation-hover) !important;
+  text-decoration: none;
 }
 
 .mainNavigationLinkActive a {

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
@@ -10,13 +10,18 @@
 .mainNavigationLink a:hover,
 .mainNavigationLink a:focus-visible,
 .mainNavigationLink:focus-within {
-  color: var(--main-navigation-hover) !important;
-  text-decoration: none;
+  color: var(--navigation-elements-hover) !important;
+}
+
+.mainNavigationLink a:hover,
+.mainNavigationLink a:focus-visible,
+.mainNavigationLink:focus-within,
+.mainNavigationLinkActive a {
+  text-decoration: none !important;
 }
 
 .mainNavigationLinkActive a {
   display: block;
-  color: var(--main-navigation-active) !important;
 }
 
 .mainNavigationLinkActive {

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.module.css
@@ -20,4 +20,3 @@
 .mainNavigationLinkActive {
   background-color: white !important;
 }
-

--- a/coral/src/app/layout/main-navigation/MainNavigationLink.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationLink.tsx
@@ -1,8 +1,8 @@
-import { Box, Icon } from "@aivenio/aquarium";
+import { Box, Icon, Link } from "@aivenio/aquarium";
 import data from "@aivenio/aquarium/dist/src/icons/console";
 import classes from "src/app/layout/main-navigation/MainNavigationLink.module.css";
 import { Routes } from "src/app/router_utils";
-import { Link } from "react-router-dom";
+import { Link as RouterLink } from "react-router-dom";
 
 function LinkContent({
   linkText,
@@ -52,13 +52,13 @@ function MainNavigationLink(props: MainNavigationLinkProps) {
       paddingBottom={"3"}
     >
       {isRouterLink() ? (
-        <Link to={to} aria-current={active && "page"}>
+        <RouterLink to={to} aria-current={active && "page"}>
+          <LinkContent icon={icon} linkText={linkText} />
+        </RouterLink>
+      ) : (
+        <Link href={to} aria-current={active && "page"}>
           <LinkContent icon={icon} linkText={linkText} />
         </Link>
-      ) : (
-        <a href={to} aria-current={active && "page"}>
-          <LinkContent icon={icon} linkText={linkText} />
-        </a>
       )}
     </Box>
   );

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.module.css
@@ -4,5 +4,5 @@
 /*temp class until we have a solution for that*/
 .mainNavigationSubmenuButton:hover,
 .mainNavigationSubmenuButton:focus-within {
-  color: var(--main-navigation-hover);
+  color: var(--navigation-elements-hover);
 }

--- a/coral/src/app/layout/skip-link/SkipLink.module.css
+++ b/coral/src/app/layout/skip-link/SkipLink.module.css
@@ -20,7 +20,7 @@
   top: 0;
   left: calc(50% - 100px);
   cursor: default;
-  color: #e41a4a;
+  color: var(--interactive-elements-focus);
   background-color: white;
   font-size: 16px;
   width: 200px;

--- a/coral/src/app/main.module.css
+++ b/coral/src/app/main.module.css
@@ -27,15 +27,15 @@ body {
   --aquarium-colors-primary-100: #0788d1;
   --aquarium-colors-primary-90: #0788d1;
   --aquarium-colors-primary-80: #0788d1;
-  --aquarium-colors-primary-70: #0399e3;
-  --aquarium-colors-primary-60: #02a8f3;
-  --aquarium-colors-primary-50: #28b4f4;
-  --aquarium-colors-primary-40: #4cc2f7;
-  --aquarium-colors-primary-30: #7fd1f7;
-  --aquarium-colors-primary-20: #b4e5fb;
-  --aquarium-colors-primary-10: #e0f5fe;
-  --aquarium-colors-primary-5: #eff0fa;
-  --aquarium-colors-primary-0: #5c6bc0;
+  --aquarium-colors-primary-70: #139fe4;
+  --aquarium-colors-primary-60: #3cb7f4;
+  --aquarium-colors-primary-50: #80cff9;
+  --aquarium-colors-primary-40: #bce5fb;
+  --aquarium-colors-primary-30: #ccebfc;
+  --aquarium-colors-primary-20: #dbf1fd;
+  --aquarium-colors-primary-10: #eaf7fe;
+  --aquarium-colors-primary-5: #f9fdff;
+  --aquarium-colors-primary-0: #f9fdff;
 
   /* --headline-text-color represents the value for
      --aquarium-colors-grey-100. We need to set this

--- a/coral/src/app/pages/not-found/index.tsx
+++ b/coral/src/app/pages/not-found/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@aivenio/aquarium";
+import { Box, Link, Typography } from "@aivenio/aquarium";
 
 const NotFound = () => {
   return (
@@ -13,7 +13,7 @@ const NotFound = () => {
         </Typography.LargeText>
 
         <Typography.MediumText>
-          <a href={"/index"}>Return to the old interface.</a>
+          <Link href={"/index"}>Return to the old interface.</Link>
         </Typography.MediumText>
       </Box>
     </>


### PR DESCRIPTION
## About this change - What it does

Update `aquarium` to version `1.33.0`. This update brings many improvement and one regression (see below). The improvements:
- `Alert` now correctly has an `alert` role when `type` is `error`. This allows us to remove all the wrappers we had to address this shortcoming: 7aaab286af001f85e76e75fd75b9f648aa6e1277
- `Link` now has better styles (underline on hover), which allows us to use it instead of styled `a` tags: cb2f479d1b1beb58f9e779ef74049fdd799766c0
- the two above elements allows a refactoring of `PreviewBanner` to be a little less custom and complex: 6807076b604a46f17d4821ea7922e4d1c757d778
- `SegmentControlGroup` now can get an `ariaLabel` prop, allowing some refactoring: a942245a301775863d6562479ba71fb3760c1c3e

Slight change to the typography of `PageHeader` to be noted:

- before:
<img width="1502" alt="Screenshot 2023-07-31 at 15 39 37" src="https://github.com/Aiven-Open/klaw/assets/20607294/d66d3148-a59b-4670-9eaf-d5afc4c22915">

- after:
<img width="1253" alt="Screenshot 2023-07-31 at 15 39 25" src="https://github.com/Aiven-Open/klaw/assets/20607294/29f611d5-8751-4122-9792-39aa63b1c625">



## BLOCKING: issues to be addressed

`disabled` buttons now use `--aquarium-colors-primary-40` as a color. This results in unclear disabled state for all our buttons. Most notably:

- `disabled` `Button.Primary`:
<img width="1235" alt="Screenshot 2023-07-31 at 15 25 04" src="https://github.com/Aiven-Open/klaw/assets/20607294/bd2927e3-d540-44b6-b402-8523eba3a297">

- the `DataTable` disabled `action` columns:
<img width="1179" alt="Screenshot 2023-07-31 at 14 49 16" src="https://github.com/Aiven-Open/klaw/assets/20607294/a8ff9ec6-34cc-4ded-a2f8-23c069c0b499">

This probably requires a revision of our custom theme.

## Follwoup changes enabled by this update

- many inputs now have ` description` prop, enabling us to proceed with this issue: https://github.com/Aiven-Open/klaw/issues/480