### PR TITLE
Remove useless validation `Validate.notEmpty`

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/ValidationHelper.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/ValidationHelper.java
@@ -7,7 +7,6 @@ public class ValidationHelper {
 
   public static void validateNotEmptyOrBlank(String value, String errMsg) throws KlawRestException {
     try {
-      Validate.notEmpty(value);
       Validate.notBlank(value);
     } catch (Exception ex) {
       throw new KlawRestException(errMsg);


### PR DESCRIPTION
There is a useless validation `Validate.notEmpty` since `Validate.notBlank` does the same thing + checks whether input consists of only whitespaces or not