### PR TITLE
Validate consumer groups in sql

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -133,6 +133,9 @@ public interface HandleDbRequests {
 
   List<Acl> getUniqueConsumerGroups(int tenantId);
 
+  boolean validateIfConsumerGroupUsedByAnotherTeam(
+      Integer teamId, int tenantId, String consumerGroup);
+
   Acl getSyncAclsFromReqNo(int reqNo, int tenantId);
 
   boolean existsAclRequest(String topicName, String requestStatus, String env, int tenantId);

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -309,6 +309,13 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public boolean validateIfConsumerGroupUsedByAnotherTeam(
+      Integer teamId, int tenantId, String consumerGroup) {
+    return jdbcSelectHelper.validateIfConsumerGroupUsedByAnotherTeam(
+        teamId, tenantId, consumerGroup);
+  }
+
+  @Override
   public Acl getSyncAclsFromReqNo(int reqNo, int tenantId) {
     return jdbcSelectHelper.selectSyncAclsFromReqNo(reqNo, tenantId);
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1044,6 +1044,11 @@ public class SelectDataJdbc {
     return aclRepo.findAllByTenantId(tenantId);
   }
 
+  public boolean validateIfConsumerGroupUsedByAnotherTeam(
+      Integer teamId, int tenantId, String consumerGroup) {
+    return aclRepo.validateIfConsumerGroupUsedByAnotherTeam(teamId, tenantId, consumerGroup);
+  }
+
   public Team selectTeamDetails(Integer teamId, int tenantId) {
     TeamID teamID = new TeamID(teamId, tenantId);
     Optional<Team> teamList = teamRepo.findById(teamID);

--- a/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
@@ -25,7 +25,22 @@ public interface AclRepo extends CrudRepository<Acl, AclID> {
 
   List<Acl> findAllByTenantId(int tenantId);
 
+  @Query(
+      value =
+          "select exists(select 1 from kwacls where teamid != :teamId and tenantid = :tenantId and consumergroup = :consumerGroup)",
+      nativeQuery = true)
+  boolean validateIfConsumerGroupUsedByAnotherTeam(
+      @Param("teamId") Integer teamId,
+      @Param("tenantId") Integer tenantId,
+      @Param("consumerGroup") String consumerGroup);
+
   boolean existsByEnvironmentAndTenantId(
+      @Param("envId") String envId, @Param("tenantId") Integer tenantId);
+
+  @Query(
+      value = "select count(*) from kwacls where env = :envId and tenantid = :tenantId",
+      nativeQuery = true)
+  List<Object[]> findAllAclsCountForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -122,7 +122,7 @@ public class AclControllerService {
 
       // ignore consumer group check for Aiven kafka flavors
       if (!kafkaFlavor.equals(KafkaFlavors.AIVEN_FOR_APACHE_KAFKA.value)) {
-        if (validateTeamConsumerGroup(
+        if (validateIfConsumerGroupUsedByAnotherTeam(
             aclRequestsModel.getRequestingteam(), aclRequestsModel.getConsumergroup(), tenantId)) {
           result = String.format(ACL_ERR_103, aclRequestsModel.getConsumergroup());
           return ApiResponse.notOk(result);
@@ -863,17 +863,11 @@ public class AclControllerService {
     return mailService.getCurrentUserName();
   }
 
-  private boolean validateTeamConsumerGroup(Integer teamId, String consumerGroup, int tenantId) {
-    List<Acl> acls = manageDatabase.getHandleDbRequests().getUniqueConsumerGroups(tenantId);
-
-    for (Acl acl : acls) {
-      if (!Objects.equals(acl.getTeamId(), teamId)
-          && acl.getConsumergroup() != null
-          && Objects.equals(acl.getConsumergroup(), consumerGroup)) {
-        return true;
-      }
-    }
-    return false;
+  private boolean validateIfConsumerGroupUsedByAnotherTeam(
+      Integer teamId, String consumerGroup, int tenantId) {
+    return manageDatabase
+        .getHandleDbRequests()
+        .validateIfConsumerGroupUsedByAnotherTeam(teamId, tenantId, consumerGroup);
   }
 
   public Env getEnvDetails(String envId, int tenantId) {

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -241,8 +241,8 @@ public class AclControllerServiceTest {
     acl.setConsumergroup(aclRequestsModel.getConsumergroup());
 
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt())).thenReturn(topicList);
-    when(handleDbRequests.getUniqueConsumerGroups(anyInt()))
-        .thenReturn(Collections.singletonList(acl));
+    when(handleDbRequests.validateIfConsumerGroupUsedByAnotherTeam(anyInt(), anyInt(), anyString()))
+        .thenReturn(true);
     stubUserInfo();
     mockKafkaFlavor();
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7096,10 +7096,10 @@
             "type" : "integer",
             "format" : "int32"
           },
-          "topicOwner" : {
+          "highestEnv" : {
             "type" : "boolean"
           },
-          "highestEnv" : {
+          "topicOwner" : {
             "type" : "boolean"
           }
         },


### PR DESCRIPTION
Currently major part of consumer groups validation happens in memory with preliminay loading lots of data into memory.
The PR makes it on DB level minimizing amount of data transferring between the app and db