### PR TITLE
refactor(coral) - Topic/Connector details: Rename "Documentation" to "Readme" and add description

### DIFF
--- a/coral/src/app/components/documentation/DocumentationEditor.test.tsx
+++ b/coral/src/app/components/documentation/DocumentationEditor.test.tsx
@@ -16,7 +16,7 @@ const requiredProps = {
 describe("DocumentationEditor", () => {
   const user = userEvent.setup();
 
-  describe("shows all necessary elements when there is no existing documentation", () => {
+  describe("shows all necessary elements when there is no existing readme", () => {
     beforeAll(() => {
       render(<DocumentationEditor {...requiredProps} />);
     });
@@ -101,16 +101,16 @@ describe("DocumentationEditor", () => {
       expect(cancel).toBeEnabled();
     });
 
-    it("shows a button to save the documentation", () => {
-      const save = screen.getByRole("button", { name: "Save documentation" });
+    it("shows a button to save the readme", () => {
+      const save = screen.getByRole("button", { name: "Save readme" });
 
       expect(save).toBeEnabled();
     });
   });
 
-  describe("shows all necessary elements including an existing documentation", () => {
+  describe("shows all necessary elements including an existing readme", () => {
     const testDocumentation =
-      `# Hello world this is documentation` as TopicDocumentationMarkdown;
+      `# Hello world this is readme` as TopicDocumentationMarkdown;
     beforeAll(() => {
       render(
         <DocumentationEditor
@@ -128,14 +128,14 @@ describe("DocumentationEditor", () => {
       expect(textarea).toBeEnabled();
     });
 
-    it("shows the given documentation as value of textarea", () => {
+    it("shows the given readme as value of textarea", () => {
       const textarea = screen.getByRole("textbox", { name: "Markdown editor" });
 
       expect(textarea).toHaveValue(testDocumentation);
     });
   });
 
-  describe("shows a state where saving of documentation is in progress", () => {
+  describe("shows a state where saving of readme is in progress", () => {
     beforeAll(() => {
       render(<DocumentationEditor {...requiredProps} isSaving={true} />);
     });
@@ -155,7 +155,7 @@ describe("DocumentationEditor", () => {
     });
 
     it("disables the save button and shows loading information", () => {
-      const save = screen.getByRole("button", { name: "Saving documentation" });
+      const save = screen.getByRole("button", { name: "Saving readme" });
 
       expect(save).toBeDisabled();
     });
@@ -223,7 +223,7 @@ describe("DocumentationEditor", () => {
     });
   });
 
-  describe("enables user to add documentation in markdown format", () => {
+  describe("enables user to add readme in markdown format", () => {
     const existingDoc = "#Hello" as TopicDocumentationMarkdown;
     beforeEach(() => {
       render(
@@ -265,7 +265,7 @@ describe("DocumentationEditor", () => {
     it("does not call the given save function if user text did not change", async () => {
       const textarea = screen.getByRole("textbox", { name: "Markdown editor" });
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.type(textarea, "     ");
@@ -278,7 +278,7 @@ describe("DocumentationEditor", () => {
     it("calls the given save function when user clicks button", async () => {
       const textarea = screen.getByRole("textbox", { name: "Markdown editor" });
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.type(textarea, " world");
@@ -368,7 +368,7 @@ describe("DocumentationEditor", () => {
     it("enables user to save input using keyboard only", async () => {
       const textarea = screen.getByRole("textbox", { name: "Markdown editor" });
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.type(textarea, "#Hello world");

--- a/coral/src/app/components/documentation/DocumentationEditor.tsx
+++ b/coral/src/app/components/documentation/DocumentationEditor.tsx
@@ -130,7 +130,7 @@ function DocumentationEditor({
           Cancel
         </Button.Secondary>
         <Button.Primary onClick={saveDocumentation} loading={isSaving}>
-          {isSaving ? "Saving documentation" : "Save documentation"}
+          {isSaving ? "Saving readme" : "Save readme"}
         </Button.Primary>
       </Box.Flex>
     </Box.Flex>

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
@@ -18,8 +18,8 @@ const testMapTabs = [
     title: "Overview",
   },
   {
-    linkTo: "documentation",
-    title: "Documentation",
+    linkTo: "readme",
+    title: "Readme",
   },
   {
     linkTo: "history",

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
@@ -56,7 +56,7 @@ function ConnectorOverviewResourcesTabs({
     },
     {
       connectorOverviewTabEnum: ConnectorOverviewTabEnum.DOCUMENTATION,
-      title: "Documentation",
+      title: "Readme",
     },
     {
       connectorOverviewTabEnum: ConnectorOverviewTabEnum.HISTORY,

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
@@ -54,7 +54,7 @@ describe("ConnectorDocumentation", () => {
 
   const user = userEvent.setup();
 
-  describe("if the connector has no documentation yet", () => {
+  describe("if the connector has no readme yet", () => {
     describe("shows all necessary elements", () => {
       beforeAll(() => {
         mockUseConnectorDetails.mockReturnValue(mockConnectorDetails);
@@ -72,22 +72,22 @@ describe("ConnectorDocumentation", () => {
 
       afterAll(cleanup);
 
-      it("shows headline No Documentation", () => {
+      it("shows headline No readme available", () => {
         const headline = screen.getByRole("heading", {
-          name: "No documentation",
+          name: "No readme available",
         });
         expect(headline).toBeVisible();
       });
 
-      it("shows a button to add documentation", () => {
-        const addDocumentationButton = screen.getByRole("button", {
-          name: "Add documentation",
+      it("shows a button to add readme", () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Add readme",
         });
-        expect(addDocumentationButton).toBeEnabled();
+        expect(addReadmeButton).toBeEnabled();
       });
     });
 
-    describe("enables user to add documentation", () => {
+    describe("enables user to add readme", () => {
       beforeEach(() => {
         mockUseConnectorDetails.mockReturnValue(mockConnectorDetails);
         mockUpdateConnectorDocumentation.mockResolvedValue({
@@ -111,32 +111,45 @@ describe("ConnectorDocumentation", () => {
         expect(markdownEditor).not.toBeInTheDocument();
       });
 
-      it("shows the edit mode when user clicks button to add documentation", async () => {
-        const addDocumentationButton = screen.getByRole("button", {
-          name: "Add documentation",
+      it("shows the edit mode when user clicks button to add readme", async () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Add readme",
         });
-        const headlineNoDocumentation = screen.getByRole("heading", {
-          name: "No documentation",
+        const headlineNoReadme = screen.getByRole("heading", {
+          name: "No readme available",
         });
 
-        expect(headlineNoDocumentation).toBeVisible();
-        await user.click(addDocumentationButton);
+        expect(headlineNoReadme).toBeVisible();
+        await user.click(addReadmeButton);
 
         const markdownEditor = screen.getByRole("textbox", {
           name: "Markdown editor",
         });
         const headlineEdit = screen.getByRole("heading", {
-          name: "Edit documentation",
+          name: "Edit readme",
         });
 
         expect(markdownEditor).toBeVisible();
-        expect(headlineNoDocumentation).not.toBeInTheDocument();
+        expect(headlineNoReadme).not.toBeInTheDocument();
         expect(headlineEdit).toBeVisible();
+      });
+
+      it("shows a description about the readme", async () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Add readme",
+        });
+        await user.click(addReadmeButton);
+
+        const description = screen.getByText(
+          `Readme provides essential information, guidelines, and explanations about the connector, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the connector evolves.`
+        );
+
+        expect(description).toBeVisible();
       });
     });
   });
 
-  describe("if the connector has existing documentation", () => {
+  describe("if the connector has existing readme", () => {
     const existingDocumentation = "# Hello" as ConnectorDocumentationMarkdown;
 
     describe("shows all necessary elements", () => {
@@ -164,28 +177,36 @@ describe("ConnectorDocumentation", () => {
 
       afterAll(cleanup);
 
-      it("shows documentation headline", () => {
-        const headline = screen.getByRole("heading", { name: "Documentation" });
+      it("shows readme headline", () => {
+        const headline = screen.getByRole("heading", { name: "Readme" });
 
         expect(headline).toBeVisible();
       });
 
-      it("shows the documentation", () => {
+      it("shows a description about the readme", () => {
+        const description = screen.getByText(
+          `Readme provides essential information, guidelines, and explanations about the connector, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the connector evolves.`
+        );
+
+        expect(description).toBeVisible();
+      });
+
+      it("shows the readme", () => {
         const markdownView = screen.getByTestId("react-markdown-mock");
 
         expect(markdownView).toBeVisible();
         expect(markdownView).toHaveTextContent(existingDocumentation);
       });
 
-      it("shows a button to edit documentation", () => {
-        const addDocumentationButton = screen.getByRole("button", {
-          name: "Edit documentation",
+      it("shows a button to edit readme", () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Edit readme",
         });
-        expect(addDocumentationButton).toBeEnabled();
+        expect(addReadmeButton).toBeEnabled();
       });
     });
 
-    describe("enables user to edit documentation", () => {
+    describe("enables user to edit readme", () => {
       beforeEach(() => {
         mockUseConnectorDetails.mockReturnValue({
           ...mockConnectorDetails,
@@ -205,18 +226,18 @@ describe("ConnectorDocumentation", () => {
 
       afterEach(cleanup);
 
-      it("shows the edit mode when user clicks button to edit documentation", async () => {
-        const editDocumentation = screen.getByRole("button", {
-          name: "Edit documentation",
+      it("shows the edit mode when user clicks button to edit readme", async () => {
+        const editReadme = screen.getByRole("button", {
+          name: "Edit readme",
         });
 
-        await user.click(editDocumentation);
+        await user.click(editReadme);
 
         const markdownEditor = screen.getByRole("textbox", {
           name: "Markdown editor",
         });
         const headlineEdit = screen.getByRole("heading", {
-          name: "Edit documentation",
+          name: "Edit readme",
         });
 
         expect(markdownEditor).toBeVisible();
@@ -225,7 +246,7 @@ describe("ConnectorDocumentation", () => {
     });
   });
 
-  describe("if documentation is updating", () => {
+  describe("if readme is updating", () => {
     const existingDocumentation = "# Hello" as ConnectorDocumentationMarkdown;
 
     beforeAll(() => {
@@ -253,34 +274,34 @@ describe("ConnectorDocumentation", () => {
 
     afterAll(cleanup);
 
-    it("shows documentation headline", () => {
-      const headline = screen.getByRole("heading", { name: "Documentation" });
+    it("shows readme headline", () => {
+      const headline = screen.getByRole("heading", { name: "Readme" });
 
       expect(headline).toBeVisible();
     });
 
-    it("shows accessible information about loading documentation", () => {
-      const loadingInformation = screen.getByText("Loading documentation");
+    it("shows accessible information about loading readme", () => {
+      const loadingInformation = screen.getByText("Loading readme");
 
       expect(loadingInformation).toBeVisible();
       expect(loadingInformation).toHaveClass("visually-hidden");
     });
 
-    it("shows no documentation", () => {
+    it("shows no readme", () => {
       const markdownView = screen.queryByTestId("react-markdown-mock");
 
       expect(markdownView).not.toBeInTheDocument();
     });
 
-    it("shows no button to edit documentation", () => {
-      const addDocumentationButton = screen.queryByRole("button", {
-        name: "Edit documentation",
+    it("shows no button to edit readme", () => {
+      const addReadmeButton = screen.queryByRole("button", {
+        name: "Edit readme",
       });
-      expect(addDocumentationButton).not.toBeInTheDocument();
+      expect(addReadmeButton).not.toBeInTheDocument();
     });
   });
 
-  describe("enables user to update documentation", () => {
+  describe("enables user to update readme", () => {
     const existingDocumentation = "# Hello" as ConnectorDocumentationMarkdown;
     const userInput = "**Hello world**";
 
@@ -309,9 +330,9 @@ describe("ConnectorDocumentation", () => {
       cleanup();
     });
 
-    it("enables user to cancel editing the documentation", async () => {
+    it("enables user to cancel editing the readme", async () => {
       const editButton = screen.getByRole("button", {
-        name: "Edit documentation",
+        name: "Edit readme",
       });
 
       await user.click(editButton);
@@ -334,9 +355,9 @@ describe("ConnectorDocumentation", () => {
       expect(previewMode).toBeVisible();
     });
 
-    it("saves documentation when user clicks button", async () => {
+    it("saves readme when user clicks button", async () => {
       const editButton = screen.getByRole("button", {
-        name: "Edit documentation",
+        name: "Edit readme",
       });
 
       await user.click(editButton);
@@ -347,7 +368,7 @@ describe("ConnectorDocumentation", () => {
       await user.type(markdownEditor, userInput);
 
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.click(saveButton);
@@ -358,12 +379,13 @@ describe("ConnectorDocumentation", () => {
         connectorDocumentation: existingDocumentation + userInput,
       });
     });
+
     it("shows preview mode after successful update", async () => {
-      const editDocumentation = screen.getByRole("button", {
-        name: "Edit documentation",
+      const editReadme = screen.getByRole("button", {
+        name: "Edit readme",
       });
 
-      await user.click(editDocumentation);
+      await user.click(editReadme);
 
       const markdownEditor = screen.getByRole("textbox", {
         name: "Markdown editor",
@@ -371,7 +393,7 @@ describe("ConnectorDocumentation", () => {
       await user.type(markdownEditor, userInput);
 
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.click(saveButton);
@@ -382,7 +404,7 @@ describe("ConnectorDocumentation", () => {
     });
   });
 
-  describe("handles errors when transforming documentation intro correct markdown from backend", () => {
+  describe("handles errors when transforming readme intro correct markdown from backend", () => {
     const originalConsoleError = console.error;
     beforeEach(() => {
       console.error = jest.fn();
@@ -415,7 +437,7 @@ describe("ConnectorDocumentation", () => {
 
       expect(errorInformation).toBeVisible();
       expect(errorInformation).toHaveTextContent(
-        "Something went wrong while trying to transform the documentation into the right format."
+        "Something went wrong while trying to transform the readme into the right format."
       );
 
       const previewMode = screen.queryByTestId("react-markdown-mock");
@@ -426,7 +448,7 @@ describe("ConnectorDocumentation", () => {
     });
   });
 
-  describe("handles errors with updating documentation", () => {
+  describe("handles errors with updating readme", () => {
     const existingDocumentation = "# Hello" as ConnectorDocumentationMarkdown;
     const userInput = "**Hello world**";
 
@@ -459,9 +481,9 @@ describe("ConnectorDocumentation", () => {
       cleanup();
     });
 
-    it("shows errors without saving documentation when user clicks button", async () => {
+    it("shows errors without saving readme when user clicks button", async () => {
       const editButton = screen.getByRole("button", {
-        name: "Edit documentation",
+        name: "Edit readme",
       });
 
       await user.click(editButton);
@@ -472,7 +494,7 @@ describe("ConnectorDocumentation", () => {
       await user.type(markdownEditor, userInput);
 
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.click(saveButton);
@@ -480,7 +502,7 @@ describe("ConnectorDocumentation", () => {
       const error = screen.getByRole("alert");
       expect(error).toBeVisible();
       expect(error).toHaveTextContent(
-        "The documentation could not be saved, there was an error"
+        "The readme could not be saved, there was an error"
       );
 
       const previewMode = screen.queryByTestId("react-markdown-mock");

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
@@ -141,7 +141,7 @@ describe("ConnectorDocumentation", () => {
         await user.click(addReadmeButton);
 
         const description = screen.getByText(
-          `Readme provides essential information, guidelines, and explanations about the connector, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the connector evolves.`
+          `Readme provides essential information, guidelines, and explanations about the connector, helping team members understand its purpose and usage. Edit the readme to update the information as the connector evolves.`
         );
 
         expect(description).toBeVisible();
@@ -185,7 +185,7 @@ describe("ConnectorDocumentation", () => {
 
       it("shows a description about the readme", () => {
         const description = screen.getByText(
-          `Readme provides essential information, guidelines, and explanations about the connector, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the connector evolves.`
+          `Readme provides essential information, guidelines, and explanations about the connector, helping team members understand its purpose and usage. Edit the readme to update the information as the connector evolves.`
         );
 
         expect(description).toBeVisible();

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
@@ -76,8 +76,8 @@ function ConnectorDocumentation() {
         <Box component={Typography.SmallText} marginBottom={"l2"}>
           Readme provides essential information, guidelines, and explanations
           about the connector, helping team members understand its purpose and
-          usage. Edit the readme to update or expand this information as the
-          connector evolves.
+          usage. Edit the readme to update the information as the connector
+          evolves.
         </Box>
         <>
           {isError && (
@@ -137,8 +137,8 @@ function ConnectorDocumentation() {
       <Box component={Typography.SmallText} marginBottom={"l2"}>
         Readme provides essential information, guidelines, and explanations
         about the connector, helping team members understand its purpose and
-        usage. Edit the readme to update or expand this information as the
-        connector evolves.
+        usage. Edit the readme to update the information as the connector
+        evolves.
       </Box>
       <Box paddingTop={"l2"}>
         <DocumentationView

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
@@ -19,6 +19,13 @@ import {
 import { isDocumentationTransformationError } from "src/domain/helper/documentation-helper";
 import { parseErrorMsg } from "src/services/mutation-utils";
 
+const readmeDescription = (
+  <Box component={Typography.SmallText} marginBottom={"l2"}>
+    Readme provides essential information, guidelines, and explanations about
+    the connector, helping team members understand its purpose and usage. Edit
+    the readme to update the information as the connector evolves.
+  </Box>
+);
 function ConnectorDocumentation() {
   const queryClient = useQueryClient();
 
@@ -73,12 +80,7 @@ function ConnectorDocumentation() {
     return (
       <>
         <PageHeader title={"Edit readme"} />
-        <Box component={Typography.SmallText} marginBottom={"l2"}>
-          Readme provides essential information, guidelines, and explanations
-          about the connector, helping team members understand its purpose and
-          usage. Edit the readme to update the information as the connector
-          evolves.
-        </Box>
+        {readmeDescription}
         <>
           {isError && (
             <Box marginBottom={"l1"}>
@@ -134,12 +136,7 @@ function ConnectorDocumentation() {
           onClick: () => setEditMode(true),
         }}
       />
-      <Box component={Typography.SmallText} marginBottom={"l2"}>
-        Readme provides essential information, guidelines, and explanations
-        about the connector, helping team members understand its purpose and
-        usage. Edit the readme to update the information as the connector
-        evolves.
-      </Box>
+      {readmeDescription}
       <Box paddingTop={"l2"}>
         <DocumentationView
           markdownString={connectorOverview.connectorDocumentation}

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.tsx
@@ -1,4 +1,11 @@
-import { Alert, Box, PageHeader, Skeleton, useToast } from "@aivenio/aquarium";
+import {
+  Alert,
+  Box,
+  PageHeader,
+  Skeleton,
+  Typography,
+  useToast,
+} from "@aivenio/aquarium";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { DocumentationEditor } from "src/app/components/documentation/DocumentationEditor";
@@ -36,7 +43,7 @@ function ConnectorDocumentation() {
       onSuccess: () => {
         queryClient.refetchQueries(["connector-overview"]).then(() => {
           toast({
-            message: "Documentation successfully updated",
+            message: "Readme successfully updated",
             position: "bottom-left",
             variant: "default",
           });
@@ -53,9 +60,9 @@ function ConnectorDocumentation() {
   if (connectorIsRefetching) {
     return (
       <>
-        <PageHeader title={"Documentation"} />
+        <PageHeader title={"Readme"} />
         <Box paddingTop={"l2"}>
-          <div className={"visually-hidden"}>Loading documentation</div>
+          <div className={"visually-hidden"}>Loading readme</div>
           <Skeleton />
         </Box>
       </>
@@ -65,12 +72,18 @@ function ConnectorDocumentation() {
   if (editMode) {
     return (
       <>
-        <PageHeader title={"Edit documentation"} />
+        <PageHeader title={"Edit readme"} />
+        <Box component={Typography.SmallText} marginBottom={"l2"}>
+          Readme provides essential information, guidelines, and explanations
+          about the connector, helping team members understand its purpose and
+          usage. Edit the readme to update or expand this information as the
+          connector evolves.
+        </Box>
         <>
           {isError && (
             <Box marginBottom={"l1"}>
               <Alert type="error">
-                The documentation could not be saved, there was an error: <br />
+                The readme could not be saved, there was an error: <br />
                 {parseErrorMsg(error)}
               </Alert>
             </Box>
@@ -92,7 +105,7 @@ function ConnectorDocumentation() {
   ) {
     return (
       <>
-        <PageHeader title={"Documentation"} />
+        <PageHeader title={"Readme"} />
         <NoDocumentationBanner addDocumentation={() => setEditMode(true)} />
       </>
     );
@@ -103,10 +116,10 @@ function ConnectorDocumentation() {
   ) {
     return (
       <>
-        <PageHeader title={"Documentation"} />
+        <PageHeader title={"Readme"} />
         <Alert type="error">
-          Something went wrong while trying to transform the documentation into
-          the right format.
+          Something went wrong while trying to transform the readme into the
+          right format.
         </Alert>
       </>
     );
@@ -115,12 +128,18 @@ function ConnectorDocumentation() {
   return (
     <>
       <PageHeader
-        title={"Documentation"}
+        title={"Readme"}
         primaryAction={{
-          text: "Edit documentation",
+          text: "Edit readme",
           onClick: () => setEditMode(true),
         }}
       />
+      <Box component={Typography.SmallText} marginBottom={"l2"}>
+        Readme provides essential information, guidelines, and explanations
+        about the connector, helping team members understand its purpose and
+        usage. Edit the readme to update or expand this information as the
+        connector evolves.
+      </Box>
       <Box paddingTop={"l2"}>
         <DocumentationView
           markdownString={connectorOverview.connectorDocumentation}

--- a/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.test.tsx
+++ b/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.test.tsx
@@ -14,22 +14,22 @@ describe("NoDocumentationBanner", () => {
 
     afterAll(cleanup);
 
-    it("shows headline No Documentation", () => {
+    it("shows headline No readme", () => {
       const headline = screen.getByRole("heading", {
-        name: "No documentation",
+        name: "No readme available",
       });
       expect(headline).toBeVisible();
     });
 
-    it("shows information that no documentation is available for this connector", () => {
+    it("shows information that no readme is available for this connector", () => {
       const infoText = screen.getByText(
-        "You can add documentation for your connector."
+        "Add a readme to give your team essential information, guidelines, and context about the connector."
       );
       expect(infoText).toBeVisible();
     });
 
-    it("shows button to add a documentation", () => {
-      const button = screen.getByRole("button", { name: "Add documentation" });
+    it("shows button to add a readme", () => {
+      const button = screen.getByRole("button", { name: "Add readme" });
       expect(button).toBeVisible();
     });
   });
@@ -44,8 +44,8 @@ describe("NoDocumentationBanner", () => {
       jest.clearAllMocks();
     });
 
-    it("adds documentation when user clicks button", async () => {
-      const button = screen.getByRole("button", { name: "Add documentation" });
+    it("adds readme when user clicks button", async () => {
+      const button = screen.getByRole("button", { name: "Add readme" });
       await user.click(button);
 
       expect(testAddDocumentation).toHaveBeenCalled();

--- a/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.tsx
+++ b/coral/src/app/features/connectors/details/documentation/components/NoDocumentationBanner.tsx
@@ -9,15 +9,16 @@ function NoDocumentationBanner({
 }: NoDocumentationBannerProps) {
   return (
     <EmptyState
-      title={"No documentation"}
+      title={"No readme available"}
       image={illustration}
       layout={EmptyStateLayout.CenterHorizontal}
       primaryAction={{
-        text: "Add documentation",
+        text: "Add readme",
         onClick: addDocumentation,
       }}
     >
-      You can add documentation for your connector.
+      Add a readme to give your team essential information, guidelines, and
+      context about the connector.
     </EmptyState>
   );
 }

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -32,8 +32,8 @@ const testMapTabs = [
     title: "Schema",
   },
   {
-    linkTo: "documentation",
-    title: "Documentation",
+    linkTo: "readme",
+    title: "Readme",
   },
   {
     linkTo: "history",

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -75,7 +75,7 @@ function TopicOverviewResourcesTabs({
     },
     {
       topicOverviewTabEnum: TopicOverviewTabEnum.DOCUMENTATION,
-      title: "Documentation",
+      title: "Readme",
     },
     {
       topicOverviewTabEnum: TopicOverviewTabEnum.HISTORY,

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
@@ -82,22 +82,22 @@ describe("TopicDocumentation", () => {
 
       afterAll(cleanup);
 
-      it("shows headline No Documentation", () => {
+      it("shows headline No readme available", () => {
         const headline = screen.getByRole("heading", {
-          name: "No documentation",
+          name: "No readme available",
         });
         expect(headline).toBeVisible();
       });
 
-      it("shows a button to add documentation", () => {
-        const addDocumentationButton = screen.getByRole("button", {
-          name: "Add documentation",
+      it("shows a button to add readme", () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Add readme",
         });
-        expect(addDocumentationButton).toBeEnabled();
+        expect(addReadmeButton).toBeEnabled();
       });
     });
 
-    describe("enables user to add documentation", () => {
+    describe("enables user to add readme", () => {
       beforeEach(() => {
         mockUseTopicDetails.mockReturnValue(mockTopicDetails);
         mockUpdateTopicDocumentation.mockResolvedValue({
@@ -121,33 +121,46 @@ describe("TopicDocumentation", () => {
         expect(markdownEditor).not.toBeInTheDocument();
       });
 
-      it("shows the edit mode when user clicks button to add documentation", async () => {
-        const addDocumentationButton = screen.getByRole("button", {
-          name: "Add documentation",
+      it("shows the edit mode when user clicks button to add readme", async () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Add readme",
         });
-        const headlineNoDocumentation = screen.getByRole("heading", {
-          name: "No documentation",
+        const headlineNoReadme = screen.getByRole("heading", {
+          name: "No readme available",
         });
 
-        expect(headlineNoDocumentation).toBeVisible();
-        await user.click(addDocumentationButton);
+        expect(headlineNoReadme).toBeVisible();
+        await user.click(addReadmeButton);
 
         const markdownEditor = screen.getByRole("textbox", {
           name: "Markdown editor",
         });
         const headlineEdit = screen.getByRole("heading", {
-          name: "Edit documentation",
+          name: "Edit readme",
         });
 
         expect(markdownEditor).toBeVisible();
-        expect(headlineNoDocumentation).not.toBeInTheDocument();
+        expect(headlineNoReadme).not.toBeInTheDocument();
         expect(headlineEdit).toBeVisible();
+      });
+
+      it("shows a description about the readme", async () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Add readme",
+        });
+        await user.click(addReadmeButton);
+
+        const description = screen.getByText(
+          `Readme provides essential information, guidelines, and explanations about the topic, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the topic evolves.`
+        );
+
+        expect(description).toBeVisible();
       });
     });
   });
 
-  describe("if the topic has existing documentation", () => {
-    const existingDocumentation = "# Hello" as TopicDocumentationMarkdown;
+  describe("if the topic has existing readme", () => {
+    const existingReadme = "# Hello" as TopicDocumentationMarkdown;
 
     describe("shows all necessary elements", () => {
       beforeAll(() => {
@@ -155,7 +168,7 @@ describe("TopicDocumentation", () => {
           ...mockTopicDetails,
           topicOverview: {
             ...mockTopicDetails.topicOverview,
-            topicDocumentation: existingDocumentation,
+            topicDocumentation: existingReadme,
           },
         });
 
@@ -174,34 +187,42 @@ describe("TopicDocumentation", () => {
 
       afterAll(cleanup);
 
-      it("shows documentation headline", () => {
-        const headline = screen.getByRole("heading", { name: "Documentation" });
+      it("shows readme headline", () => {
+        const headline = screen.getByRole("heading", { name: "Readme" });
 
         expect(headline).toBeVisible();
       });
 
-      it("shows the documentation", () => {
+      it("shows a description about the readme", () => {
+        const description = screen.getByText(
+          `Readme provides essential information, guidelines, and explanations about the topic, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the topic evolves.`
+        );
+
+        expect(description).toBeVisible();
+      });
+
+      it("shows the readme", () => {
         const markdownView = screen.getByTestId("react-markdown-mock");
 
         expect(markdownView).toBeVisible();
-        expect(markdownView).toHaveTextContent(existingDocumentation);
+        expect(markdownView).toHaveTextContent(existingReadme);
       });
 
-      it("shows a button to edit documentation", () => {
-        const addDocumentationButton = screen.getByRole("button", {
-          name: "Edit documentation",
+      it("shows a button to edit readme", () => {
+        const addReadmeButton = screen.getByRole("button", {
+          name: "Edit readme",
         });
-        expect(addDocumentationButton).toBeEnabled();
+        expect(addReadmeButton).toBeEnabled();
       });
     });
 
-    describe("enables user to edit documentation", () => {
+    describe("enables user to edit readme", () => {
       beforeEach(() => {
         mockUseTopicDetails.mockReturnValue({
           ...mockTopicDetails,
           topicOverview: {
             ...mockTopicDetails.topicOverview,
-            topicDocumentation: existingDocumentation,
+            topicDocumentation: existingReadme,
           },
         });
 
@@ -215,18 +236,18 @@ describe("TopicDocumentation", () => {
 
       afterEach(cleanup);
 
-      it("shows the edit mode when user clicks button to edit documentation", async () => {
-        const editDocumentation = screen.getByRole("button", {
-          name: "Edit documentation",
+      it("shows the edit mode when user clicks button to edit readme", async () => {
+        const editReadme = screen.getByRole("button", {
+          name: "Edit readme",
         });
 
-        await user.click(editDocumentation);
+        await user.click(editReadme);
 
         const markdownEditor = screen.getByRole("textbox", {
           name: "Markdown editor",
         });
         const headlineEdit = screen.getByRole("heading", {
-          name: "Edit documentation",
+          name: "Edit readme",
         });
 
         expect(markdownEditor).toBeVisible();
@@ -235,8 +256,8 @@ describe("TopicDocumentation", () => {
     });
   });
 
-  describe("if documentation is updating", () => {
-    const existingDocumentation = "# Hello" as TopicDocumentationMarkdown;
+  describe("if readme is updating", () => {
+    const existingReadme = "# Hello" as TopicDocumentationMarkdown;
 
     beforeAll(() => {
       mockUseTopicDetails.mockReturnValue({
@@ -244,7 +265,7 @@ describe("TopicDocumentation", () => {
         topicOverviewIsRefetching: true,
         topicOverview: {
           ...mockTopicDetails.topicOverview,
-          topicDocumentation: existingDocumentation,
+          topicDocumentation: existingReadme,
         },
       });
 
@@ -263,35 +284,35 @@ describe("TopicDocumentation", () => {
 
     afterAll(cleanup);
 
-    it("shows documentation headline", () => {
-      const headline = screen.getByRole("heading", { name: "Documentation" });
+    it("shows readme headline", () => {
+      const headline = screen.getByRole("heading", { name: "Readme" });
 
       expect(headline).toBeVisible();
     });
 
-    it("shows accessible information about loading documentation", () => {
-      const loadingInformation = screen.getByText("Loading documentation");
+    it("shows accessible information about loading readme", () => {
+      const loadingInformation = screen.getByText("Loading readme");
 
       expect(loadingInformation).toBeVisible();
       expect(loadingInformation).toHaveClass("visually-hidden");
     });
 
-    it("shows no documentation", () => {
+    it("shows no readme", () => {
       const markdownView = screen.queryByTestId("react-markdown-mock");
 
       expect(markdownView).not.toBeInTheDocument();
     });
 
-    it("shows no button to edit documentation", () => {
-      const addDocumentationButton = screen.queryByRole("button", {
-        name: "Edit documentation",
+    it("shows no button to edit readme", () => {
+      const addReadmeButton = screen.queryByRole("button", {
+        name: "Edit readme",
       });
-      expect(addDocumentationButton).not.toBeInTheDocument();
+      expect(addReadmeButton).not.toBeInTheDocument();
     });
   });
 
-  describe("enables user to update documentation", () => {
-    const existingDocumentation = "# Hello" as TopicDocumentationMarkdown;
+  describe("enables user to update readme", () => {
+    const existingReadme = "# Hello" as TopicDocumentationMarkdown;
     const userInput = "**Hello world**";
 
     beforeEach(() => {
@@ -299,7 +320,7 @@ describe("TopicDocumentation", () => {
         ...mockTopicDetails,
         topicOverview: {
           ...mockTopicDetails.topicOverview,
-          topicDocumentation: existingDocumentation,
+          topicDocumentation: existingReadme,
         },
       });
       mockUpdateTopicDocumentation.mockResolvedValue({
@@ -319,9 +340,9 @@ describe("TopicDocumentation", () => {
       cleanup();
     });
 
-    it("enables user to cancel editing the documentation", async () => {
+    it("enables user to cancel editing the readme", async () => {
       const editButton = screen.getByRole("button", {
-        name: "Edit documentation",
+        name: "Edit readme",
       });
 
       await user.click(editButton);
@@ -344,9 +365,9 @@ describe("TopicDocumentation", () => {
       expect(previewMode).toBeVisible();
     });
 
-    it("saves documentation when user clicks button", async () => {
+    it("saves readme when user clicks button", async () => {
       const editButton = screen.getByRole("button", {
-        name: "Edit documentation",
+        name: "Edit readme",
       });
 
       await user.click(editButton);
@@ -357,7 +378,7 @@ describe("TopicDocumentation", () => {
       await user.type(markdownEditor, userInput);
 
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.click(saveButton);
@@ -365,16 +386,16 @@ describe("TopicDocumentation", () => {
       expect(mockUpdateTopicDocumentation).toHaveBeenCalledWith({
         topicName: "documentation-test-topic",
         topicIdForDocumentation: 99999,
-        topicDocumentation: existingDocumentation + userInput,
+        topicDocumentation: existingReadme + userInput,
       });
     });
 
     it("shows preview mode after successful update", async () => {
-      const editDocumentation = screen.getByRole("button", {
-        name: "Edit documentation",
+      const editReadme = screen.getByRole("button", {
+        name: "Edit readme",
       });
 
-      await user.click(editDocumentation);
+      await user.click(editReadme);
 
       const markdownEditor = screen.getByRole("textbox", {
         name: "Markdown editor",
@@ -382,7 +403,7 @@ describe("TopicDocumentation", () => {
       await user.type(markdownEditor, userInput);
 
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.click(saveButton);
@@ -393,7 +414,7 @@ describe("TopicDocumentation", () => {
     });
   });
 
-  describe("handles errors when transforming documentation intro correct markdown from backend", () => {
+  describe("handles errors when transforming readme intro correct markdown from backend", () => {
     const originalConsoleError = console.error;
     beforeEach(() => {
       console.error = jest.fn();
@@ -426,7 +447,7 @@ describe("TopicDocumentation", () => {
 
       expect(errorInformation).toBeVisible();
       expect(errorInformation).toHaveTextContent(
-        "Something went wrong while trying to transform the documentation into the right format."
+        "Something went wrong while trying to transform the readme into the right format."
       );
 
       const previewMode = screen.queryByTestId("react-markdown-mock");
@@ -437,8 +458,8 @@ describe("TopicDocumentation", () => {
     });
   });
 
-  describe("handles errors with updating documentation", () => {
-    const existingDocumentation = "# Hello" as TopicDocumentationMarkdown;
+  describe("handles errors with updating readme", () => {
+    const existingReadme = "# Hello" as TopicDocumentationMarkdown;
     const userInput = "**Hello world**";
 
     const originalConsoleError = console.error;
@@ -448,7 +469,7 @@ describe("TopicDocumentation", () => {
         ...mockTopicDetails,
         topicOverview: {
           ...mockTopicDetails.topicOverview,
-          topicDocumentation: existingDocumentation,
+          topicDocumentation: existingReadme,
         },
       });
       mockUpdateTopicDocumentation.mockRejectedValue({
@@ -470,9 +491,9 @@ describe("TopicDocumentation", () => {
       cleanup();
     });
 
-    it("shows errors without saving documentation when user clicks button", async () => {
+    it("shows errors without saving readme when user clicks button", async () => {
       const editButton = screen.getByRole("button", {
-        name: "Edit documentation",
+        name: "Edit readme",
       });
 
       await user.click(editButton);
@@ -483,7 +504,7 @@ describe("TopicDocumentation", () => {
       await user.type(markdownEditor, userInput);
 
       const saveButton = screen.getByRole("button", {
-        name: "Save documentation",
+        name: "Save readme",
       });
 
       await user.click(saveButton);
@@ -491,7 +512,7 @@ describe("TopicDocumentation", () => {
       const error = screen.getByRole("alert");
       expect(error).toBeVisible();
       expect(error).toHaveTextContent(
-        "The documentation could not be saved, there was an error"
+        "The readme could not be saved, there was an error"
       );
 
       const previewMode = screen.queryByTestId("react-markdown-mock");

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
@@ -151,7 +151,7 @@ describe("TopicDocumentation", () => {
         await user.click(addReadmeButton);
 
         const description = screen.getByText(
-          `Readme provides essential information, guidelines, and explanations about the topic, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the topic evolves.`
+          `Readme provides essential information, guidelines, and explanations about the topic, helping team members understand its purpose and usage. Edit the readme to update the information as the topic evolves.`
         );
 
         expect(description).toBeVisible();
@@ -195,7 +195,7 @@ describe("TopicDocumentation", () => {
 
       it("shows a description about the readme", () => {
         const description = screen.getByText(
-          `Readme provides essential information, guidelines, and explanations about the topic, helping team members understand its purpose and usage. Edit the readme to update or expand this information as the topic evolves.`
+          `Readme provides essential information, guidelines, and explanations about the topic, helping team members understand its purpose and usage. Edit the readme to update the information as the topic evolves.`
         );
 
         expect(description).toBeVisible();

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
@@ -19,6 +19,13 @@ import { DocumentationEditor } from "src/app/components/documentation/Documentat
 import { DocumentationView } from "src/app/components/documentation/DocumentationView";
 import { isDocumentationTransformationError } from "src/domain/helper/documentation-helper";
 
+const readmeDescription = (
+  <Box component={Typography.SmallText} marginBottom={"l2"}>
+    Readme provides essential information, guidelines, and explanations about
+    the topic, helping team members understand its purpose and usage. Edit the
+    readme to update the information as the topic evolves.
+  </Box>
+);
 function TopicDocumentation() {
   const queryClient = useQueryClient();
 
@@ -72,11 +79,7 @@ function TopicDocumentation() {
     return (
       <>
         <PageHeader title={"Edit readme"} />
-        <Box component={Typography.SmallText} marginBottom={"l2"}>
-          Readme provides essential information, guidelines, and explanations
-          about the topic, helping team members understand its purpose and
-          usage. Edit the readme to update the information as the topic evolves.
-        </Box>
+        {readmeDescription}
 
         {isError && (
           <Box marginBottom={"l1"}>
@@ -129,11 +132,7 @@ function TopicDocumentation() {
           onClick: () => setEditMode(true),
         }}
       />
-      <Box component={Typography.SmallText} marginBottom={"l2"}>
-        Readme provides essential information, guidelines, and explanations
-        about the topic, helping team members understand its purpose and usage.
-        Edit the readme to update the information as the topic evolves.
-      </Box>
+      {readmeDescription}
 
       <Box paddingTop={"l2"}>
         <DocumentationView markdownString={topicOverview.topicDocumentation} />

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
@@ -75,8 +75,7 @@ function TopicDocumentation() {
         <Box component={Typography.SmallText} marginBottom={"l2"}>
           Readme provides essential information, guidelines, and explanations
           about the topic, helping team members understand its purpose and
-          usage. Edit the readme to update or expand this information as the
-          topic evolves.
+          usage. Edit the readme to update the information as the topic evolves.
         </Box>
 
         {isError && (
@@ -133,8 +132,7 @@ function TopicDocumentation() {
       <Box component={Typography.SmallText} marginBottom={"l2"}>
         Readme provides essential information, guidelines, and explanations
         about the topic, helping team members understand its purpose and usage.
-        Edit the readme to update or expand this information as the topic
-        evolves.
+        Edit the readme to update the information as the topic evolves.
       </Box>
 
       <Box paddingTop={"l2"}>

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.tsx
@@ -1,4 +1,11 @@
-import { Alert, Box, PageHeader, Skeleton, useToast } from "@aivenio/aquarium";
+import {
+  Alert,
+  Box,
+  PageHeader,
+  Skeleton,
+  Typography,
+  useToast,
+} from "@aivenio/aquarium";
 import { NoDocumentationBanner } from "src/app/features/topics/details/documentation/components/NoDocumentationBanner";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { useState } from "react";
@@ -35,7 +42,7 @@ function TopicDocumentation() {
       onSuccess: () => {
         queryClient.refetchQueries(["topic-overview"]).then(() => {
           toast({
-            message: "Documentation successfully updated",
+            message: "Readme successfully updated",
             position: "bottom-left",
             variant: "default",
           });
@@ -52,9 +59,9 @@ function TopicDocumentation() {
   if (topicOverviewIsRefetching) {
     return (
       <>
-        <PageHeader title={"Documentation"} />
+        <PageHeader title={"Readme"} />
         <Box paddingTop={"l2"}>
-          <div className={"visually-hidden"}>Loading documentation</div>
+          <div className={"visually-hidden"}>Loading readme</div>
           <Skeleton />
         </Box>
       </>
@@ -64,23 +71,28 @@ function TopicDocumentation() {
   if (editMode) {
     return (
       <>
-        <PageHeader title={"Edit documentation"} />
-        <>
-          {isError && (
-            <Box marginBottom={"l1"}>
-              <Alert type="error">
-                The documentation could not be saved, there was an error: <br />
-                {parseErrorMsg(error)}
-              </Alert>
-            </Box>
-          )}
-          <DocumentationEditor
-            documentation={topicOverview.topicDocumentation}
-            save={(text) => mutate(text)}
-            cancel={() => setEditMode(false)}
-            isSaving={saving}
-          />
-        </>
+        <PageHeader title={"Edit readme"} />
+        <Box component={Typography.SmallText} marginBottom={"l2"}>
+          Readme provides essential information, guidelines, and explanations
+          about the topic, helping team members understand its purpose and
+          usage. Edit the readme to update or expand this information as the
+          topic evolves.
+        </Box>
+
+        {isError && (
+          <Box marginBottom={"l1"}>
+            <Alert type="error">
+              The readme could not be saved, there was an error: <br />
+              {parseErrorMsg(error)}
+            </Alert>
+          </Box>
+        )}
+        <DocumentationEditor
+          documentation={topicOverview.topicDocumentation}
+          save={(text) => mutate(text)}
+          cancel={() => setEditMode(false)}
+          isSaving={saving}
+        />
       </>
     );
   }
@@ -91,7 +103,7 @@ function TopicDocumentation() {
   ) {
     return (
       <>
-        <PageHeader title={"Documentation"} />
+        <PageHeader title={"Readme"} />
         <NoDocumentationBanner addDocumentation={() => setEditMode(true)} />
       </>
     );
@@ -100,10 +112,10 @@ function TopicDocumentation() {
   if (isDocumentationTransformationError(topicOverview.topicDocumentation)) {
     return (
       <>
-        <PageHeader title={"Documentation"} />
+        <PageHeader title={"Readme"} />
         <Alert type="error">
-          Something went wrong while trying to transform the documentation into
-          the right format.
+          Something went wrong while trying to transform the readme into the
+          right format.
         </Alert>
       </>
     );
@@ -112,12 +124,19 @@ function TopicDocumentation() {
   return (
     <>
       <PageHeader
-        title={"Documentation"}
+        title={"Readme"}
         primaryAction={{
-          text: "Edit documentation",
+          text: "Edit readme",
           onClick: () => setEditMode(true),
         }}
       />
+      <Box component={Typography.SmallText} marginBottom={"l2"}>
+        Readme provides essential information, guidelines, and explanations
+        about the topic, helping team members understand its purpose and usage.
+        Edit the readme to update or expand this information as the topic
+        evolves.
+      </Box>
+
       <Box paddingTop={"l2"}>
         <DocumentationView markdownString={topicOverview.topicDocumentation} />
       </Box>

--- a/coral/src/app/features/topics/details/documentation/components/NoDocumentationBanner.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/components/NoDocumentationBanner.test.tsx
@@ -1,6 +1,6 @@
-import { NoDocumentationBanner } from "src/app/features/topics/details/documentation/components/NoDocumentationBanner";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { NoDocumentationBanner } from "src/app/features/topics/details/documentation/components/NoDocumentationBanner";
 
 const testAddDocumentation = jest.fn();
 
@@ -16,20 +16,20 @@ describe("NoDocumentationBanner", () => {
 
     it("shows headline No Documentation", () => {
       const headline = screen.getByRole("heading", {
-        name: "No documentation",
+        name: "No readme available",
       });
       expect(headline).toBeVisible();
     });
 
-    it("shows information that no documentation is available for this topic", () => {
+    it("shows information that no readme is available for this topic", () => {
       const infoText = screen.getByText(
-        "You can add documentation for your topic."
+        "Add a readme to give your team essential information, guidelines, and context about the topic."
       );
       expect(infoText).toBeVisible();
     });
 
-    it("shows button to add a documentation", () => {
-      const button = screen.getByRole("button", { name: "Add documentation" });
+    it("shows button to add a readme", () => {
+      const button = screen.getByRole("button", { name: "Add readme" });
       expect(button).toBeVisible();
     });
   });
@@ -44,8 +44,8 @@ describe("NoDocumentationBanner", () => {
       jest.clearAllMocks();
     });
 
-    it("adds documentation when user clicks button", async () => {
-      const button = screen.getByRole("button", { name: "Add documentation" });
+    it("adds readme when user clicks button", async () => {
+      const button = screen.getByRole("button", { name: "Add readme" });
       await user.click(button);
 
       expect(testAddDocumentation).toHaveBeenCalled();

--- a/coral/src/app/features/topics/details/documentation/components/NoDocumentationBanner.tsx
+++ b/coral/src/app/features/topics/details/documentation/components/NoDocumentationBanner.tsx
@@ -9,15 +9,16 @@ function NoDocumentationBanner({
 }: NoDocumentationBannerProps) {
   return (
     <EmptyState
-      title={"No documentation"}
+      title={"No readme available"}
       image={illustration}
       layout={EmptyStateLayout.CenterHorizontal}
       primaryAction={{
-        text: "Add documentation",
+        text: "Add readme",
         onClick: addDocumentation,
       }}
     >
-      You can add documentation for your topic.
+      Add a readme to give your team essential information, guidelines, and
+      context about the topic.
     </EmptyState>
   );
 }

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -54,14 +54,14 @@ const TOPIC_OVERVIEW_TAB_ID_INTO_PATH = {
   [TopicOverviewTabEnum.ACLS]: "subscriptions",
   [TopicOverviewTabEnum.MESSAGES]: "messages",
   [TopicOverviewTabEnum.SCHEMA]: "schema",
-  [TopicOverviewTabEnum.DOCUMENTATION]: "documentation",
+  [TopicOverviewTabEnum.DOCUMENTATION]: "readme",
   [TopicOverviewTabEnum.HISTORY]: "history",
   [TopicOverviewTabEnum.SETTINGS]: "settings",
 } as const;
 
 const CONNECTOR_OVERVIEW_TAB_ID_INTO_PATH = {
   [ConnectorOverviewTabEnum.OVERVIEW]: "overview",
-  [ConnectorOverviewTabEnum.DOCUMENTATION]: "documentation",
+  [ConnectorOverviewTabEnum.DOCUMENTATION]: "readme",
   [ConnectorOverviewTabEnum.HISTORY]: "history",
   [ConnectorOverviewTabEnum.SETTINGS]: "settings",
 } as const;


### PR DESCRIPTION
# About this change - What it does

- renames "Documentation" to "Readme" (UI only) for topic and connector
- adds description to readme view (view of existing one as well as edit view)

1. No readme 

<img width="1229" alt="no-readme" src="https://github.com/Aiven-Open/klaw/assets/943800/7317ceb7-afef-48cf-95d2-d4cdd42e7e3c">


2. View for readme
<img width="1020" alt="view-readme" src="https://github.com/Aiven-Open/klaw/assets/943800/3e146f05-be70-4315-9afb-206df9cfb3d1">


3. Edit readme

<img width="1005" alt="edit-readme" src="https://github.com/Aiven-Open/klaw/assets/943800/a7969eae-418a-4fe7-ab4d-064f87020f4e">



Resolves: #1534

