### PR TITLE
Find the first available team rather than all and then pick only the first one

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1050,12 +1050,7 @@ public class SelectDataJdbc {
   }
 
   public Team selectTeamDetailsFromName(String teamName, int tenantId) {
-    List<Team> teamList = teamRepo.findAllByTenantIdAndTeamname(tenantId, teamName);
-    if (!teamList.isEmpty()) {
-      return teamList.get(0);
-    } else {
-      return null;
-    }
+    return teamRepo.findFirstByTenantIdAndTeamnameOrderByTenantId(tenantId, teamName);
   }
 
   public List<Map<String, String>> selectActivityLogByTeam(

--- a/core/src/main/java/io/aiven/klaw/repository/TeamRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TeamRepo.java
@@ -23,4 +23,6 @@ public interface TeamRepo extends CrudRepository<Team, TeamID> {
 
   @Query(value = "select max(teamid) from kwteams where tenantid = :tenantId", nativeQuery = true)
   Integer getNextTeamId(@Param("tenantId") Integer tenantId);
+
+  Team findFirstByTenantIdAndTeamnameOrderByTenantId(int tenantId, String teamName);
 }


### PR DESCRIPTION
The problem with current `io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc#selectTeamDetailsFromName` is that it requests for **ALL** teams for the specified tenant and and name and then takes only the first one.

The improvement is to select only the first one on DB level to minimize amount of data transferred between the app and DB