### PR TITLE
Invoke queries for finding all components in lazy mode

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -428,6 +428,8 @@ public interface HandleDbRequests {
 
   int getAllComponentsCountForTeam(Integer teamId, int tenantId);
 
+  boolean existsComponentsCountForTeam(Integer teamId, int tenantId);
+
   int getAllTopicsCountInAllTenants();
 
   int getAllComponentsCountForUser(String userName, int tenantId);

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -977,6 +977,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public boolean existsComponentsCountForTeam(Integer teamId, int tenantId) {
+    return jdbcSelectHelper.existsComponentsCountForTeam(teamId, tenantId);
+  }
+
+  @Override
   public int getAllComponentsCountForUser(String userId, int tenantId) {
     return jdbcSelectHelper.findAllComponentsCountForUser(userId, tenantId);
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1473,78 +1474,91 @@ public class SelectDataJdbc {
         + ((Long) messageSchemaRepo.findAllSchemaCountForEnv(env, tenantId).get(0)[0]).intValue();
   }
 
-  public int findAllComponentsCountForTeam(Integer teamId, int tenantId) {
+  public boolean existsComponentsCountForTeam(Integer teamId, int tenantId) {
+    return calculateComponentsCountForTeam(teamId, tenantId, true) > 0;
+  }
 
-    if (log.isDebugEnabled()) {
-      int schemaRequestsRepoCount =
-          ((Long) schemaRequestRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-              .intValue();
-      int messageSchemaRepoCount =
-          ((Long) messageSchemaRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-              .intValue();
-      int kafkaConnectorRepoCount =
-          ((Long) kafkaConnectorRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-              .intValue();
-      int kafkaConnectorRequestsRepoCount =
-          ((Long)
-                  kafkaConnectorRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId)
-                      .get(0)[0])
-              .intValue();
-      int topicRepoCount =
-          ((Long) topicRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0]).intValue();
-      int topicRequestsRepoCount =
-          ((Long) topicRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-              .intValue();
-      int aclRepoCount =
-          ((Long) aclRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0]).intValue();
-      int aclRequestRepoCount =
-          ((Long) aclRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-              .intValue();
-      log.debug(
-          "For team {} Active Schema Requests {}, number of Schemas in DB {}",
-          teamId,
-          schemaRequestsRepoCount,
-          messageSchemaRepoCount);
-      log.debug(
-          "For team {} Active Connector Requests {}, number of Connector in DB {}",
-          teamId,
-          kafkaConnectorRepoCount,
-          kafkaConnectorRequestsRepoCount);
-      log.debug(
-          "For team {} Active Topic Requests {}, number of Topic in DB {}",
-          teamId,
-          topicRepoCount,
-          topicRequestsRepoCount);
-      log.debug(
-          "For team {} Active ACL Requests {}, number of ACL in DB {}",
-          teamId,
-          aclRepoCount,
-          aclRequestRepoCount);
-      // return here instead of doing a second search
-      return schemaRequestsRepoCount
-          + messageSchemaRepoCount
-          + kafkaConnectorRepoCount
-          + kafkaConnectorRequestsRepoCount
-          + topicRepoCount
-          + topicRequestsRepoCount
-          + aclRepoCount
-          + aclRequestRepoCount;
+  public int calculateComponentsCountForTeam(Integer teamId, int tenantId, boolean existsOnly) {
+    List<Supplier<Integer>> list =
+        List.of(
+            () -> {
+              int res =
+                  ((Long)
+                          schemaRequestRepo.findAllRecordsCountForTeamId(teamId, tenantId)
+                              .get(0)[0])
+                      .intValue();
+              log.debug("For team {} Active Schema Requests {}", teamId, res);
+              return res;
+            },
+            () -> {
+              int res =
+                  ((Long)
+                          messageSchemaRepo.findAllRecordsCountForTeamId(teamId, tenantId)
+                              .get(0)[0])
+                      .intValue();
+              log.debug("For team {} number of Schemas in DB {}", teamId, res);
+              return res;
+            },
+            () -> {
+              int res =
+                  ((Long)
+                          kafkaConnectorRepo.findAllRecordsCountForTeamId(teamId, tenantId)
+                              .get(0)[0])
+                      .intValue();
+              log.debug("For team {} Active Connector Requests {}", teamId, res);
+              return res;
+            },
+            () -> {
+              int res =
+                  ((Long)
+                          kafkaConnectorRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId)
+                              .get(0)[0])
+                      .intValue();
+              log.debug("For team {} number of Connector in DB {}", teamId, res);
+              return res;
+            },
+            () -> {
+              int res =
+                  ((Long) topicRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+                      .intValue();
+              log.debug("For team {} Active Topic Requests {}", teamId, res);
+              return res;
+            },
+            () -> {
+              int res =
+                  ((Long)
+                          topicRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId)
+                              .get(0)[0])
+                      .intValue();
+              log.debug("For team {} number of Topic in DB {}", teamId, res);
+              return res;
+            },
+            () -> {
+              int res =
+                  ((Long) aclRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+                      .intValue();
+              log.debug("For team {} Active ACL Requests {}", teamId, res);
+              return res;
+            },
+            () -> {
+              int res =
+                  ((Long) aclRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
+                      .intValue();
+              log.debug("For team {} number of ACL in DB {}", teamId, res);
+              return res;
+            });
+    int res = 0;
+    for (var elem : list) {
+      res += elem.get();
+      if (existsOnly && res > 0) {
+        return res;
+      }
     }
-    return ((Long) schemaRequestRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-            .intValue()
-        + ((Long) messageSchemaRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-            .intValue()
-        + ((Long) kafkaConnectorRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-            .intValue()
-        + ((Long)
-                kafkaConnectorRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-            .intValue()
-        + ((Long) topicRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0]).intValue()
-        + ((Long) topicRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-            .intValue()
-        + ((Long) aclRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0]).intValue()
-        + ((Long) aclRequestsRepo.findAllRecordsCountForTeamId(teamId, tenantId).get(0)[0])
-            .intValue();
+    return res;
+  }
+
+  public int findAllComponentsCountForTeam(Integer teamId, int tenantId) {
+    return calculateComponentsCountForTeam(teamId, tenantId, false);
   }
 
   public int findAllComponentsCountForUser(String userId, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -460,7 +460,7 @@ public class UsersTeamsControllerService {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_103).build();
     }
 
-    if (manageDatabase.getHandleDbRequests().getAllComponentsCountForTeam(teamId, tenantId) > 0) {
+    if (manageDatabase.getHandleDbRequests().existsComponentsCountForTeam(teamId, tenantId)) {
       return ApiResponse.builder().success(false).message(TEAMS_ERR_104).build();
     }
 


### PR DESCRIPTION
The issue of `io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc#findAllComponentsCountForTeam` is that from one side it tries to calcute everything by running a number of quesries to db, from another side sometimes there is no need for it for instance at `core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService#deleteTeam`
so it would make sense to have lazy option. The pr adds this option