### PR TITLE
Speed up insertIntoTopicSOT

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/InsertDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/InsertDataJdbc.java
@@ -173,7 +173,7 @@ public class InsertDataJdbc {
         .forEach(existingTopicIds::add);
 
     for (Topic topic : existingTopicIds) {
-      log.info("insertIntoTopicSOT {}", topic.getTopicname());
+      log.debug("insertIntoTopicSOT {}", topic.getTopicname());
       topic.setTopicid(getNextTopicRequestId("TOPIC_ID", topic.getTenantId()));
       topicRepo.save(topic);
     }
@@ -181,7 +181,7 @@ public class InsertDataJdbc {
       if (existingTopicIds.contains(topic)) {
         continue;
       }
-      log.info("insertIntoTopicSOT {}", topic.getTopicname());
+      log.debug("insertIntoTopicSOT {}", topic.getTopicname());
       topicRepo.save(topic);
     }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/InsertDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/InsertDataJdbc.java
@@ -7,9 +7,12 @@ import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.repository.*;
 import java.sql.Timestamp;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -160,20 +163,27 @@ public class InsertDataJdbc {
   }
 
   public synchronized String insertIntoTopicSOT(List<Topic> topics) {
-    topics.forEach(
-        topic -> {
-          log.debug("insertIntoTopicSOT {}", topic.getTopicname());
-          if (!topic.isExistingTopic()) {
-            TopicID topicID = new TopicID();
-            topicID.setTenantId(topic.getTenantId());
-            topicID.setTopicid(topic.getTopicid());
+    Set<Topic> existingTopicIds = new HashSet<>();
+    topicRepo
+        .findAllById(
+            topics.stream()
+                .filter(t -> !t.isExistingTopic())
+                .map(t -> new TopicID(t.getTopicid(), t.getTenantId()))
+                .collect(Collectors.toList()))
+        .forEach(existingTopicIds::add);
 
-            if (topicRepo.existsById(topicID)) {
-              topic.setTopicid(getNextTopicRequestId("TOPIC_ID", topic.getTenantId()));
-            }
-          }
-          topicRepo.save(topic);
-        });
+    for (Topic topic : existingTopicIds) {
+      log.info("insertIntoTopicSOT {}", topic.getTopicname());
+      topic.setTopicid(getNextTopicRequestId("TOPIC_ID", topic.getTenantId()));
+      topicRepo.save(topic);
+    }
+    for (Topic topic : topics) {
+      if (existingTopicIds.contains(topic)) {
+        continue;
+      }
+      log.info("insertIntoTopicSOT {}", topic.getTopicname());
+      topicRepo.save(topic);
+    }
 
     return ApiResultStatus.SUCCESS.value;
   }


### PR DESCRIPTION
The idea is pretty straightforward.
The problem is that for every topic (almost every) it invokes `topicRepo#existsById` which is under the hood is a call to DB. That means it is a heavy call. 
The idea is to minimize a number of calls to DB by replacement of multiple calls `topicRepo#existsById` by just one `findAllById` and then processing separately  `existingTopicIds` and others