### PR TITLE
Check for existence of kafka components rather than select all and check for size of collection

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -420,7 +420,7 @@ public interface HandleDbRequests {
 
   Optional<ProductDetails> getProductDetails(String name);
 
-  int getAllKafkaComponentsCountForEnv(String env, int tenantId);
+  boolean existsKafkaComponentsForEnv(String env, int tenantId);
 
   boolean existsConnectorComponentsForEnv(String env, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -957,8 +957,8 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public int getAllKafkaComponentsCountForEnv(String env, int tenantId) {
-    return jdbcSelectHelper.findAllKafkaComponentsCountForEnv(env, tenantId);
+  public boolean existsKafkaComponentsForEnv(String env, int tenantId) {
+    return jdbcSelectHelper.existsKafkaComponentsForEnv(env, tenantId);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1436,13 +1436,19 @@ public class SelectDataJdbc {
     return productDetailsRepo.findById(name);
   }
 
-  public int findAllKafkaComponentsCountForEnv(String env, int tenantId) {
-    return ((Long) topicRepo.findAllTopicsCountForEnv(env, tenantId).get(0)[0]).intValue()
-        + ((Long) topicRequestsRepo.findAllTopicRequestsCountForEnv(env, tenantId).get(0)[0])
-            .intValue()
-        + ((Long) aclRepo.findAllAclsCountForEnv(env, tenantId).get(0)[0]).intValue()
-        + ((Long) aclRequestsRepo.findAllAclRequestsCountForEnv(env, tenantId).get(0)[0])
-            .intValue();
+  public boolean existsKafkaComponentsForEnv(String env, int tenantId) {
+    List<Supplier<Boolean>> list =
+        List.of(
+            () -> topicRepo.existsTopicsCountForEnv(env, tenantId),
+            () -> topicRequestsRepo.existsTopicRequestsCountForEnv(env, tenantId),
+            () -> aclRepo.existsAclsCountForEnv(env, tenantId),
+            () -> aclRequestsRepo.existsAclRequestsCountForEnv(env, tenantId));
+    for (var elem : list) {
+      if (elem.get()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public boolean existsConnectorComponentsForEnv(String env, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1439,10 +1439,10 @@ public class SelectDataJdbc {
   public boolean existsKafkaComponentsForEnv(String env, int tenantId) {
     List<Supplier<Boolean>> list =
         List.of(
-            () -> topicRepo.existsTopicsCountForEnv(env, tenantId),
+            () -> topicRepo.existsByEnvironmentAndTenantId(env, tenantId),
             () -> topicRequestsRepo.existsTopicRequestsCountForEnv(env, tenantId),
             () -> aclRepo.existsAclsCountForEnv(env, tenantId),
-            () -> aclRequestsRepo.existsAclRequestsCountForEnv(env, tenantId));
+            () -> aclRequestsRepo.existsByEnvironmentAndTenantId(env, tenantId));
     for (var elem : list) {
       if (elem.get()) {
         return true;

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1440,8 +1440,8 @@ public class SelectDataJdbc {
     List<Supplier<Boolean>> list =
         List.of(
             () -> topicRepo.existsByEnvironmentAndTenantId(env, tenantId),
-            () -> topicRequestsRepo.existsTopicRequestsCountForEnv(env, tenantId),
-            () -> aclRepo.existsAclsCountForEnv(env, tenantId),
+            () -> topicRequestsRepo.existsByEnvironmentAndTenantId(env, tenantId),
+            () -> aclRepo.existsByEnvironmentAndTenantId(env, tenantId),
             () -> aclRequestsRepo.existsByEnvironmentAndTenantId(env, tenantId));
     for (var elem : list) {
       if (elem.get()) {

--- a/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
@@ -26,10 +26,9 @@ public interface AclRepo extends CrudRepository<Acl, AclID> {
   List<Acl> findAllByTenantId(int tenantId);
 
   @Query(
-      value = "select count(*) from kwacls where env = :envId and tenantid = :tenantId",
+      value = "select exists(select 1 from kwacls where env = :envId and tenantid = :tenantId)",
       nativeQuery = true)
-  List<Object[]> findAllAclsCountForEnv(
-      @Param("envId") String envId, @Param("tenantId") Integer tenantId);
+  boolean existsAclsCountForEnv(@Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value = "select exists(select 1 from kwacls where teamid = :teamId and tenantid = :tenantId)",

--- a/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRepo.java
@@ -25,10 +25,8 @@ public interface AclRepo extends CrudRepository<Acl, AclID> {
 
   List<Acl> findAllByTenantId(int tenantId);
 
-  @Query(
-      value = "select exists(select 1 from kwacls where env = :envId and tenantid = :tenantId)",
-      nativeQuery = true)
-  boolean existsAclsCountForEnv(@Param("envId") String envId, @Param("tenantId") Integer tenantId);
+  boolean existsByEnvironmentAndTenantId(
+      @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value = "select exists(select 1 from kwacls where teamid = :teamId and tenantid = :tenantId)",

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -18,11 +18,7 @@ public interface AclRequestsRepo
   boolean existsByTenantIdAndEnvironmentAndRequestStatusAndTopicname(
       int tenantId, String env, String requestStatus, String topicname);
 
-  @Query(
-      value =
-          "select exists(select 1 from kwaclrequests where env = :envId and tenantid = :tenantId)",
-      nativeQuery = true)
-  boolean existsAclRequestsCountForEnv(
+  boolean existsByEnvironmentAndTenantId(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -19,9 +19,10 @@ public interface AclRequestsRepo
       int tenantId, String env, String requestStatus, String topicname);
 
   @Query(
-      value = "select count(*) from kwaclrequests where env = :envId and tenantid = :tenantId",
+      value =
+          "select exists(select 1 from kwaclrequests where env = :envId and tenantid = :tenantId)",
       nativeQuery = true)
-  List<Object[]> findAllAclRequestsCountForEnv(
+  boolean existsAclRequestsCountForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
@@ -47,10 +47,7 @@ public interface TopicRepo extends CrudRepository<Topic, TopicID> {
   List<Object[]> findAllTopicsForTeam(
       @Param("teamIdVar") Integer teamIdVar, @Param("tenantId") Integer tenantId);
 
-  @Query(
-      value = "select exists(select 1 from kwtopics where env = :envId and tenantid = :tenantId)",
-      nativeQuery = true)
-  boolean existsTopicsCountForEnv(
+  boolean existsByEnvironmentAndTenantId(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
@@ -48,9 +48,9 @@ public interface TopicRepo extends CrudRepository<Topic, TopicID> {
       @Param("teamIdVar") Integer teamIdVar, @Param("tenantId") Integer tenantId);
 
   @Query(
-      value = "select count(*) from kwtopics where env = :envId and tenantid = :tenantId",
+      value = "select exists(select 1 from kwtopics where env = :envId and tenantid = :tenantId)",
       nativeQuery = true)
-  List<Object[]> findAllTopicsCountForEnv(
+  boolean existsTopicsCountForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -31,11 +31,7 @@ public interface TopicRequestsRepo
   List<TopicRequest> findAllByRequestStatusAndTopicnameAndEnvironmentAndTenantId(
       String topicStatus, String topicName, String envId, int tenantId);
 
-  @Query(
-      value =
-          "select exists(select 1 from kwtopicrequests where env = :envId and tenantid = :tenantId)",
-      nativeQuery = true)
-  boolean existsTopicRequestsCountForEnv(
+  boolean existsByEnvironmentAndTenantId(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -32,9 +32,10 @@ public interface TopicRequestsRepo
       String topicStatus, String topicName, String envId, int tenantId);
 
   @Query(
-      value = "select count(*) from kwtopicrequests where env = :envId and tenantid = :tenantId",
+      value =
+          "select exists(select 1 from kwtopicrequests where env = :envId and tenantid = :tenantId)",
       nativeQuery = true)
-  List<Object[]> findAllTopicRequestsCountForEnv(
+  boolean existsTopicRequestsCountForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -354,10 +354,9 @@ public class EnvsClustersTenantsControllerService {
       envModelList.forEach(
           envModel -> {
             envModel.setShowDeleteEnv(
-                manageDatabase
-                        .getHandleDbRequests()
-                        .getAllKafkaComponentsCountForEnv(envModel.getId(), tenantId)
-                    <= 0);
+                !manageDatabase
+                    .getHandleDbRequests()
+                    .existsKafkaComponentsForEnv(envModel.getId(), tenantId));
           });
     }
 
@@ -878,8 +877,7 @@ public class EnvsClustersTenantsControllerService {
 
     switch (envType) {
       case "kafka":
-        if (manageDatabase.getHandleDbRequests().getAllKafkaComponentsCountForEnv(envId, tenantId)
-            > 0) {
+        if (manageDatabase.getHandleDbRequests().existsKafkaComponentsForEnv(envId, tenantId)) {
           return ApiResponse.notOk(ENV_CLUSTER_TNT_ERR_105);
         }
         break;


### PR DESCRIPTION
The change is similar to https://github.com/Aiven-Open/klaw/pull/1573

instead of selection of all and checking for size of the collection there could be only check for existence done which minimizes amount of data transferring between the app and db
