### PR TITLE
bugfix - Allow delete kafka env when no open reqs

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1440,9 +1440,13 @@ public class SelectDataJdbc {
     List<Supplier<Boolean>> list =
         List.of(
             () -> topicRepo.existsByEnvironmentAndTenantId(env, tenantId),
-            () -> topicRequestsRepo.existsByEnvironmentAndTenantId(env, tenantId),
+            () ->
+                topicRequestsRepo.existsByTenantIdAndEnvironmentAndRequestStatus(
+                    tenantId, env, RequestStatus.CREATED.value),
             () -> aclRepo.existsByEnvironmentAndTenantId(env, tenantId),
-            () -> aclRequestsRepo.existsByEnvironmentAndTenantId(env, tenantId));
+            () ->
+                aclRequestsRepo.existsByTenantIdAndEnvironmentAndRequestStatus(
+                    tenantId, env, RequestStatus.CREATED.value));
     for (var elem : list) {
       if (elem.get()) {
         return true;

--- a/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/AclRequestsRepo.java
@@ -18,6 +18,9 @@ public interface AclRequestsRepo
   boolean existsByTenantIdAndEnvironmentAndRequestStatusAndTopicname(
       int tenantId, String env, String requestStatus, String topicname);
 
+  boolean existsByTenantIdAndEnvironmentAndRequestStatus(
+      int tenantId, String env, String requestStatus);
+
   boolean existsByEnvironmentAndTenantId(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -28,6 +28,9 @@ public interface TopicRequestsRepo
   boolean existsByTenantIdAndRequestStatusAndRequestOperationTypeAndTopicname(
       int tenantId, String requestStatus, String requestOperationType, String topicname);
 
+  boolean existsByTenantIdAndEnvironmentAndRequestStatus(
+      int tenantId, String environment, String requestStatus);
+
   List<TopicRequest> findAllByRequestStatusAndTopicnameAndEnvironmentAndTenantId(
       String topicStatus, String topicName, String envId, int tenantId);
 


### PR DESCRIPTION
When checking if a env can be deleted we should only check for open requests not any request that has ever been made.

About this change - What it does
It adds the RequestStatus value "created" to the exists query making sure that there are no open requests.
Resolves: #xxxxx
Why this way
