### PR TITLE
Use map for props to speed up checking for existence of properties

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/ServerConfigController.java
@@ -7,6 +7,7 @@ import io.aiven.klaw.model.ServerConfigProperties;
 import io.aiven.klaw.model.response.ConnectivityStatus;
 import io.aiven.klaw.model.response.KwPropertiesResponse;
 import io.aiven.klaw.service.ServerConfigService;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +31,7 @@ public class ServerConfigController {
       value = "/getAllServerConfig",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<List<ServerConfigProperties>> getAllProperties() {
+  public ResponseEntity<Collection<ServerConfigProperties>> getAllProperties() {
     return new ResponseEntity<>(serverConfigService.getAllProps(), HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/model/ServerConfigProperties.java
+++ b/core/src/main/java/io/aiven/klaw/model/ServerConfigProperties.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.model;
 
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,4 +13,20 @@ public class ServerConfigProperties {
   private String key;
 
   private String value;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ServerConfigProperties that)) return false;
+
+    if (!Objects.equals(id, that.id)) return false;
+    return Objects.equals(key, that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (key != null ? key.hashCode() : 0);
+    return result;
+  }
 }

--- a/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
@@ -26,6 +26,7 @@ import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.response.KwPropertiesResponse;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,8 +79,8 @@ public class ServerConfigServiceTest {
   public void getAllPropsNotAuthorized() {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
     serverConfigService.getAllProperties();
-    List<ServerConfigProperties> list = serverConfigService.getAllProps();
-    assertThat(list).isEmpty(); // filtering for spring. and klaw.
+    Collection<ServerConfigProperties> collection = serverConfigService.getAllProps();
+    assertThat(collection).isEmpty(); // filtering for spring. and klaw.
   }
 
   @Test
@@ -87,8 +88,8 @@ public class ServerConfigServiceTest {
   public void getAllProps() {
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     serverConfigService.getAllProperties();
-    List<ServerConfigProperties> list = serverConfigService.getAllProps();
-    assertThat(list).isEmpty(); // filtering for spring. and klaw.
+    Collection<ServerConfigProperties> collection = serverConfigService.getAllProps();
+    assertThat(collection).isEmpty(); // filtering for spring. and klaw.
   }
 
   private void loginMock() {


### PR DESCRIPTION
The issue with `io.aiven.klaw.service.ServerConfigService` is that it keeps properties in a property list.
As a result to answer a question whether it contains a property with a specific key or not it should go through all properties inside that list (worst case) that means O(N) complexity.
The  obvious solution is to use `map (key, property)` then it will require to check only existence of a corresponding key and the complexity will be O(1)