### PR TITLE
Check for existence of connector components rather than select all and check for size of collection

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -422,7 +422,7 @@ public interface HandleDbRequests {
 
   int getAllKafkaComponentsCountForEnv(String env, int tenantId);
 
-  int getAllConnectorComponentsCountForEnv(String env, int tenantId);
+  boolean existsConnectorComponentsForEnv(String env, int tenantId);
 
   boolean existsSchemaComponentsForEnv(String env, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -962,8 +962,8 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
-  public int getAllConnectorComponentsCountForEnv(String env, int tenantId) {
-    return jdbcSelectHelper.findAllConnectorComponentsCountForEnv(env, tenantId);
+  public boolean existsConnectorComponentsForEnv(String env, int tenantId) {
+    return jdbcSelectHelper.existsConnectorComponentsForEnv(env, tenantId);
   }
 
   @Override

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1449,7 +1449,9 @@ public class SelectDataJdbc {
     List<Supplier<Boolean>> list =
         List.of(
             () -> kafkaConnectorRepo.existsByEnvironmentAndTenantId(env, tenantId),
-            () -> kafkaConnectorRequestsRepo.existsConnectorRequestsForEnv(env, tenantId));
+            () ->
+                kafkaConnectorRequestsRepo.existsConnectorRequestsForEnvTenantIdAndCreatedStatus(
+                    env, tenantId));
     for (var elem : list) {
       if (elem.get()) {
         return true;

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1445,13 +1445,17 @@ public class SelectDataJdbc {
             .intValue();
   }
 
-  public int findAllConnectorComponentsCountForEnv(String env, int tenantId) {
-    return ((Long) kafkaConnectorRepo.findAllConnectorCountForEnv(env, tenantId).get(0)[0])
-            .intValue()
-        + ((Long)
-                kafkaConnectorRequestsRepo.findAllConnectorRequestsCountForEnv(env, tenantId)
-                    .get(0)[0])
-            .intValue();
+  public boolean existsConnectorComponentsForEnv(String env, int tenantId) {
+    List<Supplier<Boolean>> list =
+        List.of(
+            () -> kafkaConnectorRepo.existConnectorForEnv(env, tenantId),
+            () -> kafkaConnectorRequestsRepo.existsConnectorRequestsForEnv(env, tenantId));
+    for (var elem : list) {
+      if (elem.get()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public boolean existsSchemaComponentsForEnv(String env, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1448,7 +1448,7 @@ public class SelectDataJdbc {
   public boolean existsConnectorComponentsForEnv(String env, int tenantId) {
     List<Supplier<Boolean>> list =
         List.of(
-            () -> kafkaConnectorRepo.existConnectorForEnv(env, tenantId),
+            () -> kafkaConnectorRepo.existsByEnvironmentAndTenantId(env, tenantId),
             () -> kafkaConnectorRequestsRepo.existsConnectorRequestsForEnv(env, tenantId));
     for (var elem : list) {
       if (elem.get()) {

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRepo.java
@@ -26,10 +26,10 @@ public interface KwKafkaConnectorRepo extends CrudRepository<KwKafkaConnector, K
       String connectorName, String env, int tenantId);
 
   @Query(
-      value = "select count(*) from kwkafkaconnector where env = :envId and tenantid = :tenantId",
+      value =
+          "select exists(select 1 from kwkafkaconnector where env = :envId and tenantid = :tenantId)",
       nativeQuery = true)
-  List<Object[]> findAllConnectorCountForEnv(
-      @Param("envId") String envId, @Param("tenantId") Integer tenantId);
+  boolean existConnectorForEnv(@Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value =

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRepo.java
@@ -25,11 +25,8 @@ public interface KwKafkaConnectorRepo extends CrudRepository<KwKafkaConnector, K
   List<KwKafkaConnector> findAllByConnectorNameAndEnvironmentAndTenantId(
       String connectorName, String env, int tenantId);
 
-  @Query(
-      value =
-          "select exists(select 1 from kwkafkaconnector where env = :envId and tenantid = :tenantId)",
-      nativeQuery = true)
-  boolean existConnectorForEnv(@Param("envId") String envId, @Param("tenantId") Integer tenantId);
+  boolean existsByEnvironmentAndTenantId(
+      @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(
       value =

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -2,6 +2,7 @@ package io.aiven.klaw.repository;
 
 import io.aiven.klaw.dao.KafkaConnectorRequest;
 import io.aiven.klaw.dao.KafkaConnectorRequestID;
+import io.aiven.klaw.model.enums.RequestStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
@@ -29,12 +30,16 @@ public interface KwKafkaConnectorRequestsRepo
 
   List<KafkaConnectorRequest> findAllByTenantId(int tenantId);
 
-  @Query(
-      value =
-          "select exists(select 1 from kwkafkaconnectorrequests where env = :envId and tenantid = :tenantId and connectorstatus='created')",
-      nativeQuery = true)
-  boolean existsConnectorRequestsForEnv(
-      @Param("envId") String envId, @Param("tenantId") Integer tenantId);
+  default boolean existsConnectorRequestsForEnvTenantIdAndCreatedStatus(
+      String envId, Integer tenantId) {
+    return existsByEnvironmentAndTenantIdAndRequestStatus(
+        envId, tenantId, RequestStatus.CREATED.value);
+  }
+
+  boolean existsByEnvironmentAndTenantIdAndRequestStatus(
+      @Param("envId") String envId,
+      @Param("tenantId") Integer tenantId,
+      @Param("requestStatus") String requestStatus);
 
   @Query(
       value = "select max(connectorid) from kwkafkaconnectorrequests where tenantid = :tenantId",

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -31,9 +31,9 @@ public interface KwKafkaConnectorRequestsRepo
 
   @Query(
       value =
-          "select count(*) from kwkafkaconnectorrequests where env = :envId and tenantid = :tenantId and connectorstatus='created'",
+          "select exists(select 1 from kwkafkaconnectorrequests where env = :envId and tenantid = :tenantId and connectorstatus='created')",
       nativeQuery = true)
-  List<Object[]> findAllConnectorRequestsCountForEnv(
+  boolean existsConnectorRequestsForEnv(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -529,10 +529,9 @@ public class EnvsClustersTenantsControllerService {
       envModelList.forEach(
           envModel -> {
             envModel.setShowDeleteEnv(
-                manageDatabase
-                        .getHandleDbRequests()
-                        .getAllConnectorComponentsCountForEnv(envModel.getId(), tenantId)
-                    <= 0);
+                !manageDatabase
+                    .getHandleDbRequests()
+                    .existsConnectorComponentsForEnv(envModel.getId(), tenantId));
           });
     }
 
@@ -607,10 +606,9 @@ public class EnvsClustersTenantsControllerService {
       envModelList.forEach(
           envModel -> {
             envModel.setShowDeleteEnv(
-                manageDatabase
-                        .getHandleDbRequests()
-                        .getAllConnectorComponentsCountForEnv(envModel.getId(), tenantId)
-                    <= 0);
+                !manageDatabase
+                    .getHandleDbRequests()
+                    .existsConnectorComponentsForEnv(envModel.getId(), tenantId));
           });
     }
 
@@ -886,10 +884,7 @@ public class EnvsClustersTenantsControllerService {
         }
         break;
       case "kafkaconnect":
-        if (manageDatabase
-                .getHandleDbRequests()
-                .getAllConnectorComponentsCountForEnv(envId, tenantId)
-            > 0) {
+        if (manageDatabase.getHandleDbRequests().existsConnectorComponentsForEnv(envId, tenantId)) {
           return ApiResponse.notOk(ENV_CLUSTER_TNT_ERR_106);
         }
         break;


### PR DESCRIPTION
The change is similar to https://github.com/Aiven-Open/klaw/pull/1573

instead of selection of all and checking for size of the collection there could be only check for existence done which minimizes amount of data transferring between the app and db
