### PR TITLE
fix(coral): Temporary deny access to coral to superadmins

### DIFF
--- a/coral/src/app/context-provider/AuthProvider.test.tsx
+++ b/coral/src/app/context-provider/AuthProvider.test.tsx
@@ -18,6 +18,7 @@ const testAuthUser: AuthUser = {
   teamId: "",
   teamname: "",
   username: "Jon Snow",
+  userrole: "USER",
 };
 
 const ChildComponent = () => {

--- a/coral/src/app/context-provider/AuthProvider.test.tsx
+++ b/coral/src/app/context-provider/AuthProvider.test.tsx
@@ -5,7 +5,7 @@ import {
   useAuthContext,
 } from "src/app/context-provider/AuthProvider";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import { AuthUser } from "src/domain/auth-user";
+import { testAuthUser } from "src/domain/auth-user/auth-user-test-helper";
 
 const getAuthMock = jest.fn();
 jest.mock("src/domain/auth-user", () => ({
@@ -13,20 +13,13 @@ jest.mock("src/domain/auth-user", () => ({
   getAuth: () => getAuthMock(),
 }));
 
-const testAuthUser: AuthUser = {
-  canSwitchTeams: "",
-  teamId: "",
-  teamname: "",
-  username: "Jon Snow",
-  userrole: "USER",
-};
-
 const ChildComponent = () => {
   const authUser = useAuthContext();
 
   return <div data-testid={"auth-provider-child"}>{authUser?.username}</div>;
 };
 
+const mockAuthUser = { ...testAuthUser, username: "Jon Snow" };
 describe("AuthProvider.tsx", () => {
   describe("gets the auth user", () => {
     beforeEach(() => {
@@ -58,7 +51,7 @@ describe("AuthProvider.tsx", () => {
 
   describe("renders an auth provider with given children when auth user is available", () => {
     beforeEach(async () => {
-      getAuthMock.mockReturnValue(testAuthUser);
+      getAuthMock.mockReturnValue(mockAuthUser);
       customRender(
         <AuthProvider>
           <ChildComponent />

--- a/coral/src/app/features/team-info/TeamInfo.test.tsx
+++ b/coral/src/app/features/team-info/TeamInfo.test.tsx
@@ -2,17 +2,9 @@ import { Context as AquariumContext } from "@aivenio/aquarium";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { cleanup, screen } from "@testing-library/react";
 import { TeamInfo } from "src/app/features/team-info/TeamInfo";
-import { AuthUser } from "src/domain/auth-user";
 import { getTeamsOfUser } from "src/domain/team";
 import { KlawApiResponse } from "types/utils";
-
-const authUser: AuthUser = {
-  canSwitchTeams: "false",
-  teamId: "2",
-  teamname: "awesome-bunch-of-people",
-  username: "i-am-test-user",
-  userrole: "USER",
-};
+import { testAuthUser } from "src/domain/auth-user/auth-user-test-helper";
 
 const mockAuthUser = jest.fn();
 jest.mock("src/app/context-provider/AuthProvider", () => ({
@@ -47,7 +39,7 @@ const testTeams: KlawApiResponse<"getSwitchTeams"> = [
 
 describe("TeamInfo", () => {
   describe("shows a info about user's team when they can't switch teams", () => {
-    mockAuthUser.mockReturnValue(authUser);
+    mockAuthUser.mockReturnValue(testAuthUser);
 
     beforeAll(() => {
       mockGetTeamsOfUser.mockResolvedValue([]);
@@ -72,13 +64,13 @@ describe("TeamInfo", () => {
     });
 
     it("shows team of the user as text", async () => {
-      const team = await screen.findByText(authUser.teamname);
+      const team = await screen.findByText(testAuthUser.teamname);
 
       expect(team).toBeVisible();
     });
 
     it("does not render a menu to change teams", async () => {
-      await screen.findByText(authUser.teamname);
+      await screen.findByText(testAuthUser.teamname);
       const menuButton = screen.queryByRole("button", {
         name: "Change your team",
       });
@@ -88,7 +80,7 @@ describe("TeamInfo", () => {
   });
 
   describe("shows a info about user's team and a dropdown to switch team", () => {
-    mockAuthUser.mockReturnValue({ ...authUser, canSwitchTeams: "true" });
+    mockAuthUser.mockReturnValue({ ...testAuthUser, canSwitchTeams: "true" });
 
     beforeAll(() => {
       mockGetTeamsOfUser.mockResolvedValue(testTeams);
@@ -104,7 +96,7 @@ describe("TeamInfo", () => {
     afterAll(cleanup);
 
     it("shows team of the user as menu", async () => {
-      const team = await screen.findByText(authUser.teamname);
+      const team = await screen.findByText(testAuthUser.teamname);
       const menuButton = await screen.findByRole("button", {
         name: "Change your team",
       });

--- a/coral/src/app/features/team-info/TeamInfo.test.tsx
+++ b/coral/src/app/features/team-info/TeamInfo.test.tsx
@@ -11,6 +11,7 @@ const authUser: AuthUser = {
   teamId: "2",
   teamname: "awesome-bunch-of-people",
   username: "i-am-test-user",
+  userrole: "USER",
 };
 
 const mockAuthUser = jest.fn();

--- a/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
@@ -8,9 +8,9 @@ import {
   getAivenServiceAccountDetails,
   getConsumerOffsets,
 } from "src/domain/acl/acl-api";
-import { AuthUser } from "src/domain/auth-user";
 import { AclOverviewInfo } from "src/domain/topic/topic-types";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { testAuthUser } from "src/domain/auth-user/auth-user-test-helper";
 
 jest.mock("src/domain/acl/acl-api");
 jest.mock("src/app/context-provider/AuthProvider", () => ({
@@ -26,14 +26,6 @@ const mockGetAivenServiceAccountDetails =
   >;
 const mockAuthUser = jest.fn();
 const mockCloseDetailsModal = jest.fn();
-
-const authUser: AuthUser = {
-  canSwitchTeams: "false",
-  teamId: "2",
-  teamname: "awesome-bunch-of-people",
-  username: "i-am-test-user",
-  userrole: "USER",
-};
 
 const testServiceAccountData = {
   username: "nkira",
@@ -132,7 +124,7 @@ const findTerm = (term: string) => {
 
 describe("TopicSubscriptionsDetailsModal.tsx", () => {
   beforeAll(() => {
-    mockAuthUser.mockReturnValue(authUser);
+    mockAuthUser.mockReturnValue(testAuthUser);
   });
 
   afterEach(() => {

--- a/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.test.tsx
@@ -32,6 +32,7 @@ const authUser: AuthUser = {
   teamId: "2",
   teamname: "awesome-bunch-of-people",
   username: "i-am-test-user",
+  userrole: "USER",
 };
 
 const testServiceAccountData = {

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -13,6 +13,7 @@ const authUser: AuthUser = {
   teamId: "2",
   teamname: "awesome-bunch-of-people",
   username: "i-am-test-user",
+  userrole: "USER",
 };
 
 jest.mock("src/domain/team/team-api.ts");

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -6,21 +6,13 @@ import {
   tabThroughBackward,
   tabThroughForward,
 } from "src/services/test-utils/tabbing";
-import { AuthUser } from "src/domain/auth-user";
-
-const authUser: AuthUser = {
-  canSwitchTeams: "false",
-  teamId: "2",
-  teamname: "awesome-bunch-of-people",
-  username: "i-am-test-user",
-  userrole: "USER",
-};
+import { testAuthUser } from "src/domain/auth-user/auth-user-test-helper";
 
 jest.mock("src/domain/team/team-api.ts");
 
 jest.mock("src/app/context-provider/AuthProvider", () => ({
   useAuthContext: () => {
-    return authUser;
+    return testAuthUser;
   },
 }));
 
@@ -76,7 +68,7 @@ describe("MainNavigation.tsx", () => {
 
     it("renders the user's current team", async () => {
       const teamLabel = screen.getByText("Team");
-      const teamName = screen.getByText(authUser.teamname);
+      const teamName = screen.getByText(testAuthUser.teamname);
       expect(teamLabel).toBeVisible();
       expect(teamName).toBeVisible();
     });

--- a/coral/src/domain/auth-user/auth-user-api.msw.ts
+++ b/coral/src/domain/auth-user/auth-user-api.msw.ts
@@ -1,15 +1,7 @@
 import { rest } from "msw";
 import { getHTTPBaseAPIUrl } from "src/config";
-import { AuthUser } from "src/domain/auth-user/auth-user-types";
 import { SetupServerApi } from "msw/node";
-
-const user: AuthUser = {
-  username: "Super Admin",
-  teamname: "",
-  teamId: "",
-  canSwitchTeams: "",
-  userrole: "USER",
-};
+import { testAuthUser } from "src/domain/auth-user/auth-user-test-helper";
 
 const correctUsername = "superadmin";
 
@@ -28,7 +20,7 @@ function mockUserAuthRequest(mswInstance: SetupServerApi) {
           })
         );
       }
-      return res(ctx.status(200), ctx.json(user));
+      return res(ctx.status(200), ctx.json(testAuthUser));
     })
   );
 }

--- a/coral/src/domain/auth-user/auth-user-api.msw.ts
+++ b/coral/src/domain/auth-user/auth-user-api.msw.ts
@@ -8,6 +8,7 @@ const user: AuthUser = {
   teamname: "",
   teamId: "",
   canSwitchTeams: "",
+  userrole: "USER",
 };
 
 const correctUsername = "superadmin";

--- a/coral/src/domain/auth-user/auth-user-api.ts
+++ b/coral/src/domain/auth-user/auth-user-api.ts
@@ -2,7 +2,7 @@ import {
   AuthUser,
   AuthUserLoginData,
 } from "src/domain/auth-user/auth-user-types";
-import api, { API_PATHS } from "src/services/api";
+import api, { API_PATHS, HTTPError } from "src/services/api";
 import { paths as ApiPaths } from "types/api";
 import { KlawApiResponse } from "types/utils";
 
@@ -15,7 +15,31 @@ const getAuthUserMockForLogin = (
   return api.post("/login" as keyof ApiPaths, userLogin);
 };
 
+// user roles are added dynamically by admins, we can't make them enums
+// but "SUPERADMIN" is the default role set by us. It's highly unlikely
+// that users would change that string, so we can use it to identify
+// the superadmin role, which has different view-access
+const SUPERADMIN_USERROLE = "SUPERADMIN";
+function isSuperAdmin(user: AuthUser) {
+  return user.userrole === SUPERADMIN_USERROLE;
+}
+
 function transformAuthResponse(response: KlawApiResponse<"getAuth">): AuthUser {
+  const headers = {} as Headers;
+
+  if (isSuperAdmin(response)) {
+    // We're marking the SUPERADMIN as not authorized
+    // by manually throwing the correct error that will
+    // be caught by isUnauthorizedError
+    const error: HTTPError = {
+      data: " ",
+      headers,
+      status: 401,
+      statusText: "Not authorized to access Coral.",
+    };
+    throw error;
+  }
+
   return {
     username: response.username,
     teamname: response.teamname,
@@ -25,7 +49,7 @@ function transformAuthResponse(response: KlawApiResponse<"getAuth">): AuthUser {
   };
 }
 
-function getAuth(): Promise<AuthUser> {
+async function getAuth(): Promise<AuthUser> {
   return api
     .get<KlawApiResponse<"getAuth">>(API_PATHS.getAuth)
     .then((response) => transformAuthResponse(response));

--- a/coral/src/domain/auth-user/auth-user-api.ts
+++ b/coral/src/domain/auth-user/auth-user-api.ts
@@ -20,7 +20,8 @@ const getAuthUserMockForLogin = (
 // that users would change that string, so we can use it to identify
 // the superadmin role, which has different view-access
 const SUPERADMIN_USERROLE = "SUPERADMIN";
-function isSuperAdmin(user: AuthUser) {
+type SuperAdminUser = AuthUser & { userrole: typeof SUPERADMIN_USERROLE };
+function isSuperAdmin(user: AuthUser): user is SuperAdminUser {
   return user.userrole === SUPERADMIN_USERROLE;
 }
 

--- a/coral/src/domain/auth-user/auth-user-api.ts
+++ b/coral/src/domain/auth-user/auth-user-api.ts
@@ -49,7 +49,7 @@ function transformAuthResponse(response: KlawApiResponse<"getAuth">): AuthUser {
   };
 }
 
-async function getAuth(): Promise<AuthUser> {
+function getAuth(): Promise<AuthUser> {
   return api
     .get<KlawApiResponse<"getAuth">>(API_PATHS.getAuth)
     .then((response) => transformAuthResponse(response));

--- a/coral/src/domain/auth-user/auth-user-api.ts
+++ b/coral/src/domain/auth-user/auth-user-api.ts
@@ -21,6 +21,7 @@ function transformAuthResponse(response: KlawApiResponse<"getAuth">): AuthUser {
     teamname: response.teamname,
     teamId: response.teamId,
     canSwitchTeams: response.canSwitchTeams,
+    userrole: response.userrole,
   };
 }
 

--- a/coral/src/domain/auth-user/auth-user-test-helper.ts
+++ b/coral/src/domain/auth-user/auth-user-test-helper.ts
@@ -1,0 +1,11 @@
+import { AuthUser } from "src/domain/auth-user/auth-user-types";
+
+const testAuthUser: AuthUser = {
+  canSwitchTeams: "false",
+  teamId: "1234567",
+  teamname: "awesome-bunch-of-people",
+  username: "i-am-test-user",
+  userrole: "USER",
+};
+
+export { testAuthUser };

--- a/coral/src/domain/auth-user/auth-user-types.ts
+++ b/coral/src/domain/auth-user/auth-user-types.ts
@@ -2,6 +2,7 @@ import { KlawApiModel } from "types/utils";
 
 type AuthUser = {
   username: KlawApiModel<"AuthenticationInfo">["username"];
+  userrole: KlawApiModel<"AuthenticationInfo">["userrole"];
   teamname: KlawApiModel<"AuthenticationInfo">["teamname"];
   teamId: KlawApiModel<"AuthenticationInfo">["teamId"];
   canSwitchTeams: KlawApiModel<"AuthenticationInfo">["canSwitchTeams"];

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -305,6 +305,12 @@ public class UtilControllerService implements InitializingBean {
       }
 
       AuthenticationInfo authenticationInfo = new AuthenticationInfo();
+
+      boolean isUserSuperadmin =
+          SUPERADMIN
+              .name()
+              .equals(manageDatabase.getHandleDbRequests().getUsersInfo(userName).getRole());
+
       Map<String, String> teamTopics =
           reqsHandle.getDashboardInfo(commonUtilsService.getTeamId(userName), tenantId);
       authenticationInfo.setMyteamtopics(teamTopics.get("myteamtopics"));
@@ -531,13 +537,7 @@ public class UtilControllerService implements InitializingBean {
       }
 
       if (tenantId == KwConstants.DEFAULT_TENANT_ID
-          && SUPERADMIN
-              .name()
-              .equals(
-                  manageDatabase
-                      .getHandleDbRequests()
-                      .getUsersInfo(userName)
-                      .getRole())) { // allow adding tenants only to "default"
+          && isUserSuperadmin) { // allow adding tenants only to "default"
         addDeleteEditTenants = ApiResultStatus.AUTHORIZED.value;
       } else {
         addDeleteEditTenants = "NotAuthorized";
@@ -639,7 +639,8 @@ public class UtilControllerService implements InitializingBean {
       authenticationInfo.setAddDeleteEditEnvs(addDeleteEditEnvs);
 
       // coral attributes
-      authenticationInfo.setCoralEnabled(Boolean.toString(coralEnabled && isCoralBuilt));
+      authenticationInfo.setCoralEnabled(
+          Boolean.toString(coralEnabled && isCoralBuilt && !isUserSuperadmin));
 
       return authenticationInfo;
     } else return null;


### PR DESCRIPTION
# About this change - What it does

- checks for role `SUPERADMIN` when determine the `coralIsEnabled` boolean. For `SUPERADMIN`, the preview banner with link the new interfaces are not shown anymore
- checks for `userrole` when getting auth user and, if userrole us SUPERADMIN, manually throws an unauthorized error, so user get redirected from coral to Klaw (this is in case a user accesses a link to `/coral` manually)

## Why

Users with role `superadmin` only have certain processes they can do, it's a role to admin Klaw. We're currently focusing on building all views for users, not superadmins. Since coral is now enabled as preview per default, we want to avoid superadmins to access coral, to avoid confusing - they can't access the api for things they are not allowed to do, e.g. creating a topic, but there's no reason they should even see the UI for it.

This is a temporary solution until we start building the admin views and will look into a sustainable and reasonable approach to handle the different user roles.


## Screenshots/recordings

### Screenshot accessing Klaw as USER and as SUPERADMIN

#### USER
Banner! 💁‍♀️
<img width="1082" alt="Screenshot 2023-08-09 at 09 56 52" src="https://github.com/Aiven-Open/klaw/assets/943800/f53c4cee-0d15-438a-be46-505a9bf703c7">


#### SUPERADMIN
NO BANNER 🙅‍♀️
<img width="1088" alt="Screenshot 2023-08-09 at 09 57 06" src="https://github.com/Aiven-Open/klaw/assets/943800/ddd58bc1-1521-4622-8507-d02595e8c4af">


### Recordings coral

Note: This is on our local development process, the coral Vite app runs on port `1337`, but (atm) redirecting to the login does not work, so we've to login on port `9097`. I made sure to have the url in the video to show that I'm actually on the right port :D and testing the current state and not the last build. 

### User with "normal" role

https://github.com/Aiven-Open/klaw/assets/943800/c6b61886-ba1c-4c00-95d5-0c06134941ae


### User with superadmin role

https://github.com/Aiven-Open/klaw/assets/943800/e4e70bb6-7565-4c47-9120-7bad8b1571a4





Resolves: #1555 
