### PR TITLE
Boolean to indicate if environment can create new schema or only accept promotion.

### DIFF
--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -166,6 +166,7 @@ const testTopicSchemas: TopicSchemaOverview = {
     showNext: false,
     showPrev: false,
     latest: true,
+    promoteOnly: false,
   },
 };
 

--- a/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
+++ b/coral/src/app/features/topics/details/history/TopicHistory.test.tsx
@@ -90,6 +90,7 @@ const testTopicSchemas: TopicSchemaOverview = {
     showNext: false,
     showPrev: false,
     latest: true,
+    promoteOnly: false,
   },
 };
 

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -45,6 +45,7 @@ const testTopicSchemas: TopicSchemaOverview = {
     showNext: true,
     showPrev: false,
     latest: true,
+    promoteOnly: false,
   },
 };
 
@@ -70,6 +71,7 @@ const noPromotion_testTopicSchemas = {
     showNext: true,
     showPrev: false,
     latest: true,
+    promoteOnly: false,
   },
 };
 

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1368,6 +1368,7 @@ export type components = {
       showNext: boolean;
       showPrev: boolean;
       latest: boolean;
+      promoteOnly: boolean;
     };
     SchemaOverview: {
       topicExists: boolean;

--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
@@ -11,7 +11,6 @@ import io.aiven.klaw.model.response.SchemaOverview;
 import io.aiven.klaw.model.response.SchemaRequestsResponseModel;
 import io.aiven.klaw.service.SchemaOverviewService;
 import io.aiven.klaw.service.SchemaRegistryControllerService;
-import io.aiven.klaw.service.TopicOverviewService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SchemaRegistryController {
 
   @Autowired SchemaRegistryControllerService schemaRegistryControllerService;
-
-  @Autowired TopicOverviewService topicOverviewService;
   @Autowired SchemaOverviewService schemaOverviewService;
 
   /**

--- a/core/src/main/java/io/aiven/klaw/model/response/SchemaDetailsPerEnv.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/SchemaDetailsPerEnv.java
@@ -27,4 +27,6 @@ public class SchemaDetailsPerEnv {
   @NotNull private boolean showPrev;
   // simple boolean to identify if this is the latest schema on the topic for that environment.
   @NotNull private boolean latest;
+  // Indicates if this schema env is restricted to only allow new schemas through promotion.
+  @NotNull private boolean promoteOnly;
 }

--- a/core/src/main/resources/templates/execSchemas.html
+++ b/core/src/main/resources/templates/execSchemas.html
@@ -554,14 +554,10 @@
 											<h6 class="text-primary">Status</h6><b>
 											<span class="badge badge-info">{{ schemaRequest.requestStatus }}</span></b>
 										</div>
-
-										
-<div ng-show="schemaRequest.requestOperationType !== 'APPROVED'" class="p-2 border-right" style="width:12%">
-	<h6 class="text-primary">Request Type</h6><b>
-	<span class="badge badge-info">{{ schemaRequest.requestOperationType }} Schema</span></b>
-</div>
-
-
+										<div class="p-2 border-right" style="width:12%">
+											<h6 class="text-primary">Request Type</h6><b>
+											<span class="badge badge-info">{{ schemaRequest.requestOperationType }} Schema</span></b>
+										</div>
 										<div class="p-2" style="width:15%">
 											<h6 class="text-primary">Date Requested</h6><b>{{ schemaRequest.requesttimestring }}</b>
 										</div>

--- a/core/src/main/resources/templates/mySchemaRequests.html
+++ b/core/src/main/resources/templates/mySchemaRequests.html
@@ -533,7 +533,7 @@
 											<span class="badge badge-info">{{ schemaRequest.requestStatus }}</span></b>
 										</div>
 										
-						                <div ng-show="schemaRequest.requestOperationType !== 'APPROVED'" class="p-2 border-right" style="width:12%">
+						                <div class="p-2 border-right" style="width:12%">
 							                <h6 class="text-primary">Request Type</h6><b>
 							                <span class="badge badge-info">{{ schemaRequest.requestOperationType }} Schema</span></b>
 						                </div>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7805,9 +7805,12 @@
           },
           "latest" : {
             "type" : "boolean"
+          },
+          "promoteOnly" : {
+            "type" : "boolean"
           }
         },
-        "required" : [ "compatibility", "content", "env", "id", "latest", "nextVersion", "prevVersion", "showNext", "showPrev", "version" ]
+        "required" : [ "compatibility", "content", "env", "id", "latest", "nextVersion", "prevVersion", "promoteOnly", "showNext", "showPrev", "version" ]
       },
       "SchemaOverview" : {
         "properties" : {


### PR DESCRIPTION
Add a boolean to let the UI know when to show request a new schema or only allow promotion into the environment for schemas.

Removes a check  in the html which always returned true "schemaRequest.requestOperationType !== 'APPROVED'"

Removes an unused autowired service.

About this change - What it does

Resolves: #xxxxx
Why this way
