### PR TITLE
Use custom delete methods to avoid loading data before removal

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/DeleteDataJdbc.java
@@ -4,6 +4,7 @@ import io.aiven.klaw.dao.*;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.repository.*;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -246,58 +247,61 @@ public class DeleteDataJdbc {
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public void deleteTopics(Topic topic) {
     log.debug("deleteTopics {}", topic.getTopicname());
-    List<Topic> topics =
-        topicRepo.findAllByTopicnameAndEnvironmentAndTenantId(
-            topic.getTopicname(), topic.getEnvironment(), topic.getTenantId());
-    topicRepo.deleteAll(topics);
+    topicRepo.deleteByTopicnameAndEnvironmentAndTenantId(
+        topic.getTopicname(), topic.getEnvironment(), topic.getTenantId());
   }
 
+  @Transactional
   public void deleteConnectors(KwKafkaConnector connector) {
     log.debug("deleteConnectors {}", connector.getConnectorName());
-    List<KwKafkaConnector> topics =
-        kafkaConnectorRepo.findAllByConnectorNameAndEnvironmentAndTenantId(
-            connector.getConnectorName(), connector.getEnvironment(), connector.getTenantId());
-    kafkaConnectorRepo.deleteAll(topics);
+    kafkaConnectorRepo.deleteByConnectorNameAndEnvironmentAndTenantId(
+        connector.getConnectorName(), connector.getEnvironment(), connector.getTenantId());
   }
 
+  @Transactional
   public String deleteRole(String roleId, int tenantId) {
-    List<KwRolesPermissions> rolePerms =
-        kwRolesPermsRepo.findAllByRoleIdAndTenantId(roleId, tenantId);
-    kwRolesPermsRepo.deleteAll(rolePerms);
+    kwRolesPermsRepo.deleteByRoleIdAndTenantId(roleId, tenantId);
 
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public String deleteAllUsers(int tenantId) {
-    userInfoRepo.deleteAll(userInfoRepo.findAllByTenantId(tenantId));
-    registerInfoRepo.deleteAll(registerInfoRepo.findAllByTenantId(tenantId));
+    userInfoRepo.deleteByTenantId(tenantId);
+    registerInfoRepo.deleteByTenantId(tenantId);
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public String deleteAllTeams(int tenantId) {
-    teamRepo.deleteAll(teamRepo.findAllByTenantId(tenantId));
+    teamRepo.deleteByTenantId(tenantId);
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public String deleteAllEnvs(int tenantId) {
-    envRepo.deleteAll(envRepo.findAllByTenantId(tenantId));
+    envRepo.deleteByTenantId(tenantId);
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public String deleteAllClusters(int tenantId) {
-    kwClusterRepo.deleteAll(kwClusterRepo.findAllByTenantId(tenantId));
+    kwClusterRepo.deleteByTenantId(tenantId);
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public String deleteAllRolesPerms(int tenantId) {
-    kwRolesPermsRepo.deleteAll(kwRolesPermsRepo.findAllByTenantId(tenantId));
+    kwRolesPermsRepo.deleteByTenantId(tenantId);
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public String deleteAllKwProps(int tenantId) {
-    kwPropertiesRepo.deleteAll(kwPropertiesRepo.findAllByTenantId(tenantId));
+    kwPropertiesRepo.deleteByTenantId(tenantId);
     return ApiResultStatus.SUCCESS.value;
   }
 
@@ -308,32 +312,32 @@ public class DeleteDataJdbc {
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public String deleteTxnData(int tenantId) {
-    topicRequestsRepo.deleteAll(topicRequestsRepo.findAllByTenantId(tenantId));
-    topicRepo.deleteAll(topicRepo.findAllByTenantId(tenantId));
+    topicRequestsRepo.deleteByTenantId(tenantId);
+    topicRepo.deleteByTenantId(tenantId);
 
-    aclRequestsRepo.deleteAll(aclRequestsRepo.findAllByTenantId(tenantId));
-    aclRepo.deleteAll(aclRepo.findAllByTenantId(tenantId));
+    aclRequestsRepo.deleteByTenantId(tenantId);
+    aclRepo.deleteByTenantId(tenantId);
 
-    schemaRequestRepo.deleteAll(schemaRequestRepo.findAllByTenantId(tenantId));
-    messageSchemaRepo.deleteAll(messageSchemaRepo.findAllByTenantId(tenantId));
+    schemaRequestRepo.deleteByTenantId(tenantId);
+    messageSchemaRepo.deleteByTenantId(tenantId);
 
-    kafkaConnectorRepo.deleteAll(kafkaConnectorRepo.findAllByTenantId(tenantId));
-    kafkaConnectorRequestsRepo.deleteAll(kafkaConnectorRequestsRepo.findAllByTenantId(tenantId));
+    kafkaConnectorRepo.deleteByTenantId(tenantId);
+    kafkaConnectorRequestsRepo.deleteByTenantId(tenantId);
 
     return ApiResultStatus.SUCCESS.value;
   }
 
+  @Transactional
   public void deleteSchemas(Topic topicObj) {
-    messageSchemaRepo.deleteAll(
-        messageSchemaRepo.findAllByTenantIdAndTopicnameAndEnvironment(
-            topicObj.getTenantId(), topicObj.getTopicname(), topicObj.getEnvironment()));
+    messageSchemaRepo.deleteByTenantIdAndTopicnameAndEnvironment(
+        topicObj.getTenantId(), topicObj.getTopicname(), topicObj.getEnvironment());
   }
 
+  @Transactional
   public void deleteSchemasWithOptions(int tenantId, String topicName, String schemaEnv) {
-    messageSchemaRepo.deleteAll(
-        messageSchemaRepo.findAllByTenantIdAndTopicnameAndEnvironment(
-            tenantId, topicName, schemaEnv));
+    messageSchemaRepo.deleteByTenantIdAndTopicnameAndEnvironment(tenantId, topicName, schemaEnv);
   }
 
   public String deleteAcls(List<Acl> listDeleteAcls, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
@@ -81,4 +81,6 @@ public interface AclRepo extends CrudRepository<Acl, AclID> {
 
   @Query(value = "select max(aclid) from kwacls where tenantid = :tenantId", nativeQuery = true)
   Integer getNextAclId(@Param("tenantId") Integer tenantId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -98,4 +98,6 @@ public interface AclRequestsRepo
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,
       @Param("topicStatus") String topicStatus);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/EnvRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/EnvRepo.java
@@ -21,4 +21,6 @@ public interface EnvRepo extends CrudRepository<Env, EnvID> {
 
   @Query(value = "select max(id) from kwenv where tenantid = :tenantId", nativeQuery = true)
   Integer getNextId(@Param("tenantId") Integer tenantId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/KwClusterRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwClusterRepo.java
@@ -16,4 +16,6 @@ public interface KwClusterRepo extends CrudRepository<KwClusters, KwClusterID> {
   Integer getNextClusterId(@Param("tenantId") Integer tenantId);
 
   List<KwClusters> findAllByTenantId(int tenantId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRepo.java
@@ -42,4 +42,9 @@ public interface KwKafkaConnectorRepo extends CrudRepository<KwKafkaConnector, K
       value = "select max(connectorid) from kwkafkaconnector where tenantid = :tenantId",
       nativeQuery = true)
   Integer getNextConnectorRequestId(@Param("tenantId") Integer tenantId);
+
+  void deleteByConnectorNameAndEnvironmentAndTenantId(
+      String connectorName, String env, int tenantId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -81,4 +81,6 @@ public interface KwKafkaConnectorRequestsRepo
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,
       @Param("connectorStatus") String connectorStatus);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/KwPropertiesRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwPropertiesRepo.java
@@ -9,4 +9,6 @@ public interface KwPropertiesRepo extends CrudRepository<KwProperties, KwPropert
   KwProperties findFirstByKwKeyAndTenantIdOrderByTenantId(String kwKey, int tenantId);
 
   List<KwProperties> findAllByTenantId(int tenantId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/KwRolesPermsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwRolesPermsRepo.java
@@ -24,4 +24,8 @@ public interface KwRolesPermsRepo extends CrudRepository<KwRolesPermissions, KwR
       value = "select max(id) from kwrolespermissions where tenantid = :tenantId",
       nativeQuery = true)
   Integer getMaxRolePermissionId(@Param("tenantId") Integer tenantId);
+
+  void deleteByRoleIdAndTenantId(String roleId, int tenantId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/MessageSchemaRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/MessageSchemaRepo.java
@@ -49,4 +49,9 @@ public interface MessageSchemaRepo extends CrudRepository<MessageSchema, Message
       nativeQuery = true)
   List<Object[]> findTopicAndVersionsForEnvAndTenantId(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
+
+  void deleteByTenantId(int tenantId);
+
+  void deleteByTenantIdAndTopicnameAndEnvironment(
+      int tenantId, String topicName, String environmentId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
@@ -19,4 +19,6 @@ public interface RegisterInfoRepo extends CrudRepository<RegisterUserInfo, Strin
   List<RegisterUserInfo> findAllByUsernameAndStatus(String userId, String status);
 
   List<RegisterUserInfo> findAllByRegistrationId(String registrationId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -77,4 +77,6 @@ public interface SchemaRequestRepo
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,
       @Param("topicStatus") String topicStatus);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/TeamRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TeamRepo.java
@@ -25,4 +25,6 @@ public interface TeamRepo extends CrudRepository<Team, TeamID> {
   Integer getNextTeamId(@Param("tenantId") Integer tenantId);
 
   Team findFirstByTenantIdAndTeamnameOrderByTenantId(int tenantId, String teamName);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
@@ -105,4 +105,8 @@ public interface TopicRepo extends CrudRepository<Topic, TopicID> {
       @Param("envId") String envId,
       @Param("teamId") Integer teamId,
       @Param("tenantId") Integer tenantId);
+
+  void deleteByTopicnameAndEnvironmentAndTenantId(String topicName, String env, int tenantId);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -93,4 +93,6 @@ public interface TopicRequestsRepo
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,
       @Param("topicStatus") String topicStatus);
+
+  void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/repository/UserInfoRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/UserInfoRepo.java
@@ -13,4 +13,6 @@ public interface UserInfoRepo extends CrudRepository<UserInfo, String> {
   List<UserInfo> findAllByTenantId(int tenantId);
 
   List<UserInfo> findAllByTeamIdAndTenantId(Integer teamId, int tenantId);
+
+  void deleteByTenantId(int tenantId);
 }


### PR DESCRIPTION
The issue with current `DeleteDataJdbc` is that first it loads data into memory and then removes it...
In fact it could be done without extra loading into memory via custom deletes by condition.

The extra requirement for that is an explicit `Transactional` annotation