### PR TITLE
SchemaPromotionDetails Correct OperationType.

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaOverviewService.java
@@ -354,7 +354,7 @@ public class SchemaOverviewService extends BaseOverviewService {
                     .existsSchemaRequest(
                         topicName,
                         RequestStatus.CREATED.value,
-                        RequestOperationType.CREATE.value,
+                        RequestOperationType.PROMOTE.value,
                         s,
                         tenantId))
         .isPresent();

--- a/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaOverviewServiceTest.java
@@ -256,7 +256,7 @@ public class SchemaOverviewServiceTest {
     when(handleDbRequests.existsSchemaRequest(
             eq(TESTTOPIC),
             eq(RequestStatus.CREATED.value),
-            eq(RequestOperationType.CREATE.value),
+            eq(RequestOperationType.PROMOTE.value),
             eq("4"),
             eq(101)))
         .thenReturn(true);
@@ -292,7 +292,7 @@ public class SchemaOverviewServiceTest {
     when(handleDbRequests.existsSchemaRequest(
             eq(TESTTOPIC),
             eq(RequestStatus.CREATED.value),
-            eq(RequestOperationType.CREATE.value),
+            eq(RequestOperationType.PROMOTE.value),
             eq("4"),
             eq(101)))
         .thenReturn(true);


### PR DESCRIPTION
Small bugfix to check for schemas that are set up with RequestOperationType PROMOTE

About this change - What it does
When Schema Promotion was corrected to use the promote operation type, this check was missed.
Resolves: #xxxxx
Why this way
