### PR TITLE
Missing case for promote type operation on connectors

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -229,7 +229,7 @@ public class UpdateDataJdbc {
       return ApiResultStatus.SUCCESS.value;
     }
     switch (rot) {
-      case CREATE -> insertDataJdbcHelper.insertIntoConnectorSOT(connectors, false);
+      case CREATE, PROMOTE -> insertDataJdbcHelper.insertIntoConnectorSOT(connectors, false);
       case UPDATE -> updateConnectorSOT(connectors, connectorRequest.getOtherParams());
       case DELETE -> deleteDataJdbcHelper.deleteConnectors(topicObj);
     }


### PR DESCRIPTION
About this change - What it does
Adds when a connector of type promote is created to add it to the DB cache.
Resolves: #xxxxx
Why this way
Makes it available to the user straight after promotion.