### PR TITLE
Update google java format

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/MigrationUtility.java
+++ b/core/src/main/java/io/aiven/klaw/config/MigrationUtility.java
@@ -172,8 +172,11 @@ public class MigrationUtility {
    */
   private void executeMigrationInstructions(
       SortedMap<Integer, Pair<String, Class<?>>> orderedMapOfMigrationInstructions)
-      throws IllegalAccessException, InvocationTargetException, KlawDataMigrationException,
-          NoSuchMethodException, ClassNotFoundException {
+      throws IllegalAccessException,
+          InvocationTargetException,
+          KlawDataMigrationException,
+          NoSuchMethodException,
+          ClassNotFoundException {
     for (Integer value : orderedMapOfMigrationInstructions.keySet()) {
       Class<?> runner = orderedMapOfMigrationInstructions.get(value).getRight();
       for (Method method : runner.getDeclaredMethods()) {

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -883,6 +883,7 @@ public class TopicAclControllerIT {
     TopicOverview response = OBJECT_MAPPER.readValue(res, TopicOverview.class);
     assertThat(response.getAclInfoList()).hasSize(1);
   }
+
   // get acls to be synced - retrieve from Source of truth
   @Order(27)
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- the list is sorted -->
         <assertj-core.version>3.24.2</assertj-core.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-        <google-java-format.version>1.15.0</google-java-format.version>
+        <google-java-format.version>1.17.0</google-java-format.version>
         <guava.version>32.1.2-jre</guava.version>
         <httpclient5.version>5.2.1</httpclient5.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>


### PR DESCRIPTION
It seems the update of google-java-format was missed while moving to JDK17 

The reason of sticking to `1.15.0` version is that it was the latest supported jdk 11.
Since now minimum JDK is 17 we could safely bump google-java-format