### PR TITLE
Simplify SelectDataJdbc#getTopicRequestsCounts

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1528,30 +1528,14 @@ public class SelectDataJdbc {
   // claim requests
   public Map<String, Map<String, Long>> getTopicRequestsCounts(
       int teamId, RequestMode requestMode, int tenantId, String requestor) {
-    Map<String, Map<String, Long>> allCountsMap = new HashMap<>();
+    Map<String, Long> operationTypeCountsMap =
+        topicRequestsRepo.getCountPerTopicType(teamId, tenantId);
+    Map<String, Long> statusCountsMap = topicRequestsRepo.getCountPerTopicStatus(teamId, tenantId);
 
-    Map<String, Long> operationTypeCountsMap = new HashMap<>();
-    Map<String, Long> statusCountsMap = new HashMap<>();
-
-    if (RequestMode.MY_REQUESTS == requestMode) {
-      List<Object[]> topicRequestsOperationTypObj =
-          topicRequestsRepo.findAllTopicRequestsGroupByOperationType(teamId, tenantId);
-      updateMap(operationTypeCountsMap, topicRequestsOperationTypObj);
-
-      List<Object[]> topicRequestsStatusObj =
-          topicRequestsRepo.findAllTopicRequestsGroupByStatus(teamId, tenantId);
-      updateMap(statusCountsMap, topicRequestsStatusObj);
-    } else if (RequestMode.TO_APPROVE == requestMode || RequestMode.MY_APPROVALS == requestMode) {
-      List<Object[]> topicRequestsStatusObj =
-          topicRequestsRepo.findAllTopicRequestsGroupByStatus(teamId, tenantId);
-      updateMap(statusCountsMap, topicRequestsStatusObj);
-
+    if (RequestMode.TO_APPROVE == requestMode || RequestMode.MY_APPROVALS == requestMode) {
       long assignedToClaimReqs =
           topicRequestsRepo.countAllTopicRequestsByApprovingTeamAndTopictype(
               tenantId, "" + teamId, RequestOperationType.CLAIM.value);
-      List<Object[]> topicRequestsOperationTypObj =
-          topicRequestsRepo.findAllTopicRequestsGroupByOperationType(teamId, tenantId);
-      updateMap(operationTypeCountsMap, topicRequestsOperationTypObj);
 
       operationTypeCountsMap.put(RequestOperationType.CLAIM.value, assignedToClaimReqs);
       if (RequestMode.MY_APPROVALS == requestMode) {
@@ -1566,13 +1550,8 @@ public class SelectDataJdbc {
       }
     }
 
-    // update with 0L if requests don't exist
-    updateCountsForNonExistingRequestTypes(operationTypeCountsMap, statusCountsMap);
-
-    allCountsMap.put("STATUS_COUNTS", statusCountsMap);
-    allCountsMap.put("OPERATION_TYPE_COUNTS", operationTypeCountsMap);
-
-    return allCountsMap;
+    return Map.of(
+        "STATUS_COUNTS", statusCountsMap, "OPERATION_TYPE_COUNTS", operationTypeCountsMap);
   }
 
   // Acl requests can be submitted by any team. your team or other teams on topics.

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -79,7 +79,7 @@ public interface TopicRequestsRepo
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
 
   default Map<String, Long> getCountPerTopicStatus(Integer teamId, Integer tenantId) {
-    return toStringLongMap(findCountPerTopicStatus(teamId, tenantId));
+    return deriveCountsFromRequests(findCountPerTopicStatus(teamId, tenantId));
   }
 
   @Query(

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -2,7 +2,9 @@ package io.aiven.klaw.repository;
 
 import io.aiven.klaw.dao.TopicRequest;
 import io.aiven.klaw.dao.TopicRequestID;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -64,13 +66,21 @@ public interface TopicRequestsRepo
   List<Object[]> findAllTopicRequestsGroupByOperationType(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
 
+  default Map<String, Long> getCountPerTopicType(Integer teamId, Integer tenantId) {
+    return toStringLongMap(findAllTopicRequestsGroupByOperationType(teamId, tenantId));
+  }
+
   @Query(
       value =
           "select topicstatus, count(*) from kwtopicrequests where tenantid = :tenantId"
               + " and teamid = :teamId group by topicstatus",
       nativeQuery = true)
-  List<Object[]> findAllTopicRequestsGroupByStatus(
+  List<Object[]> findCountPerTopicStatus(
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
+
+  default Map<String, Long> getCountPerTopicStatus(Integer teamId, Integer tenantId) {
+    return toStringLongMap(findCountPerTopicStatus(teamId, tenantId));
+  }
 
   @Query(
       value =
@@ -96,4 +106,12 @@ public interface TopicRequestsRepo
       @Param("topicStatus") String topicStatus);
 
   void deleteByTenantId(int tenantId);
+
+  private Map<String, Long> toStringLongMap(List<Object[]> list) {
+    var result = new HashMap<String, Long>(list.size());
+    for (var elem : list) {
+      result.put((String) elem[0], (Long) elem[1]);
+    }
+    return result;
+  }
 }

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -67,7 +67,7 @@ public interface TopicRequestsRepo
       @Param("teamId") Integer teamId, @Param("tenantId") Integer tenantId);
 
   default Map<String, Long> getCountPerTopicType(Integer teamId, Integer tenantId) {
-    return toStringLongMap(findAllTopicRequestsGroupByOperationType(teamId, tenantId));
+    return deriveCountsFromRequests(findAllTopicRequestsGroupByOperationType(teamId, tenantId));
   }
 
   @Query(
@@ -107,7 +107,7 @@ public interface TopicRequestsRepo
 
   void deleteByTenantId(int tenantId);
 
-  private Map<String, Long> toStringLongMap(List<Object[]> list) {
+  private Map<String, Long> deriveCountsFromRequests(List<Object[]> list) {
     var result = new HashMap<String, Long>(list.size());
     for (var elem : list) {
       result.put((String) elem[0], (Long) elem[1]);

--- a/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
@@ -96,7 +96,7 @@ public class RequestStatisticsService {
       RequestStatusCount requestStatusCount =
           RequestStatusCount.builder()
               .requestStatus(RequestStatus.of(key))
-              .count(stCounts.get(key))
+              .count(stCounts.getOrDefault(key, 0L))
               .build();
       requestStatusCountSet.add(requestStatusCount);
     }
@@ -105,7 +105,7 @@ public class RequestStatisticsService {
       RequestsOperationTypeCount requestsOperationTypeCount =
           RequestsOperationTypeCount.builder()
               .requestOperationType(RequestOperationType.of(key))
-              .count(opCounts.get(key))
+              .count(opCounts.getOrDefault(key, 0L))
               .build();
       requestsOperationTypeCountsSet.add(requestsOperationTypeCount);
     }

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
@@ -284,14 +284,14 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
-    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);
-    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
+    assertThat(results).hasSize(2);
+    assertThat(statsCount).containsEntry(RequestStatus.CREATED.value, 4L);
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.CREATE.value, 0L)).isZero();
+    assertThat(operationTypeCount).containsEntry(RequestOperationType.CLAIM.value, 7L);
+    assertThat(statsCount.getOrDefault(RequestStatus.APPROVED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DECLINED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DELETED.value, 0L)).isZero();
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.UPDATE.value, 0L)).isZero();
   }
 
   @Test
@@ -303,14 +303,14 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> statsCount = results.get("STATUS_COUNTS");
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
-    assertThat(results.size()).isEqualTo(2);
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
-    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(4L);
-    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
+    assertThat(results).hasSize(2);
+    assertThat(statsCount).containsEntry(RequestStatus.CREATED.value, 4L);
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.CREATE.value, 0L)).isZero();
+    assertThat(operationTypeCount).containsEntry(RequestOperationType.CLAIM.value, 4L);
+    assertThat(statsCount.getOrDefault(RequestStatus.APPROVED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DECLINED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DELETED.value, 0L)).isZero();
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.UPDATE.value, 0L)).isZero();
   }
 
   @Test
