### PR TITLE
Issue only show new users request notifications with correct permissions

### DIFF
--- a/core/src/main/resources/static/index.html
+++ b/core/src/main/resources/static/index.html
@@ -160,7 +160,7 @@
 
                                             </div>
                                         </a>
-                                        <a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+                                        <a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
                                             <div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
                                             </div>
                                             <div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/activityLog.html
+++ b/core/src/main/resources/templates/activityLog.html
@@ -152,7 +152,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addCluster.html
+++ b/core/src/main/resources/templates/addCluster.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addEnv.html
+++ b/core/src/main/resources/templates/addEnv.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addKafkaConnectEnv.html
+++ b/core/src/main/resources/templates/addKafkaConnectEnv.html
@@ -153,7 +153,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addRole.html
+++ b/core/src/main/resources/templates/addRole.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addSchemaEnv.html
+++ b/core/src/main/resources/templates/addSchemaEnv.html
@@ -153,7 +153,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addTeam.html
+++ b/core/src/main/resources/templates/addTeam.html
@@ -155,7 +155,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addTenant.html
+++ b/core/src/main/resources/templates/addTenant.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addUser.html
+++ b/core/src/main/resources/templates/addUser.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/addUserLdap.html
+++ b/core/src/main/resources/templates/addUserLdap.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/analytics.html
+++ b/core/src/main/resources/templates/analytics.html
@@ -160,7 +160,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -148,7 +148,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/browseTopics.html
+++ b/core/src/main/resources/templates/browseTopics.html
@@ -176,7 +176,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/changePwd.html
+++ b/core/src/main/resources/templates/changePwd.html
@@ -157,7 +157,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/clusters.html
+++ b/core/src/main/resources/templates/clusters.html
@@ -164,7 +164,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/connectorOverview.html
+++ b/core/src/main/resources/templates/connectorOverview.html
@@ -148,7 +148,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/editTopicRequest.html
+++ b/core/src/main/resources/templates/editTopicRequest.html
@@ -151,7 +151,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/envs.html
+++ b/core/src/main/resources/templates/envs.html
@@ -155,7 +155,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/execAcls.html
+++ b/core/src/main/resources/templates/execAcls.html
@@ -153,7 +153,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/execConnectors.html
+++ b/core/src/main/resources/templates/execConnectors.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/execRegisteredUsers.html
+++ b/core/src/main/resources/templates/execRegisteredUsers.html
@@ -153,7 +153,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/execSchemas.html
+++ b/core/src/main/resources/templates/execSchemas.html
@@ -153,7 +153,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/execTopics.html
+++ b/core/src/main/resources/templates/execTopics.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/helpwizard.html
+++ b/core/src/main/resources/templates/helpwizard.html
@@ -155,7 +155,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/index.html
+++ b/core/src/main/resources/templates/index.html
@@ -160,7 +160,7 @@
 
                                             </div>
                                         </a>
-                                        <a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+                                        <a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
                                             <div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
                                             </div>
                                             <div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/kafkaConnectors.html
+++ b/core/src/main/resources/templates/kafkaConnectors.html
@@ -176,7 +176,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/kwmetrics.html
+++ b/core/src/main/resources/templates/kwmetrics.html
@@ -160,7 +160,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/manageConnectors.html
+++ b/core/src/main/resources/templates/manageConnectors.html
@@ -177,7 +177,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/modifyCluster.html
+++ b/core/src/main/resources/templates/modifyCluster.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/modifyEnv.html
+++ b/core/src/main/resources/templates/modifyEnv.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/modifyTeam.html
+++ b/core/src/main/resources/templates/modifyTeam.html
@@ -155,7 +155,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/modifyUser.html
+++ b/core/src/main/resources/templates/modifyUser.html
@@ -154,7 +154,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/monitorEnvs.html
+++ b/core/src/main/resources/templates/monitorEnvs.html
@@ -151,7 +151,7 @@
 
                                             </div>
                                         </a>
-                                        <a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+                                        <a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
                                             <div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
                                             </div>
                                             <div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/myAclRequests.html
+++ b/core/src/main/resources/templates/myAclRequests.html
@@ -153,7 +153,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/myConnectorRequests.html
+++ b/core/src/main/resources/templates/myConnectorRequests.html
@@ -149,7 +149,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/myProfile.html
+++ b/core/src/main/resources/templates/myProfile.html
@@ -158,7 +158,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/mySchemaRequests.html
+++ b/core/src/main/resources/templates/mySchemaRequests.html
@@ -149,7 +149,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/myTopicRequests.html
+++ b/core/src/main/resources/templates/myTopicRequests.html
@@ -149,7 +149,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/permissions.html
+++ b/core/src/main/resources/templates/permissions.html
@@ -149,7 +149,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/requestAcls.html
+++ b/core/src/main/resources/templates/requestAcls.html
@@ -151,7 +151,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/requestConnector.html
+++ b/core/src/main/resources/templates/requestConnector.html
@@ -151,7 +151,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/requestSchema.html
+++ b/core/src/main/resources/templates/requestSchema.html
@@ -151,7 +151,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/requestTopics.html
+++ b/core/src/main/resources/templates/requestTopics.html
@@ -151,7 +151,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/roles.html
+++ b/core/src/main/resources/templates/roles.html
@@ -149,7 +149,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/serverConfig.html
+++ b/core/src/main/resources/templates/serverConfig.html
@@ -151,7 +151,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/showTeams.html
+++ b/core/src/main/resources/templates/showTeams.html
@@ -157,7 +157,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/showUsers.html
+++ b/core/src/main/resources/templates/showUsers.html
@@ -149,7 +149,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/syncBackAcls.html
+++ b/core/src/main/resources/templates/syncBackAcls.html
@@ -180,7 +180,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/syncBackSchemas.html
+++ b/core/src/main/resources/templates/syncBackSchemas.html
@@ -180,7 +180,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/syncBackTopics.html
+++ b/core/src/main/resources/templates/syncBackTopics.html
@@ -180,7 +180,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/synchronizeAcls.html
+++ b/core/src/main/resources/templates/synchronizeAcls.html
@@ -177,7 +177,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/synchronizeConnectors.html
+++ b/core/src/main/resources/templates/synchronizeConnectors.html
@@ -177,7 +177,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/synchronizeSchemas.html
+++ b/core/src/main/resources/templates/synchronizeSchemas.html
@@ -176,7 +176,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/synchronizeTopics.html
+++ b/core/src/main/resources/templates/synchronizeTopics.html
@@ -176,7 +176,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/tenantInfo.html
+++ b/core/src/main/resources/templates/tenantInfo.html
@@ -158,7 +158,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">

--- a/core/src/main/resources/templates/tenants.html
+++ b/core/src/main/resources/templates/tenants.html
@@ -149,7 +149,7 @@
 
 											</div>
 										</a>
-										<a href="execUsers" class="border-bottom d-block text-decoration-none py-2 px-3">
+										<a href="execUsers" ng-show="dashboardDetails.addUser=='Authorized'" class="border-bottom d-block text-decoration-none py-2 px-3">
 											<div class="btn btn-primary btn-circle mr-2"><i class="ti-link"></i>
 											</div>
 											<div class="mail-contnet d-inline-block align-middle">


### PR DESCRIPTION
About this change - What it does
Only show the drop down for new user notifications if the correct permission to be able to view the page is assigned to the user.
Resolves: #xxxxx
Why this way
Better user experience.