### PR TITLE
Dont load users with empty password and auth type is db

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
@@ -163,7 +163,7 @@ public class SecurityConfigNoSSO {
       try {
         String secPwd = userInfo.getPwd();
         if (secPwd != null && secPwd.equals("")) {
-          secPwd = "gfGF%64GFDd766hfgfHFD$%#453";
+          continue;
         } else {
           secPwd = decodePwd(secPwd);
         }

--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
@@ -162,7 +162,7 @@ public class SecurityConfigNoSSO {
       userInfo = iter.next();
       try {
         String secPwd = userInfo.getPwd();
-        if (secPwd != null && secPwd.equals("")) {
+        if (secPwd == null || secPwd.equals("")) {
           continue;
         } else {
           secPwd = decodePwd(secPwd);


### PR DESCRIPTION
About this change - What it does

When authentication type is db and user pwds are "", then user doesn't have to be loaded. 
These users added only during AD auth type.

Resolves: #1220 
Why this way
For clean loading of users when auth type is db