### PR TITLE
Upgrade kafka test spring

### DIFF
--- a/cluster-api/pom.xml
+++ b/cluster-api/pom.xml
@@ -25,7 +25,7 @@
         <guava.version>31.1-jre</guava.version>
         <kafka.client.version>3.4.1</kafka.client.version>
         <mockserver.version>5.15.0</mockserver.version>
-        <spring-kafka-test.version>3.0.8</spring-kafka-test.version>
+        <spring-kafka-test.version>3.0.9</spring-kafka-test.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
About this change - What it does

Upgrades spring kafka test version. to 3.0.9

Resolves PR: #1498
Why this way
