### PR TITLE
refactor(coral): Improve UI for schema requests per topic

### DIFF
--- a/coral/src/app/components/InternalLinkButton.tsx
+++ b/coral/src/app/components/InternalLinkButton.tsx
@@ -1,12 +1,13 @@
 import { asButton, ButtonProps, Button } from "@aivenio/aquarium";
 import { Link, LinkProps } from "react-router-dom";
 import { ResolveIntersectionTypes } from "types/utils";
+import { ReactNode } from "react";
 
 const AsButton = asButton<"a", LinkProps, HTMLAnchorElement>(Link);
 
 type InternalLinkButtonProps = ResolveIntersectionTypes<
   {
-    children: string;
+    children: string | ReactNode;
     kind?: ButtonProps["kind"];
     disabled?: boolean;
   } & LinkProps

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -26,6 +26,7 @@ jest.mock("react-router-dom", () => ({
 
 const testTopicName = "topic-name";
 const testEnvironmentId = 1;
+
 const testTopicSchemas: TopicSchemaOverview = {
   prefixAclsExists: false,
   txnAclsExists: false,
@@ -55,23 +56,24 @@ const testTopicSchemas: TopicSchemaOverview = {
   },
 };
 
-const noSchema_testTopicSchemas = {
+const noSchema_testTopicSchemas: TopicSchemaOverview = {
   topicExists: true,
   schemaExists: false,
   prefixAclsExists: false,
   txnAclsExists: false,
+  createSchemaAllowed: true,
   allSchemaVersions: [],
   schemaPromotionDetails: {
     status: "NO_PROMOTION",
   },
 };
 
-const noPromotion_testTopicSchemas = {
+const noPromotion_testTopicSchemas: TopicSchemaOverview = {
   topicExists: true,
   schemaExists: true,
   prefixAclsExists: false,
   txnAclsExists: false,
-  createSchemaAllowed: false,
+  createSchemaAllowed: true,
   allSchemaVersions: [3, 2, 1],
   latestVersion: 3,
   schemaPromotionDetails: {
@@ -213,13 +215,13 @@ describe("TopicDetailsSchema", () => {
           topicSchemasIsRefetching: false,
           topicName: testTopicName,
           environmentId: testEnvironmentId,
-          topicSchemas: testTopicSchemas,
+          topicSchemas: { ...testTopicSchemas, createSchemaAllowed: false },
           setSchemaVersion: mockSetSchemaVersion,
           topicOverview: { topicInfo: { topicOwner: true } },
         });
         customRender(
           <AquariumContext>
-            <TopicDetailsSchema createSchemaAllowed={false} />
+            <TopicDetailsSchema />
           </AquariumContext>,
           {
             memoryRouter: true,
@@ -336,13 +338,16 @@ describe("TopicDetailsSchema", () => {
           topicSchemasIsRefetching: false,
           topicName: testTopicName,
           environmentId: testEnvironmentId,
-          topicSchemas: noSchema_testTopicSchemas,
+          topicSchemas: {
+            ...noSchema_testTopicSchemas,
+            createSchemaAllowed: false,
+          },
           setSchemaVersion: mockSetSchemaVersion,
           topicOverview: { topicInfo: { topicOwner: true } },
         });
         customRender(
           <AquariumContext>
-            <TopicDetailsSchema createSchemaAllowed={false} />
+            <TopicDetailsSchema />
           </AquariumContext>,
           {
             memoryRouter: true,

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -256,6 +256,9 @@ describe("TopicDetailsSchema", () => {
         const alert = screen.getByTestId("schema-promotable-only-alert");
 
         expect(alert).toBeInTheDocument();
+        expect(alert).toHaveTextContent(
+          "You can't create a new schema or new version for it here."
+        );
       });
     });
 
@@ -387,6 +390,9 @@ describe("TopicDetailsSchema", () => {
         const alert = screen.getByTestId("schema-promotable-only-alert");
 
         expect(alert).toBeInTheDocument();
+        expect(alert).toHaveTextContent(
+          "To add a schema to this topic, create a request in the lower environment"
+        );
       });
     });
 

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -1,11 +1,11 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen } from "@testing-library/react";
 import { within } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
 import { TopicDetailsSchema } from "src/app/features/topics/details/schema/TopicDetailsSchema";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { TopicSchemaOverview } from "src/domain/topic";
 import { requestSchemaPromotion } from "src/domain/schema-request";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("src/domain/schema-request/schema-request-api.ts");
 const mockPromoteSchemaRequest = requestSchemaPromotion as jest.MockedFunction<
@@ -17,6 +17,12 @@ jest.mock("src/app/features/topics/details/TopicDetails", () => ({
   useTopicDetails: () => mockedUseTopicDetails(),
 }));
 const mockSetSchemaVersion = jest.fn();
+
+const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
 
 const testTopicName = "topic-name";
 const testEnvironmentId = 1;
@@ -49,6 +55,17 @@ const testTopicSchemas: TopicSchemaOverview = {
   },
 };
 
+const noSchema_testTopicSchemas = {
+  topicExists: true,
+  schemaExists: false,
+  prefixAclsExists: false,
+  txnAclsExists: false,
+  allSchemaVersions: [],
+  schemaPromotionDetails: {
+    status: "NO_PROMOTION",
+  },
+};
+
 const noPromotion_testTopicSchemas = {
   topicExists: true,
   schemaExists: true,
@@ -78,166 +95,8 @@ const noPromotion_testTopicSchemas = {
 describe("TopicDetailsSchema", () => {
   const user = userEvent.setup();
 
-  describe("renders right view for topic owner when schema is not promoteOnly", () => {
-    beforeAll(() => {
-      mockPromoteSchemaRequest.mockResolvedValue({
-        success: true,
-        message: "",
-      });
-      mockedUseTopicDetails.mockReturnValue({
-        topicOverviewIsRefetching: false,
-        topicSchemasIsRefetching: false,
-        topicName: testTopicName,
-        environmentId: testEnvironmentId,
-        topicSchemas: testTopicSchemas,
-        setSchemaVersion: mockSetSchemaVersion,
-        topicOverview: { topicInfo: { topicOwner: true } },
-      });
-      customRender(
-        <AquariumContext>
-          <TopicDetailsSchema />
-        </AquariumContext>,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
-    });
-
-    afterAll(() => {
-      cleanup();
-      jest.clearAllMocks();
-    });
-
-    it("shows a headline", () => {
-      const headline = screen.getByRole("heading", { name: "Schema" });
-
-      expect(headline).toBeVisible();
-    });
-
-    it("shows a select element to choose version", () => {
-      const select = screen.getByRole("combobox", { name: "Select version" });
-
-      expect(select).toBeEnabled();
-    });
-
-    it("shows all options", () => {
-      const select = screen.getByRole("combobox", { name: "Select version" });
-      const options = within(select).getAllByRole("option");
-
-      expect(options).toHaveLength(3);
-      expect(options[0]).toHaveValue("3");
-      expect(options[0]).toHaveTextContent("Version 3 (latest)");
-    });
-
-    it("shows information about available amount of versions", () => {
-      const versions = screen.getByText("3 versions");
-
-      expect(versions).toBeVisible();
-    });
-
-    it("shows a link to request a new schema version", () => {
-      const link = screen.getByRole("link", {
-        name: "Request a new version",
-      });
-
-      // schemaDetailsPerEnv could be undefined based on its type,
-      // but it's always defined for the test here
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      const environment = testTopicSchemas.schemaDetailsPerEnv.env;
-
-      expect(link).toBeVisible();
-      expect(link).toHaveAttribute(
-        "href",
-        `/topic/${testTopicName}/request-schema?env=${environment}`
-      );
-    });
-
-    it("shows schema statistic about versions", () => {
-      const versionsStats = screen.getByText("Version no.");
-
-      expect(versionsStats).toBeVisible();
-      expect(versionsStats.parentElement).toHaveTextContent("3Version no.");
-    });
-
-    it("shows schema info about ID", () => {
-      const idInfo = screen.getByText("ID");
-
-      expect(idInfo).toBeVisible();
-      expect(idInfo.parentElement).toHaveTextContent("0ID");
-    });
-
-    it("shows schema info about compatibility", () => {
-      const compatibilityInfo = screen.getByText("Compatibility");
-
-      expect(compatibilityInfo).toBeVisible();
-      expect(compatibilityInfo.parentElement).toHaveTextContent(
-        "COULDN'T RETRIEVECompatibility"
-      );
-    });
-
-    it("shows an editor with preview of the schema", () => {
-      const previewEditor = screen.getByTestId("topic-schema");
-
-      expect(previewEditor).toBeVisible();
-    });
-  });
-
-  describe("renders right view for topic owner when schema is promoteOnly", () => {
-    beforeAll(() => {
-      mockPromoteSchemaRequest.mockResolvedValue({
-        success: true,
-        message: "",
-      });
-      mockedUseTopicDetails.mockReturnValue({
-        topicOverviewIsRefetching: false,
-        topicSchemasIsRefetching: false,
-        topicName: testTopicName,
-        environmentId: testEnvironmentId,
-        topicSchemas: {
-          ...testTopicSchemas,
-          schemaDetailsPerEnv: {
-            ...testTopicSchemas.schemaDetailsPerEnv,
-            promoteOnly: true,
-          },
-        },
-        setSchemaVersion: mockSetSchemaVersion,
-        topicOverview: { topicInfo: { topicOwner: true } },
-      });
-      customRender(
-        <AquariumContext>
-          <TopicDetailsSchema />
-        </AquariumContext>,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
-    });
-
-    afterAll(() => {
-      cleanup();
-      jest.clearAllMocks();
-    });
-
-    it("shows a headline", () => {
-      const headline = screen.getByRole("heading", { name: "Schema" });
-
-      expect(headline).toBeVisible();
-    });
-
-    it("shows no link to request a new schema version", () => {
-      const link = screen.queryByRole("link", {
-        name: "Request a new version",
-      });
-
-      expect(link).not.toBeInTheDocument();
-    });
-  });
-
-  describe("shows promotion details to topic owner", () => {
-    describe("shows when promotion is possible", () => {
+  describe("renders correct views for topic owner", () => {
+    describe("when topic has (multiple) schema(s)", () => {
       beforeAll(() => {
         mockPromoteSchemaRequest.mockResolvedValue({
           success: true,
@@ -268,47 +127,82 @@ describe("TopicDetailsSchema", () => {
         jest.clearAllMocks();
       });
 
-      it("shows information about possible promotion", () => {
-        const infoText = screen.getByText(
-          `This schema has not yet been promoted to the ${testTopicSchemas.schemaPromotionDetails.targetEnv} environment.`
-        );
+      it("shows a headline", () => {
+        const headline = screen.getByRole("heading", { name: "Schema" });
 
-        expect(infoText).toBeVisible();
+        expect(headline).toBeVisible();
       });
 
-      it("shows a button to promote schema", () => {
-        const button = screen.getByRole("button", { name: "Promote" });
+      it("shows a select element to choose version", () => {
+        const select = screen.getByRole("combobox", { name: "Select version" });
 
-        expect(button).toBeEnabled();
+        expect(select).toBeEnabled();
       });
 
-      it("shows a modal to promote schema when clicking on the Promote schema button", async () => {
-        const button = screen.getByRole("button", { name: "Promote" });
+      it("shows all options", () => {
+        const select = screen.getByRole("combobox", { name: "Select version" });
+        const options = within(select).getAllByRole("option");
 
-        await userEvent.click(button);
-
-        expect(screen.getByRole("dialog")).toBeVisible();
+        expect(options).toHaveLength(3);
+        expect(options[0]).toHaveValue("3");
+        expect(options[0]).toHaveTextContent("Version 3 (latest)");
       });
 
-      it("shows information about schema promotion", () => {
-        const promotionBanner = screen.getByTestId("schema-promotion-banner");
-        const infoText = within(promotionBanner).getByText(
-          "This schema has not yet been promoted",
-          {
-            exact: false,
-          }
-        );
-        const button = within(promotionBanner).getByRole("button", {
-          name: "Promote",
+      it("shows information about available amount of versions", () => {
+        const versions = screen.getByText("3 versions");
+
+        expect(versions).toBeVisible();
+      });
+
+      it("shows a link to request a new schema version", () => {
+        const link = screen.getByRole("link", {
+          name: "Request a new version",
         });
 
-        expect(promotionBanner).toBeVisible();
-        expect(infoText).toBeVisible();
-        expect(button).toBeEnabled();
+        // schemaDetailsPerEnv could be undefined based on its type,
+        // but it's always defined for the test here
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        const environment = testTopicSchemas.schemaDetailsPerEnv.env;
+
+        expect(link).toBeVisible();
+        expect(link).toHaveAttribute(
+          "href",
+          `/topic/${testTopicName}/request-schema?env=${environment}`
+        );
+      });
+
+      it("shows schema statistic about versions", () => {
+        const versionsStats = screen.getByText("Version no.");
+
+        expect(versionsStats).toBeVisible();
+        expect(versionsStats.parentElement).toHaveTextContent("3Version no.");
+      });
+
+      it("shows schema info about ID", () => {
+        const idInfo = screen.getByText("ID");
+
+        expect(idInfo).toBeVisible();
+        expect(idInfo.parentElement).toHaveTextContent("0ID");
+      });
+
+      it("shows schema info about compatibility", () => {
+        const compatibilityInfo = screen.getByText("Compatibility");
+
+        expect(compatibilityInfo).toBeVisible();
+        expect(compatibilityInfo.parentElement).toHaveTextContent(
+          "COULDN'T RETRIEVECompatibility"
+        );
+      });
+
+      it("shows an editor with preview of the schema", () => {
+        const previewEditor = screen.getByTestId("topic-schema");
+
+        expect(previewEditor).toBeVisible();
       });
     });
 
-    describe("shows when promotion is not available right now", () => {
+    describe("when topic has no schema yet", () => {
       beforeAll(() => {
         mockPromoteSchemaRequest.mockResolvedValue({
           success: true,
@@ -319,14 +213,9 @@ describe("TopicDetailsSchema", () => {
           topicSchemasIsRefetching: false,
           topicName: testTopicName,
           environmentId: testEnvironmentId,
-          topicSchemas: testTopicSchemas,
+          topicSchemas: noSchema_testTopicSchemas,
           setSchemaVersion: mockSetSchemaVersion,
-          topicOverview: {
-            topicInfo: {
-              topicOwner: true,
-              hasOpenSchemaRequest: true,
-            },
-          },
+          topicOverview: { topicInfo: { topicOwner: true } },
         });
         customRender(
           <AquariumContext>
@@ -344,25 +233,370 @@ describe("TopicDetailsSchema", () => {
         jest.clearAllMocks();
       });
 
-      it("shows information why schema request is not possible", () => {
-        const promotionBanner = screen.getByTestId("schema-promotion-banner");
+      it("shows a headline", () => {
+        const headline = screen.getByRole("heading", { name: "Schema" });
 
-        expect(promotionBanner).toBeVisible();
-        expect(promotionBanner.textContent).toContain(
-          "topic-name has a pending request."
+        expect(headline).toBeVisible();
+      });
+
+      it("shows information that there is no schema yet", () => {
+        const text = screen.getByText("No schema available for this topic");
+
+        expect(text).toBeVisible();
+      });
+
+      it("shows button to request a new schema", () => {
+        const button = screen.getByRole("button", {
+          name: "Request a new schema",
+        });
+
+        expect(button).toBeEnabled();
+      });
+
+      it("shows no select element for versions", () => {
+        const select = screen.queryByRole("combobox", {
+          name: "Select version",
+        });
+
+        expect(select).not.toBeInTheDocument();
+      });
+
+      it("shows no link to request a new schema version", () => {
+        const link = screen.queryByRole("link", {
+          name: "Request a new version",
+        });
+
+        expect(link).not.toBeInTheDocument();
+      });
+    });
+
+    describe("shows promotion details to topic owner", () => {
+      describe("shows when promotion is possible", () => {
+        beforeAll(() => {
+          mockPromoteSchemaRequest.mockResolvedValue({
+            success: true,
+            message: "",
+          });
+          mockedUseTopicDetails.mockReturnValue({
+            topicOverviewIsRefetching: false,
+            topicSchemasIsRefetching: false,
+            topicName: testTopicName,
+            environmentId: testEnvironmentId,
+            topicSchemas: testTopicSchemas,
+            setSchemaVersion: mockSetSchemaVersion,
+            topicOverview: { topicInfo: { topicOwner: true } },
+          });
+          customRender(
+            <AquariumContext>
+              <TopicDetailsSchema />
+            </AquariumContext>,
+            {
+              memoryRouter: true,
+              queryClient: true,
+            }
+          );
+        });
+
+        afterAll(() => {
+          cleanup();
+          jest.clearAllMocks();
+        });
+
+        it("shows information about possible promotion", () => {
+          const infoText = screen.getByText(
+            `This schema has not yet been promoted to the ${testTopicSchemas.schemaPromotionDetails.targetEnv} environment.`
+          );
+
+          expect(infoText).toBeVisible();
+        });
+
+        it("shows a button to promote schema", () => {
+          const button = screen.getByRole("button", { name: "Promote" });
+
+          expect(button).toBeEnabled();
+        });
+
+        it("shows a modal to promote schema when clicking on the Promote schema button", async () => {
+          const button = screen.getByRole("button", { name: "Promote" });
+
+          await user.click(button);
+
+          expect(screen.getByRole("dialog")).toBeVisible();
+        });
+
+        it("shows information about schema promotion", () => {
+          const promotionBanner = screen.getByTestId("schema-promotion-banner");
+          const infoText = within(promotionBanner).getByText(
+            "This schema has not yet been promoted",
+            {
+              exact: false,
+            }
+          );
+          const button = within(promotionBanner).getByRole("button", {
+            name: "Promote",
+          });
+
+          expect(promotionBanner).toBeVisible();
+          expect(infoText).toBeVisible();
+          expect(button).toBeEnabled();
+        });
+      });
+
+      describe("shows when promotion is not available right now", () => {
+        beforeAll(() => {
+          mockPromoteSchemaRequest.mockResolvedValue({
+            success: true,
+            message: "",
+          });
+          mockedUseTopicDetails.mockReturnValue({
+            topicOverviewIsRefetching: false,
+            topicSchemasIsRefetching: false,
+            topicName: testTopicName,
+            environmentId: testEnvironmentId,
+            topicSchemas: testTopicSchemas,
+            setSchemaVersion: mockSetSchemaVersion,
+            topicOverview: {
+              topicInfo: {
+                topicOwner: true,
+                hasOpenSchemaRequest: true,
+              },
+            },
+          });
+          customRender(
+            <AquariumContext>
+              <TopicDetailsSchema />
+            </AquariumContext>,
+            {
+              memoryRouter: true,
+              queryClient: true,
+            }
+          );
+        });
+
+        afterAll(() => {
+          cleanup();
+          jest.clearAllMocks();
+        });
+
+        it("shows information why schema request is not possible", () => {
+          const promotionBanner = screen.getByTestId("schema-promotion-banner");
+
+          expect(promotionBanner).toBeVisible();
+          expect(promotionBanner.textContent).toContain(
+            "topic-name has a pending request."
+          );
+        });
+
+        it("shows no button to promote the schema", () => {
+          const button = screen.queryByRole("button", { name: "Promote" });
+
+          expect(button).not.toBeInTheDocument();
+        });
+
+        it("shows a link to see open schema requests", () => {
+          const link = screen.getByRole("link", { name: "View request" });
+
+          expect(link).toBeVisible();
+        });
+      });
+    });
+
+    describe("shows correct state when data is updating", () => {
+      beforeAll(() => {
+        mockedUseTopicDetails.mockReturnValue({
+          topicOverviewIsRefetching: false,
+          topicSchemasIsRefetching: true,
+          topicName: testTopicName,
+          environmentId: testEnvironmentId,
+          topicSchemas: testTopicSchemas,
+          setSchemaVersion: mockSetSchemaVersion,
+          topicOverview: { topicInfo: { topicOwner: true } },
+        });
+        customRender(
+          <AquariumContext>
+            <TopicDetailsSchema />
+          </AquariumContext>,
+          {
+            memoryRouter: true,
+            queryClient: true,
+          }
         );
       });
 
-      it("shows no button to promote the schema", () => {
+      afterAll(() => {
+        cleanup();
+        jest.clearAllMocks();
+      });
+
+      it("shows no select element to choose version", () => {
+        const select = screen.queryByRole("combobox", {
+          name: "Select version",
+        });
+
+        expect(select).not.toBeInTheDocument();
+      });
+
+      it("shows accessible information that versions are loading", () => {
+        const loadingInformation = screen.getByText("Versions loading");
+
+        expect(loadingInformation).toBeVisible();
+        expect(loadingInformation).toHaveClass("visually-hidden");
+      });
+
+      it("shows no information about available amount of versions", () => {
+        const versions = screen.queryByText("3 versions");
+
+        expect(versions).not.toBeInTheDocument();
+      });
+
+      it("shows a no link to request a new schema version", () => {
+        const link = screen.queryByRole("link", {
+          name: "Request a new version",
+        });
+
+        expect(link).not.toBeInTheDocument();
+      });
+
+      it("shows no information about possible promotion", () => {
+        const infoText = screen.queryByText(
+          `This schema has not yet been promoted to the ${testTopicSchemas.schemaPromotionDetails.targetEnv} environment.`
+        );
+
+        expect(infoText).not.toBeInTheDocument();
+      });
+
+      it("shows no button to promote schema", () => {
         const button = screen.queryByRole("button", { name: "Promote" });
 
         expect(button).not.toBeInTheDocument();
       });
 
-      it("shows a link to see open schema requests", () => {
-        const link = screen.getByRole("link", { name: "View request" });
+      it("shows schema statistic about versions", () => {
+        const versionsStats = screen.getByText("Version no.");
 
-        expect(link).toBeVisible();
+        expect(versionsStats).toBeVisible();
+        expect(versionsStats.parentElement).toHaveTextContent(
+          "Loading informationVersion no."
+        );
+      });
+
+      it("shows schema info about ID", () => {
+        const idInfo = screen.getByText("ID");
+
+        expect(idInfo).toBeVisible();
+        expect(idInfo.parentElement).toHaveTextContent("Loading informationID");
+      });
+
+      it("shows schema info about compatibility", () => {
+        const compatibilityInfo = screen.getByText("Compatibility");
+
+        expect(compatibilityInfo).toBeVisible();
+        expect(compatibilityInfo.parentElement).toHaveTextContent(
+          "Loading informationCompatibility"
+        );
+      });
+
+      it("shows no editor with preview of the schema", () => {
+        const previewEditor = screen.queryByTestId("topic-schema");
+
+        expect(previewEditor).not.toBeInTheDocument();
+      });
+
+      it("shows accessible loading information for preview", () => {
+        const loadingPreview = screen.getByText("Loading schema preview");
+
+        expect(loadingPreview).toBeVisible();
+        expect(loadingPreview).toHaveClass("visually-hidden");
+      });
+    });
+  });
+
+  describe("renders right view for user that is not topic owner", () => {
+    beforeAll(() => {
+      mockedUseTopicDetails.mockReturnValue({
+        topicOverviewIsRefetching: false,
+        topicSchemasIsRefetching: false,
+        topicName: testTopicName,
+        environmentId: testEnvironmentId,
+        topicSchemas: testTopicSchemas,
+        setSchemaVersion: mockSetSchemaVersion,
+        topicOverview: { topicInfo: { topicOwner: false } },
+      });
+      customRender(
+        <AquariumContext>
+          <TopicDetailsSchema />
+        </AquariumContext>,
+        {
+          memoryRouter: true,
+          queryClient: true,
+        }
+      );
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("does not show a link to request a new schema version", () => {
+      const link = screen.queryByRole("link", {
+        name: "Request a new version",
+      });
+
+      expect(link).not.toBeInTheDocument();
+    });
+
+    it("does not show information about schema promotion", () => {
+      const promotionBanner = screen.queryByTestId("schema-promotion-banner");
+      const button = screen.queryByRole("button", { name: "Promote" });
+
+      expect(promotionBanner).not.toBeInTheDocument();
+      expect(button).not.toBeInTheDocument();
+    });
+
+    describe("TopicDetailsSchema (status: NO_PROMOTION)", () => {
+      beforeAll(() => {
+        mockedUseTopicDetails.mockReturnValue({
+          topicOverviewIsRefetching: false,
+          topicSchemasIsRefetching: false,
+          topicName: testTopicName,
+          environmentId: testEnvironmentId,
+          topicSchemas: noPromotion_testTopicSchemas,
+          setSchemaVersion: mockSetSchemaVersion,
+          topicOverview: { topicInfo: { topicOwner: true } },
+        });
+        customRender(
+          <AquariumContext>
+            <TopicDetailsSchema />
+          </AquariumContext>,
+          {
+            memoryRouter: true,
+            queryClient: true,
+          }
+        );
+      });
+
+      afterAll(cleanup);
+
+      it("does not show a link to request a new schema version", () => {
+        const link = screen.queryByRole("link", {
+          name: "Request a new version",
+        });
+
+        expect(link).toBeInTheDocument();
+      });
+
+      it("does not show information about schema promotion", () => {
+        const banner = screen.queryByText(
+          "This schema has not yet been promoted",
+          {
+            exact: false,
+          }
+        );
+        const button = screen.queryByRole("button", { name: "Promote" });
+
+        expect(banner).not.toBeInTheDocument();
+        expect(button).not.toBeInTheDocument();
       });
     });
   });
@@ -400,11 +634,54 @@ describe("TopicDetailsSchema", () => {
 
     it("allows changing the version of the schema", async () => {
       const select = screen.getByRole("combobox", { name: "Select version" });
-      await userEvent.selectOptions(select, "2");
+      await user.selectOptions(select, "2");
 
       expect(select).toHaveValue("2");
 
       expect(mockSetSchemaVersion).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe("enables topic owner to request a new schema", () => {
+    beforeEach(() => {
+      mockPromoteSchemaRequest.mockResolvedValue({
+        success: true,
+        message: "",
+      });
+      mockedUseTopicDetails.mockReturnValue({
+        topicOverviewIsRefetching: false,
+        topicSchemasIsRefetching: false,
+        topicName: testTopicName,
+        environmentId: testEnvironmentId,
+        topicSchemas: noSchema_testTopicSchemas,
+        setSchemaVersion: mockSetSchemaVersion,
+        topicOverview: { topicInfo: { topicOwner: true } },
+      });
+      customRender(
+        <AquariumContext>
+          <TopicDetailsSchema />
+        </AquariumContext>,
+        {
+          memoryRouter: true,
+          queryClient: true,
+        }
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("navigates user to correct form", async () => {
+      const button = screen.getByRole("button", {
+        name: "Request a new schema",
+      });
+      await user.click(button);
+
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        "/topic/topic-name/request-schema"
+      );
     });
   });
 
@@ -495,203 +772,6 @@ describe("TopicDetailsSchema", () => {
       expect(console.error).toHaveBeenCalledWith({
         success: false,
         message: "Oh no",
-      });
-    });
-  });
-
-  describe("renders right view for topic owner when data is updating", () => {
-    beforeAll(() => {
-      mockedUseTopicDetails.mockReturnValue({
-        topicOverviewIsRefetching: false,
-        topicSchemasIsRefetching: true,
-        topicName: testTopicName,
-        environmentId: testEnvironmentId,
-        topicSchemas: testTopicSchemas,
-        setSchemaVersion: mockSetSchemaVersion,
-        topicOverview: { topicInfo: { topicOwner: true } },
-      });
-      customRender(
-        <AquariumContext>
-          <TopicDetailsSchema />
-        </AquariumContext>,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
-    });
-
-    afterAll(() => {
-      cleanup();
-      jest.clearAllMocks();
-    });
-
-    it("shows no select element to choose version", () => {
-      const select = screen.queryByRole("combobox", { name: "Select version" });
-
-      expect(select).not.toBeInTheDocument();
-    });
-
-    it("shows accessible information that versions are loading", () => {
-      const loadingInformation = screen.getByText("Versions loading");
-
-      expect(loadingInformation).toBeVisible();
-      expect(loadingInformation).toHaveClass("visually-hidden");
-    });
-
-    it("shows no information about available amount of versions", () => {
-      const versions = screen.queryByText("3 versions");
-
-      expect(versions).not.toBeInTheDocument();
-    });
-
-    it("shows a no link to request a new schema version", () => {
-      const link = screen.queryByRole("link", {
-        name: "Request a new version",
-      });
-
-      expect(link).not.toBeInTheDocument();
-    });
-
-    it("shows no information about possible promotion", () => {
-      const infoText = screen.queryByText(
-        `This schema has not yet been promoted to the ${testTopicSchemas.schemaPromotionDetails.targetEnv} environment.`
-      );
-
-      expect(infoText).not.toBeInTheDocument();
-    });
-
-    it("shows no button to promote schema", () => {
-      const button = screen.queryByRole("button", { name: "Promote" });
-
-      expect(button).not.toBeInTheDocument();
-    });
-
-    it("shows schema statistic about versions", () => {
-      const versionsStats = screen.getByText("Version no.");
-
-      expect(versionsStats).toBeVisible();
-      expect(versionsStats.parentElement).toHaveTextContent(
-        "Loading informationVersion no."
-      );
-    });
-
-    it("shows schema info about ID", () => {
-      const idInfo = screen.getByText("ID");
-
-      expect(idInfo).toBeVisible();
-      expect(idInfo.parentElement).toHaveTextContent("Loading informationID");
-    });
-
-    it("shows schema info about compatibility", () => {
-      const compatibilityInfo = screen.getByText("Compatibility");
-
-      expect(compatibilityInfo).toBeVisible();
-      expect(compatibilityInfo.parentElement).toHaveTextContent(
-        "Loading informationCompatibility"
-      );
-    });
-
-    it("shows no editor with preview of the schema", () => {
-      const previewEditor = screen.queryByTestId("topic-schema");
-
-      expect(previewEditor).not.toBeInTheDocument();
-    });
-
-    it("shows accessible loading information for preview", () => {
-      const loadingPreview = screen.getByText("Loading schema preview");
-
-      expect(loadingPreview).toBeVisible();
-      expect(loadingPreview).toHaveClass("visually-hidden");
-    });
-  });
-
-  describe("renders right view for user that is not topic owner", () => {
-    beforeAll(() => {
-      mockedUseTopicDetails.mockReturnValue({
-        topicOverviewIsRefetching: false,
-        topicSchemasIsRefetching: false,
-        topicName: testTopicName,
-        environmentId: testEnvironmentId,
-        topicSchemas: testTopicSchemas,
-        setSchemaVersion: mockSetSchemaVersion,
-        topicOverview: { topicInfo: { topicOwner: false } },
-      });
-      customRender(
-        <AquariumContext>
-          <TopicDetailsSchema />
-        </AquariumContext>,
-        {
-          memoryRouter: true,
-          queryClient: true,
-        }
-      );
-    });
-
-    afterAll(() => {
-      cleanup();
-      jest.clearAllMocks();
-    });
-
-    it("does not show a link to request a new schema version", () => {
-      const link = screen.queryByRole("link", {
-        name: "Request a new version",
-      });
-
-      expect(link).not.toBeInTheDocument();
-    });
-
-    it("does not show information about schema promotion", () => {
-      const promotionBanner = screen.queryByTestId("schema-promotion-banner");
-      const button = screen.queryByRole("button", { name: "Promote" });
-
-      expect(promotionBanner).not.toBeInTheDocument();
-      expect(button).not.toBeInTheDocument();
-    });
-
-    describe("TopicDetailsSchema (status: NO_PROMOTION)", () => {
-      beforeAll(() => {
-        mockedUseTopicDetails.mockReturnValue({
-          topicOverviewIsRefetching: false,
-          topicSchemasIsRefetching: false,
-          topicName: testTopicName,
-          environmentId: testEnvironmentId,
-          topicSchemas: noPromotion_testTopicSchemas,
-          setSchemaVersion: mockSetSchemaVersion,
-          topicOverview: { topicInfo: { topicOwner: true } },
-        });
-        customRender(
-          <AquariumContext>
-            <TopicDetailsSchema />
-          </AquariumContext>,
-          {
-            memoryRouter: true,
-            queryClient: true,
-          }
-        );
-      });
-
-      afterAll(cleanup);
-
-      it("does not show a link to request a new schema version", () => {
-        const link = screen.queryByRole("link", {
-          name: "Request a new version",
-        });
-
-        expect(link).toBeInTheDocument();
-      });
-
-      it("does not show information about schema promotion", () => {
-        const banner = screen.queryByText(
-          "This schema has not yet been promoted",
-          {
-            exact: false,
-          }
-        );
-        const button = screen.queryByRole("button", { name: "Promote" });
-
-        expect(banner).not.toBeInTheDocument();
-        expect(button).not.toBeInTheDocument();
       });
     });
   });

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -78,7 +78,7 @@ const noPromotion_testTopicSchemas = {
 describe("TopicDetailsSchema", () => {
   const user = userEvent.setup();
 
-  describe("renders right view for topic owner", () => {
+  describe("renders right view for topic owner when schema is not promoteOnly", () => {
     beforeAll(() => {
       mockPromoteSchemaRequest.mockResolvedValue({
         success: true,
@@ -181,6 +181,58 @@ describe("TopicDetailsSchema", () => {
       const previewEditor = screen.getByTestId("topic-schema");
 
       expect(previewEditor).toBeVisible();
+    });
+  });
+
+  describe("renders right view for topic owner when schema is promoteOnly", () => {
+    beforeAll(() => {
+      mockPromoteSchemaRequest.mockResolvedValue({
+        success: true,
+        message: "",
+      });
+      mockedUseTopicDetails.mockReturnValue({
+        topicOverviewIsRefetching: false,
+        topicSchemasIsRefetching: false,
+        topicName: testTopicName,
+        environmentId: testEnvironmentId,
+        topicSchemas: {
+          ...testTopicSchemas,
+          schemaDetailsPerEnv: {
+            ...testTopicSchemas.schemaDetailsPerEnv,
+            promoteOnly: true,
+          },
+        },
+        setSchemaVersion: mockSetSchemaVersion,
+        topicOverview: { topicInfo: { topicOwner: true } },
+      });
+      customRender(
+        <AquariumContext>
+          <TopicDetailsSchema />
+        </AquariumContext>,
+        {
+          memoryRouter: true,
+          queryClient: true,
+        }
+      );
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("shows a headline", () => {
+      const headline = screen.getByRole("heading", { name: "Schema" });
+
+      expect(headline).toBeVisible();
+    });
+
+    it("shows no link to request a new schema version", () => {
+      const link = screen.queryByRole("link", {
+        name: "Request a new version",
+      });
+
+      expect(link).not.toBeInTheDocument();
     });
   });
 

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -199,7 +199,10 @@ function TopicDetailsSchema() {
       </Box>
 
       {!createSchemaAllowed && (
-        <SchemaPromotableOnlyAlert marginBottom={"l2"} />
+        <SchemaPromotableOnlyAlert
+          marginBottom={"l2"}
+          isNewVersionRequest={true}
+        />
       )}
       {!topicSchemasIsRefetching && isTopicOwner && (
         <SchemaPromotionBanner

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -168,17 +168,19 @@ function TopicDetailsSchema() {
           )}
         </Box>
 
-        {!topicSchemasIsRefetching && isTopicOwner && (
-          <Box alignSelf={"top"}>
-            <Link
-              to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv.env}`}
-            >
-              <Button.Primary icon={add} disabled={topicSchemasIsRefetching}>
-                Request a new version
-              </Button.Primary>
-            </Link>
-          </Box>
-        )}
+        {!topicSchemasIsRefetching &&
+          isTopicOwner &&
+          !schemaDetailsPerEnv?.promoteOnly && (
+            <Box alignSelf={"top"}>
+              <Link
+                to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv.env}`}
+              >
+                <Button.Primary icon={add} disabled={topicSchemasIsRefetching}>
+                  Request a new version
+                </Button.Primary>
+              </Link>
+            </Box>
+          )}
       </Box>
 
       {!topicSchemasIsRefetching && isTopicOwner && (

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -32,7 +32,7 @@ import { SchemaPromotableOnlyAlert } from "src/app/features/topics/details/schem
 
 //@ TODO change to api response value
 // eslint-disable-next-line react/prop-types
-function TopicDetailsSchema({ createSchemaAllowed = true }) {
+function TopicDetailsSchema() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
@@ -43,6 +43,7 @@ function TopicDetailsSchema({ createSchemaAllowed = true }) {
       latestVersion,
       schemaDetailsPerEnv,
       schemaPromotionDetails,
+      createSchemaAllowed,
     },
     topicSchemasIsRefetching,
     setSchemaVersion,

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -28,8 +28,11 @@ import { HTTPError } from "src/services/api";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
 import { InternalLinkButton } from "src/app/components/InternalLinkButton";
+import { SchemaPromotableOnlyAlert } from "src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert";
 
-function TopicDetailsSchema() {
+//@ TODO change to api response value
+// eslint-disable-next-line react/prop-types
+function TopicDetailsSchema({ createSchemaAllowed = true }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
@@ -112,9 +115,11 @@ function TopicDetailsSchema() {
           primaryAction={{
             onClick: () => navigate(`/topic/${topicName}/request-schema`),
             text: "Request a new schema",
-            disabled: topicSchemasIsRefetching,
+            disabled: topicSchemasIsRefetching || !createSchemaAllowed,
           }}
-        ></EmptyState>
+        >
+          {!createSchemaAllowed && <SchemaPromotableOnlyAlert />}
+        </EmptyState>
       </>
     );
   }
@@ -170,9 +175,12 @@ function TopicDetailsSchema() {
         </Box>
 
         {!topicSchemasIsRefetching && isTopicOwner && (
-          <Box alignSelf={"top"}>
+          // In case user can not create a new schema, we don't want the disabled "link" to show up
+          // as it makes it harder to convey the information for assistive technology
+          <Box alignSelf={"top"} aria-hidden={!createSchemaAllowed}>
             <InternalLinkButton
               to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv.env}`}
+              disabled={!createSchemaAllowed}
             >
               <Box.Flex component={"span"} alignItems={"center"} colGap={"3"}>
                 <InlineIcon
@@ -189,6 +197,9 @@ function TopicDetailsSchema() {
         )}
       </Box>
 
+      {!createSchemaAllowed && (
+        <SchemaPromotableOnlyAlert marginBottom={"l2"} />
+      )}
       {!topicSchemasIsRefetching && isTopicOwner && (
         <SchemaPromotionBanner
           schemaPromotionDetails={schemaPromotionDetails}

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   EmptyState,
   Icon,
   Label,
@@ -10,13 +9,14 @@ import {
   TextareaBase,
   Typography,
   useToast,
+  InlineIcon,
 } from "@aivenio/aquarium";
 import add from "@aivenio/aquarium/icons/add";
 import gitNewBranch from "@aivenio/aquarium/icons/gitNewBranch";
 import MonacoEditor from "@monaco-editor/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { SchemaPromotionModal } from "src/app/features/topics/details/schema/components/SchemaPromotionModal";
 import { SchemaStats } from "src/app/features/topics/details/schema/components/SchemaStats";
@@ -27,6 +27,7 @@ import {
 import { HTTPError } from "src/services/api";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
+import { InternalLinkButton } from "src/app/components/InternalLinkButton";
 
 function TopicDetailsSchema() {
   const queryClient = useQueryClient();
@@ -113,7 +114,7 @@ function TopicDetailsSchema() {
             text: "Request a new schema",
             disabled: topicSchemasIsRefetching,
           }}
-        />
+        ></EmptyState>
       </>
     );
   }
@@ -168,19 +169,24 @@ function TopicDetailsSchema() {
           )}
         </Box>
 
-        {!topicSchemasIsRefetching &&
-          isTopicOwner &&
-          !schemaDetailsPerEnv?.promoteOnly && (
-            <Box alignSelf={"top"}>
-              <Link
-                to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv.env}`}
-              >
-                <Button.Primary icon={add} disabled={topicSchemasIsRefetching}>
-                  Request a new version
-                </Button.Primary>
-              </Link>
-            </Box>
-          )}
+        {!topicSchemasIsRefetching && isTopicOwner && (
+          <Box alignSelf={"top"}>
+            <InternalLinkButton
+              to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv.env}`}
+            >
+              <Box.Flex component={"span"} alignItems={"center"} colGap={"3"}>
+                <InlineIcon
+                  icon={add}
+                  scale={2}
+                  style={{
+                    fontSize: "20px",
+                  }}
+                />{" "}
+                Request a new version
+              </Box.Flex>
+            </InternalLinkButton>
+          </Box>
+        )}
       </Box>
 
       {!topicSchemasIsRefetching && isTopicOwner && (

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.test.tsx
@@ -2,28 +2,56 @@ import { render, cleanup, screen } from "@testing-library/react";
 import { SchemaPromotableOnlyAlert } from "src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert";
 
 describe("SchemaPromotableOnlyAlert", () => {
-  beforeAll(() => {
-    render(<SchemaPromotableOnlyAlert />);
+  describe("renders the default alert", () => {
+    beforeAll(() => {
+      render(<SchemaPromotableOnlyAlert />);
+    });
+    afterAll(cleanup);
+
+    it("renders information that schema has to be promoted to higher env", () => {
+      const alert = screen.getByTestId("schema-promotable-only-alert");
+
+      expect(alert).toBeVisible();
+      expect(alert).toHaveTextContent(
+        "Schemas are created in lower environments and promoted to higher environment. To add a schema to this topic, create a request in the lower environment and promote it to the higher one. Learn more."
+      );
+    });
+
+    it("shows link to documentation", () => {
+      const link = screen.getByRole("link", { name: "Learn more" });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "https://www.klaw-project.io/docs/Concepts/promotion#schema-promotion"
+      );
+    });
   });
-  afterAll(cleanup);
 
-  it("renders information that schema has to be promoted to higher env", () => {
-    const alert = screen.getByTestId("schema-promotable-only-alert");
+  describe("renders the alert for a new schema version", () => {
+    beforeAll(() => {
+      render(<SchemaPromotableOnlyAlert isNewVersionRequest={true} />);
+    });
 
-    expect(alert).toBeVisible();
-    expect(alert).toHaveTextContent(
-      "Users are not allowed to request a new schema in this environment. To add a schema, promote the schema from a" +
-        " lower environment. Learn more."
-    );
-  });
+    afterAll(cleanup);
 
-  it("shows link to documentation", () => {
-    const link = screen.getByRole("link", { name: "Learn more" });
+    it("renders information that schema has to be promoted to higher env", () => {
+      const alert = screen.getByTestId("schema-promotable-only-alert");
 
-    expect(link).toBeVisible();
-    expect(link).toHaveAttribute(
-      "href",
-      "https://www.klaw-project.io/docs/Concepts/promotion#schema-promotion"
-    );
+      expect(alert).toBeVisible();
+      expect(alert).toHaveTextContent(
+        "You can't create a new schema or new version for it here. Create your request in the lowest environment and then promote it upwards. Learn more."
+      );
+    });
+
+    it("shows link to documentation", () => {
+      const link = screen.getByRole("link", { name: "Learn more" });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "https://www.klaw-project.io/docs/Concepts/promotion#schema-promotion"
+      );
+    });
   });
 });

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.test.tsx
@@ -12,12 +12,13 @@ describe("SchemaPromotableOnlyAlert", () => {
 
     expect(alert).toBeVisible();
     expect(alert).toHaveTextContent(
-      "Users are not allowed to request a new schema in this environment. To add a schema, promote the schema from a lower environment. You can read more in our documentation."
+      "Users are not allowed to request a new schema in this environment. To add a schema, promote the schema from a" +
+        " lower environment. Learn more."
     );
   });
 
   it("shows link to documentation", () => {
-    const link = screen.getByRole("link", { name: "our documentation" });
+    const link = screen.getByRole("link", { name: "Learn more" });
 
     expect(link).toBeVisible();
     expect(link).toHaveAttribute(

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.test.tsx
@@ -1,0 +1,28 @@
+import { render, cleanup, screen } from "@testing-library/react";
+import { SchemaPromotableOnlyAlert } from "src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert";
+
+describe("SchemaPromotableOnlyAlert", () => {
+  beforeAll(() => {
+    render(<SchemaPromotableOnlyAlert />);
+  });
+  afterAll(cleanup);
+
+  it("renders information that schema has to be promoted to higher env", () => {
+    const alert = screen.getByTestId("schema-promotable-only-alert");
+
+    expect(alert).toBeVisible();
+    expect(alert).toHaveTextContent(
+      "Users are not allowed to request a new schema in this environment. To add a schema, promote the schema from a lower environment. You can read more in our documentation."
+    );
+  });
+
+  it("shows link to documentation", () => {
+    const link = screen.getByRole("link", { name: "our documentation" });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      "https://www.klaw-project.io/docs/Concepts/promotion#schema-promotion"
+    );
+  });
+});

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.tsx
@@ -14,8 +14,7 @@ function SchemaPromotableOnlyAlert({
       <Alert type={"warning"}>
         <span>
           Users are not allowed to request a new schema in this environment. To
-          add a schema, promote the schema from a lower environment. You can
-          read more in{" "}
+          add a schema, promote the schema from a lower environment.{" "}
           <a
             target="_blank"
             rel="noreferrer"
@@ -23,7 +22,7 @@ function SchemaPromotableOnlyAlert({
               "https://www.klaw-project.io/docs/Concepts/promotion#schema-promotion"
             }
           >
-            our documentation
+            Learn more
           </a>
           .
         </span>

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.tsx
@@ -2,9 +2,19 @@ import { Alert, Box, BoxProps } from "@aivenio/aquarium";
 
 type SchemaPromotableOnlyAlertProps = {
   marginBottom?: BoxProps<"div">["marginBottom"];
+  isNewVersionRequest?: boolean;
 };
+
+const textVersion =
+  "You can't create a new schema or new version for it here. Create your request in the lowest environment and then" +
+  " promote it upwards.";
+
+const textNewCreation =
+  "Schemas are created in lower environments and promoted to higher environment. To add a schema to this topic, create a request in the lower environment and promote it to the higher one.";
+
 function SchemaPromotableOnlyAlert({
   marginBottom,
+  isNewVersionRequest = false,
 }: SchemaPromotableOnlyAlertProps) {
   return (
     <Box
@@ -13,8 +23,7 @@ function SchemaPromotableOnlyAlert({
     >
       <Alert type={"warning"}>
         <span>
-          Users are not allowed to request a new schema in this environment. To
-          add a schema, promote the schema from a lower environment.{" "}
+          {isNewVersionRequest ? textVersion : textNewCreation}{" "}
           <a
             target="_blank"
             rel="noreferrer"

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert.tsx
@@ -1,0 +1,35 @@
+import { Alert, Box, BoxProps } from "@aivenio/aquarium";
+
+type SchemaPromotableOnlyAlertProps = {
+  marginBottom?: BoxProps<"div">["marginBottom"];
+};
+function SchemaPromotableOnlyAlert({
+  marginBottom,
+}: SchemaPromotableOnlyAlertProps) {
+  return (
+    <Box
+      marginBottom={marginBottom}
+      data-testid={"schema-promotable-only-alert"}
+    >
+      <Alert type={"warning"}>
+        <span>
+          Users are not allowed to request a new schema in this environment. To
+          add a schema, promote the schema from a lower environment. You can
+          read more in{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href={
+              "https://www.klaw-project.io/docs/Concepts/promotion#schema-promotion"
+            }
+          >
+            our documentation
+          </a>
+          .
+        </span>
+      </Alert>
+    </Box>
+  );
+}
+
+export { SchemaPromotableOnlyAlert };


### PR DESCRIPTION
DRAFT: waiting for feedback Harshini for copy


# About this change - What it does

- user should get information if a schema can not be created directly on an environment but has to be promoted

Relates to: #1592 (FE part)

## Recording

(tested against local klaw to see different settings working)
Note: I made this recording before Harshini gave me feedback for the copy, so the text is wrong here. Will leave it, since it shows the core functionality. I updated the screenshots though!

https://github.com/Aiven-Open/klaw/assets/943800/5d18d2d8-031f-4538-81ba-df0ba9b10739



## Screenshots

### Schema request can be creates on env

#### no schema yet on this env
<img width="1118" alt="Screenshot 2023-08-11 at 15 22 27" src="https://github.com/Aiven-Open/klaw/assets/943800/cac15200-1fb9-4556-a110-d82ef020cfc2">

#### existing schema on that env
<img width="1130" alt="Screenshot 2023-08-11 at 15 22 47" src="https://github.com/Aiven-Open/klaw/assets/943800/2b3e0193-41b7-43ed-9044-980420286a70">


### Schema request can NOT be creates on env (has to be promoted)

#### no schema yet on this env
<img width="1094" alt="no-schema-yet" src="https://github.com/Aiven-Open/klaw/assets/943800/8c0161c4-1e11-4585-96a5-12a15a3f855d">


#### existing schema on that env
<img width="1089" alt="no-new-version" src="https://github.com/Aiven-Open/klaw/assets/943800/80d9670b-80f3-49c9-94c1-6201307c41e1">