@@ -780,13 +780,13 @@ public class TopicRequestsIntegrationTest {
 
     assertThat(results).hasSize(2);
     // Jackie created all the requests so we expect 0 for created status which is approval status
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);
-    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
+    assertThat(statsCount.getOrDefault(RequestStatus.CREATED.value, 0L)).isZero();
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.CREATE.value, 0L)).isZero();
+    assertThat(operationTypeCount).containsEntry(RequestOperationType.CLAIM.value, 7L);
+    assertThat(statsCount.getOrDefault(RequestStatus.APPROVED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DECLINED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DELETED.value, 0L)).isZero();
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.UPDATE.value, 0L)).isZero();
   }
 
   @Test
@@ -799,13 +799,13 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
     assertThat(results).hasSize(2);
-    assertThat(statsCount.get(RequestStatus.CREATED.value)).isEqualTo(4L);
-    assertThat(operationTypeCount.get(RequestOperationType.CREATE.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.CLAIM.value)).isEqualTo(7L);
-    assertThat(statsCount.get(RequestStatus.APPROVED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DECLINED.value)).isEqualTo(0L);
-    assertThat(statsCount.get(RequestStatus.DELETED.value)).isEqualTo(0L);
-    assertThat(operationTypeCount.get(RequestOperationType.UPDATE.value)).isEqualTo(0L);
+    assertThat(statsCount).containsEntry(RequestStatus.CREATED.value, 4L);
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.CREATE.value, 0L)).isZero();
+    assertThat(operationTypeCount).containsEntry(RequestOperationType.CLAIM.value, 7L);
+    assertThat(statsCount.getOrDefault(RequestStatus.APPROVED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DECLINED.value, 0L)).isZero();
+    assertThat(statsCount.getOrDefault(RequestStatus.DELETED.value, 0L)).isZero();
+    assertThat(operationTypeCount.getOrDefault(RequestOperationType.UPDATE.value, 0L)).isZero();
   }
 
   @Order(31)


### PR DESCRIPTION
The idea is to simplify this method and to minimize size of map transferring
