### PR TITLE
refactor(coral): Update link for open request to PROMOTE for schema promotion

### DIFF
--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -224,7 +224,7 @@ describe("PromotionBanner", () => {
       expect(link).toBeVisible();
       expect(link).toHaveAttribute(
         "href",
-        "/requests/schemas?search=my-test-topic&requestType=CREATE&status=CREATED&page=1"
+        "/requests/schemas?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1"
       );
     });
   });

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -3,7 +3,6 @@ import { ReactElement } from "react";
 import { InternalLinkButton } from "src/app/components/InternalLinkButton";
 import illustration from "src/app/images/topic-details-banner-Illustration.svg";
 import { PromotionStatus } from "src/domain/promotion";
-import { RequestOperationType } from "src/domain/requests/requests-types";
 
 interface PromotionBannerProps {
   // `entityName` is only optional on
@@ -64,16 +63,13 @@ const PromotionBanner = ({
   }
 
   if (hasOpenPromotionRequest) {
-    // Schema currently shows all types as "CREATE"
-    const requestType: RequestOperationType =
-      type === "topic" ? "PROMOTE" : "CREATE";
     return (
       <Banner image={illustration} layout="vertical" title={""}>
         <Box component={"p"} marginBottom={"l1"}>
           An promotion request for {entityName} is already in progress.
         </Box>
         <InternalLinkButton
-          to={`/requests/${type}s?search=${entityName}&requestType=${requestType}&status=CREATED&page=1`}
+          to={`/requests/${type}s?search=${entityName}&requestType=PROMOTE&status=CREATED&page=1`}
         >
           View request
         </InternalLinkButton>

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
@@ -109,7 +109,7 @@ describe("SchemaPromotionBanner", () => {
     expect(linkSeeRequest).toBeVisible();
     expect(linkSeeRequest).toHaveAttribute(
       "href",
-      "/requests/schemas?search=my-test-topic&requestType=CREATE&status=CREATED&page=1"
+      "/requests/schemas?search=my-test-topic&requestType=PROMOTE&status=CREATED&page=1"
     );
     expect(buttonPromote).not.toBeInTheDocument();
   });


### PR DESCRIPTION
# About this change - What it does

Updates link to request type PROMOTE after backend update. 

