### PR TITLE
Delete Schema Env allowed when no open requests remain

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1463,7 +1463,9 @@ public class SelectDataJdbc {
   public boolean existsSchemaComponentsForEnv(String env, int tenantId) {
     List<Supplier<Boolean>> list =
         List.of(
-            () -> schemaRequestRepo.existsSchemaRequestByEnvironmentAndTenantId(env, tenantId),
+            () ->
+                schemaRequestRepo.existsSchemaRequestByEnvironmentAndTenantIdAndRequestStatus(
+                    env, tenantId, RequestStatus.CREATED.value),
             () -> messageSchemaRepo.existsMessageSchemaByEnvironmentAndTenantId(env, tenantId));
     for (var elem : list) {
       if (elem.get()) {

--- a/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/SchemaRequestRepo.java
@@ -31,6 +31,9 @@ public interface SchemaRequestRepo
   boolean existsSchemaRequestByEnvironmentAndTenantId(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 
+  boolean existsSchemaRequestByEnvironmentAndTenantIdAndRequestStatus(
+      String envId, Integer tenantId, String requestStatus);
+
   @Query(
       value =
           "select exists(select 1 from kwschemarequests where teamid = :teamId and tenantid = :tenantId and topicstatus='created')",


### PR DESCRIPTION
Update existing check to only look for open/active schema requests when determining if it should be deleted.

About this change - What it does
Previously any request in any state would prevent the environment from being deleted, now if there are none in an open(CREATED) state it will allow the deletion/removal of the schema env.
Resolves: #xxxxx
Why this way
