### PR TITLE
Use findFirstByUsernameAndStatus rather than findAllByUsernameAndStatus

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -228,7 +228,7 @@ public interface HandleDbRequests {
 
   List<RegisterUserInfo> getAllRegisterUsersInformation();
 
-  List<RegisterUserInfo> getAllStagingRegisterUsersInfo(String userId);
+  RegisterUserInfo getFirstStagingRegisterUsersInfo(String userName);
 
   UserInfo getUsersInfo(String username);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -517,8 +517,8 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public List<RegisterUserInfo> getAllStagingRegisterUsersInfo(String userName) {
-    return jdbcSelectHelper.selectAllStagingRegisterUsersInfo(userName);
+  public RegisterUserInfo getFirstStagingRegisterUsersInfo(String userName) {
+    return jdbcSelectHelper.selectFirstStagingRegisterUsersInfo(userName);
   }
 
   public UserInfo getUsersInfo(String username) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1030,8 +1030,8 @@ public class SelectDataJdbc {
     return registerInfoRepo.findAllByStatus("PENDING");
   }
 
-  public List<RegisterUserInfo> selectAllStagingRegisterUsersInfo(String userId) {
-    return registerInfoRepo.findAllByUsernameAndStatus(userId, "STAGING");
+  public RegisterUserInfo selectFirstStagingRegisterUsersInfo(String userId) {
+    return registerInfoRepo.findFirstByUsernameAndStatus(userId, "STAGING");
   }
 
   public RegisterUserInfo selectRegisterUsersInfo(String username) {
@@ -1376,17 +1376,17 @@ public class SelectDataJdbc {
   }
 
   public String getRegistrationId(String userId) {
-    List<RegisterUserInfo> registerInfoList =
-        registerInfoRepo.findAllByUsernameAndStatus(userId, "STAGING");
-    List<RegisterUserInfo> registerInfoList1 =
-        registerInfoRepo.findAllByUsernameAndStatus(userId, "PENDING");
-    if (registerInfoList.size() > 0) {
-      return registerInfoList.get(0).getRegistrationId();
-    } else if (registerInfoList1.size() > 0) {
-      return "PENDING_ACTIVATION";
-    } else {
-      return null;
+    RegisterUserInfo registerInfoStaging =
+        registerInfoRepo.findFirstByUsernameAndStatus(userId, "STAGING");
+    if (registerInfoStaging != null) {
+      return registerInfoStaging.getRegistrationId();
     }
+    boolean pendingArePresent =
+        registerInfoRepo.existsRegisterUserInfoByUsernameAndStatus(userId, "PENDING");
+    if (pendingArePresent) {
+      return "PENDING_ACTIVATION";
+    }
+    return null;
   }
 
   public RegisterUserInfo getRegistrationDetails(String registrationId, String status) {

--- a/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
@@ -16,7 +16,9 @@ public interface RegisterInfoRepo extends CrudRepository<RegisterUserInfo, Strin
 
   List<RegisterUserInfo> findAllByRegistrationIdAndStatus(String registrationId, String status);
 
-  List<RegisterUserInfo> findAllByUsernameAndStatus(String userId, String status);
+  RegisterUserInfo findFirstByUsernameAndStatus(String userId, String status);
+
+  boolean existsRegisterUserInfoByUsernameAndStatus(String userId, String status);
 
   List<RegisterUserInfo> findAllByRegistrationId(String registrationId);
 

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -923,18 +923,19 @@ public class UsersTeamsControllerService {
     }
 
     // get the user details from db
-    List<RegisterUserInfo> stagingRegisterUsersInfo =
-        manageDatabase.getHandleDbRequests().getAllStagingRegisterUsersInfo(newUser.getUsername());
+    RegisterUserInfo stagingRegisterUserInfo =
+        manageDatabase
+            .getHandleDbRequests()
+            .getFirstStagingRegisterUsersInfo(newUser.getUsername());
 
     // enrich user info
-    if (!stagingRegisterUsersInfo.isEmpty()) {
-      RegisterUserInfo registerUserInfo = stagingRegisterUsersInfo.get(0);
-      newUser.setTeamId(registerUserInfo.getTeamId());
+    if (stagingRegisterUserInfo != null) {
+      newUser.setTeamId(stagingRegisterUserInfo.getTeamId());
       newUser.setTeam(
           manageDatabase.getTeamNameFromTeamId(
-              registerUserInfo.getTenantId(), registerUserInfo.getTeamId()));
-      newUser.setRole(registerUserInfo.getRole());
-      newUser.setTenantId(registerUserInfo.getTenantId());
+              stagingRegisterUserInfo.getTenantId(), stagingRegisterUserInfo.getTeamId()));
+      newUser.setRole(stagingRegisterUserInfo.getRole());
+      newUser.setTenantId(stagingRegisterUserInfo.getTenantId());
     }
 
     try {


### PR DESCRIPTION
Since there is a need only for the first available `RegisterInfo` or even only for existence then there is no need for `findByAll...` queries.
Having this in mind we could minimize amount of data transferring between the app and db
