### PR TITLE
Update to fix the check to determine if a shema reg can be deleted.

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -531,7 +531,7 @@ public class EnvsClustersTenantsControllerService {
             envModel.setShowDeleteEnv(
                 !manageDatabase
                     .getHandleDbRequests()
-                    .existsConnectorComponentsForEnv(envModel.getId(), tenantId));
+                    .existsSchemaComponentsForEnv(envModel.getId(), tenantId));
           });
     }
 


### PR DESCRIPTION
About this change - What it does
Previously the schema reg delete check was being checked against the connectors table instead of the schema requests table.
Resolves: #xxxxx
Why this way
