### PR TITLE
fix(coral): Fix UI and functional bug for approval tables

### DIFF
--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -116,6 +116,7 @@ function Modal(props: ModalProps) {
           className={classes.modalWrapper}
         >
           <Box
+            aria-label={title}
             component={"dialog"}
             aria-modal={"true"}
             paddingX={"l3"}

--- a/coral/src/app/features/approvals/acls/AclApprovals.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.tsx
@@ -93,7 +93,6 @@ function AclApprovals() {
     mutationFn: approveAclRequest,
     onSuccess: () => {
       setErrorMessage("");
-      setDetailsModal({ isOpen: false, reqNo: null });
 
       // Refetch to update the tag number in the tabs
       queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
@@ -113,6 +112,9 @@ function AclApprovals() {
     onError: (error: Error) => {
       setErrorMessage(parseErrorMsg(error));
     },
+    onSettled: () => {
+      setDetailsModal({ isOpen: false, reqNo: null });
+    },
   });
 
   const {
@@ -123,7 +125,6 @@ function AclApprovals() {
     mutationFn: declineAclRequest,
     onSuccess: () => {
       setErrorMessage("");
-      setDeclineModal({ isOpen: false, reqNo: null });
 
       // Refetch to update the tag number in the tabs
       queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
@@ -143,6 +144,9 @@ function AclApprovals() {
     },
     onError: (error: Error) => {
       setErrorMessage(parseErrorMsg(error));
+    },
+    onSettled: () => {
+      setDeclineModal({ isOpen: false, reqNo: null });
     },
   });
 

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
@@ -226,7 +226,7 @@ describe("AclApprovalsTable", () => {
       within(within(getNthRow(1)).getAllByRole("cell")[10]).getByRole(
         "button",
         {
-          name: "View acl request for aivtopic1",
+          name: "View ACL request for aivtopic1",
         }
       )
     );
@@ -240,7 +240,7 @@ describe("AclApprovalsTable", () => {
       within(within(getNthRow(1)).getAllByRole("cell")[11]).getByRole(
         "button",
         {
-          name: "Approve acl request for aivtopic1",
+          name: "Approve ACL request for aivtopic1",
         }
       )
     );
@@ -254,7 +254,7 @@ describe("AclApprovalsTable", () => {
       within(within(getNthRow(1)).getAllByRole("cell")[12]).getByRole(
         "button",
         {
-          name: "Decline acl request for aivtopic1",
+          name: "Decline ACL request for aivtopic1",
         }
       )
     );
@@ -315,7 +315,7 @@ describe("AclApprovalsTable", () => {
       within(within(getNthRow(1)).getAllByRole("cell")[11]).getByRole(
         "button",
         {
-          name: "Approve acl request for aivtopic1",
+          name: "Approve ACL request for aivtopic1",
         }
       )
     ).toBeDisabled();
@@ -323,7 +323,7 @@ describe("AclApprovalsTable", () => {
       within(within(getNthRow(1)).getAllByRole("cell")[12]).getByRole(
         "button",
         {
-          name: "Decline acl request for aivtopic1",
+          name: "Decline ACL request for aivtopic1",
         }
       )
     ).toBeDisabled();
@@ -341,7 +341,7 @@ describe("AclApprovalsTable", () => {
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const approve = within(approvedRequestRow).getByRole("button", {
-        name: "Approve acl request for newaudittopic",
+        name: "Approve ACL request for newaudittopic",
       });
       expect(approve).toBeDisabled();
     });
@@ -352,7 +352,7 @@ describe("AclApprovalsTable", () => {
       const rows = within(table).getAllByRole("row");
       const approvedRequestRow = rows[2];
       const decline = within(approvedRequestRow).getByRole("button", {
-        name: "Decline acl request for newaudittopic",
+        name: "Decline ACL request for newaudittopic",
       });
       expect(decline).toBeDisabled();
     });
@@ -372,7 +372,7 @@ describe("AclApprovalsTable", () => {
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const approve = within(createdRequestRow).getByRole("button", {
-        name: "Approve acl request for aivtopic1",
+        name: "Approve ACL request for aivtopic1",
       });
       expect(approve).toBeDisabled();
     });
@@ -383,7 +383,7 @@ describe("AclApprovalsTable", () => {
       const rows = within(table).getAllByRole("row");
       const createdRequestRow = rows[1];
       const decline = within(createdRequestRow).getByRole("button", {
-        name: "Decline acl request for aivtopic1",
+        name: "Decline ACL request for aivtopic1",
       });
       expect(decline).toBeDisabled();
     });
@@ -403,7 +403,7 @@ describe("AclApprovalsTable", () => {
       const createdRequestRow = rows[1];
       await userEvent.click(
         within(createdRequestRow).getByRole("button", {
-          name: "View acl request for aivtopic1",
+          name: "View ACL request for aivtopic1",
         })
       );
       expect(onDetails).toHaveBeenCalledTimes(1);

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -187,7 +187,7 @@ export default function AclApprovalsTable({
       action: (request: AclRequestTableRow) => ({
         onClick: () => onDetails(request.id),
         text: "View",
-        "aria-label": `View acl request for ${request.topicname}`,
+        "aria-label": `View ACL request for ${request.topicname}`,
         icon: infoSign,
       }),
     },
@@ -202,7 +202,7 @@ export default function AclApprovalsTable({
         return {
           onClick: () => onApprove(request.id),
           text: "Approve",
-          "aria-label": `Approve acl request for ${request.topicname}`,
+          "aria-label": `Approve ACL request for ${request.topicname}`,
           disabled:
             approveInProgress ||
             declineInProgress ||
@@ -224,13 +224,13 @@ export default function AclApprovalsTable({
         return {
           onClick: () => onDecline(request.id),
           text: "Decline",
-          "aria-label": `Decline acl request for ${request.topicname}`,
+          "aria-label": `Decline ACL request for ${request.topicname}`,
           disabled:
             approveInProgress ||
             declineInProgress ||
             actionsDisabled ||
             request.requestStatus !== "CREATED",
-          tooltip: `Decline acl request for topic ${request.topicname}`,
+          tooltip: `Decline ACL request for topic ${request.topicname}`,
           icon: declineInProgress ? loadingIcon : deleteIcon,
           loading: declineInProgress,
         };

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
@@ -656,4 +656,446 @@ describe("ConnectorApprovals", () => {
       expect(console.error).toHaveBeenCalledWith("OH NO");
     });
   });
+
+  describe("enables user to approve a request with quick action", () => {
+    const testRequest = mockedApiResponseConnectorRequests.entries[0];
+
+    const orignalConsoleError = console.error;
+    beforeEach(async () => {
+      console.error = jest.fn();
+      mockGetSyncConnectorsEnvironments.mockResolvedValue(
+        mockedEnvironmentResponse
+      );
+      mockGetConnectorRequestsForApprover.mockResolvedValue(
+        mockedApiResponseConnectorRequests
+      );
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      console.error = orignalConsoleError;
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("send a approve request api call if user approves a connector request", async () => {
+      mockApproveConnectorRequest.mockResolvedValue([
+        { success: true, message: "" },
+      ]);
+
+      const approveButton = screen.getByRole("button", {
+        name: `Approve Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(approveButton);
+
+      expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+      });
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("updates the the data for the table if user approves a connector request", async () => {
+      mockApproveConnectorRequest.mockResolvedValue([
+        { success: true, message: "" },
+      ]);
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
+        1,
+        defaultApiParams
+      );
+
+      const approveButton = screen.getByRole("button", {
+        name: `Approve Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(approveButton);
+
+      expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+      });
+
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
+        2,
+        defaultApiParams
+      );
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("informs user about error if approving request was not successful", async () => {
+      mockApproveConnectorRequest.mockRejectedValue("OH NO");
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
+        1,
+        defaultApiParams
+      );
+
+      const approveButton = screen.getByRole("button", {
+        name: `Approve Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(approveButton);
+
+      expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+      });
+
+      expect(mockApproveConnectorRequest).not.toHaveBeenCalledTimes(2);
+
+      const error = await screen.findByRole("alert");
+      expect(error).toBeVisible();
+
+      expect(console.error).toHaveBeenCalledWith("OH NO");
+    });
+  });
+
+  describe("enables user to approve a request through details modal", () => {
+    const testRequest = mockedApiResponseConnectorRequests.entries[0];
+
+    const orignalConsoleError = console.error;
+    beforeEach(async () => {
+      console.error = jest.fn();
+      mockGetSyncConnectorsEnvironments.mockResolvedValue(
+        mockedEnvironmentResponse
+      );
+      mockGetConnectorRequestsForApprover.mockResolvedValue(
+        mockedApiResponseConnectorRequests
+      );
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      console.error = orignalConsoleError;
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("send a approve request api call if user approves a connector request", async () => {
+      mockApproveConnectorRequest.mockResolvedValue([
+        { success: true, message: "" },
+      ]);
+
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog", { name: "Request details" });
+
+      expect(modal).toBeVisible();
+      const approveButton = within(modal).getByRole("button", {
+        name: "Approve",
+      });
+
+      await userEvent.click(approveButton);
+
+      expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+      });
+      expect(console.error).not.toHaveBeenCalled();
+      expect(modal).not.toBeInTheDocument();
+    });
+
+    it("updates the the data for the table if user approves a connector request", async () => {
+      mockApproveConnectorRequest.mockResolvedValue([
+        { success: true, message: "" },
+      ]);
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
+        1,
+        defaultApiParams
+      );
+
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog", { name: "Request details" });
+
+      expect(modal).toBeVisible();
+      const approveButton = within(modal).getByRole("button", {
+        name: "Approve",
+      });
+
+      await userEvent.click(approveButton);
+
+      expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+      });
+
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
+        2,
+        defaultApiParams
+      );
+      expect(console.error).not.toHaveBeenCalled();
+      expect(modal).not.toBeInTheDocument();
+    });
+
+    it("informs user about error if approving request was not successful", async () => {
+      mockApproveConnectorRequest.mockRejectedValue("OH NO");
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
+        1,
+        defaultApiParams
+      );
+
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const modal = screen.getByRole("dialog", { name: "Request details" });
+
+      expect(modal).toBeVisible();
+      const approveButton = within(modal).getByRole("button", {
+        name: "Approve",
+      });
+
+      await userEvent.click(approveButton);
+
+      expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+      });
+
+      expect(mockApproveConnectorRequest).not.toHaveBeenCalledTimes(2);
+
+      const error = await screen.findByRole("alert");
+      expect(error).toBeVisible();
+      expect(modal).not.toBeInTheDocument();
+
+      expect(console.error).toHaveBeenCalledWith("OH NO");
+    });
+  });
+
+  describe("enables user to decline a request with quick action", () => {
+    const testRequest = mockedApiResponseConnectorRequests.entries[0];
+
+    const orignalConsoleError = console.error;
+    beforeEach(async () => {
+      console.error = jest.fn();
+      mockGetSyncConnectorsEnvironments.mockResolvedValue(
+        mockedEnvironmentResponse
+      );
+      mockGetConnectorRequestsForApprover.mockResolvedValue(
+        mockedApiResponseConnectorRequests
+      );
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      console.error = orignalConsoleError;
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("does not send a decline request is user does not add a reason", async () => {
+      mockDeclineConnectorRequest.mockResolvedValue([
+        { success: true, message: "" },
+      ]);
+
+      const declineButton = screen.getByRole("button", {
+        name: `Decline Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(declineButton);
+
+      const declineModal = screen.getByRole("dialog", {
+        name: "Decline request",
+      });
+      expect(declineModal).toBeVisible();
+
+      const confirmDecline = within(declineModal).getByRole("button", {
+        name: "Decline request",
+      });
+
+      expect(confirmDecline).toBeDisabled();
+      await userEvent.click(confirmDecline);
+
+      expect(mockDeclineConnectorRequest).not.toHaveBeenCalled();
+      expect(declineModal).toBeVisible();
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("send a decline request api call if user declines a connector request", async () => {
+      mockDeclineConnectorRequest.mockResolvedValue([
+        { success: true, message: "" },
+      ]);
+
+      const declineButton = screen.getByRole("button", {
+        name: `Decline Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(declineButton);
+
+      const declineModal = screen.getByRole("dialog", {
+        name: "Decline request",
+      });
+      expect(declineModal).toBeVisible();
+
+      const textAreaReason = within(declineModal).getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      });
+
+      await userEvent.type(textAreaReason, "my reason");
+
+      const confirmDecline = within(declineModal).getByRole("button", {
+        name: "Decline request",
+      });
+
+      await userEvent.click(confirmDecline);
+
+      expect(mockDeclineConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+        reason: "my reason",
+      });
+
+      expect(console.error).not.toHaveBeenCalled();
+      expect(declineModal).not.toBeInTheDocument();
+    });
+
+    it("updates the the data for the table if user declines a connector request", async () => {
+      mockDeclineConnectorRequest.mockResolvedValue([
+        { success: true, message: "" },
+      ]);
+
+      const declineButton = screen.getByRole("button", {
+        name: `Decline Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(declineButton);
+
+      const declineModal = screen.getByRole("dialog", {
+        name: "Decline request",
+      });
+      expect(declineModal).toBeVisible();
+
+      const textAreaReason = within(declineModal).getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      });
+
+      await userEvent.type(textAreaReason, "my reason");
+
+      const confirmDecline = within(declineModal).getByRole("button", {
+        name: "Decline request",
+      });
+
+      await userEvent.click(confirmDecline);
+
+      expect(mockDeclineConnectorRequest).toHaveBeenCalledWith({
+        reqIds: [String(testRequest.connectorId)],
+        reason: "my reason",
+      });
+
+      expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
+        2,
+        defaultApiParams
+      );
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("informs user about error if declining request was not successful", async () => {
+      mockDeclineConnectorRequest.mockRejectedValue("Oh no");
+
+      const declineButton = screen.getByRole("button", {
+        name: `Decline Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(declineButton);
+
+      const declineModal = screen.getByRole("dialog", {
+        name: "Decline request",
+      });
+      expect(declineModal).toBeVisible();
+
+      const textAreaReason = within(declineModal).getByRole("textbox", {
+        name: "Submit a reason to decline the request *",
+      });
+
+      await userEvent.type(textAreaReason, "my reason");
+
+      const confirmDecline = within(declineModal).getByRole("button", {
+        name: "Decline request",
+      });
+
+      await userEvent.click(confirmDecline);
+
+      expect(mockApproveConnectorRequest).not.toHaveBeenCalledTimes(2);
+
+      const error = await screen.findByRole("alert");
+      expect(error).toBeVisible();
+      expect(declineModal).not.toBeInTheDocument();
+
+      expect(console.error).toHaveBeenCalledWith("Oh no");
+    });
+  });
+
+  describe("enables user to decline a request through details modal", () => {
+    const testRequest = mockedApiResponseConnectorRequests.entries[0];
+
+    const orignalConsoleError = console.error;
+    beforeEach(async () => {
+      console.error = jest.fn();
+      mockGetSyncConnectorsEnvironments.mockResolvedValue(
+        mockedEnvironmentResponse
+      );
+      mockGetConnectorRequestsForApprover.mockResolvedValue(
+        mockedApiResponseConnectorRequests
+      );
+
+      customRender(<ConnectorApprovals />, {
+        queryClient: true,
+        memoryRouter: true,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      console.error = orignalConsoleError;
+      jest.resetAllMocks();
+      cleanup();
+    });
+
+    it("opens the decline user flow when user clicks decline in details modal", async () => {
+      const viewDetailsButton = screen.getByRole("button", {
+        name: `View Kafka connector request for ${testRequest.connectorName}`,
+      });
+
+      await userEvent.click(viewDetailsButton);
+      const detailsModal = screen.getByRole("dialog", {
+        name: "Request details",
+      });
+
+      expect(detailsModal).toBeVisible();
+      const declineButton = within(detailsModal).getByRole("button", {
+        name: "Decline",
+      });
+
+      await userEvent.click(declineButton);
+
+      expect(detailsModal).not.toBeInTheDocument();
+
+      const declineModal = screen.getByRole("dialog", {
+        name: "Decline request",
+      });
+
+      expect(declineModal).toBeVisible();
+      expect(console.error).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/coral/src/app/features/approvals/topics/TopicApprovals.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.tsx
@@ -96,7 +96,6 @@ function TopicApprovals() {
     mutationFn: approveTopicRequest,
     onSuccess: () => {
       setErrorQuickActions("");
-      setDetailsModal({ isOpen: false, reqNo: null });
 
       // Refetch to update the tag number in the tabs
       queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
@@ -120,6 +119,7 @@ function TopicApprovals() {
     onError: (error: HTTPError) => {
       setErrorQuickActions(parseErrorMsg(error));
     },
+    onSettled: closeDetailsModal,
   });
 
   const {
@@ -130,7 +130,6 @@ function TopicApprovals() {
     mutationFn: declineTopicRequest,
     onSuccess: () => {
       setErrorQuickActions("");
-      setDeclineModal({ isOpen: false, reqNo: null });
 
       // Refetch to update the tag number in the tabs
       queryClient.refetchQueries(["getRequestsWaitingForApproval"]);
@@ -154,12 +153,21 @@ function TopicApprovals() {
     onError: (error: HTTPError) => {
       setErrorQuickActions(parseErrorMsg(error));
     },
+    onSettled: closeDeclineModal,
   });
 
   const setCurrentPage = (page: number) => {
     searchParams.set("page", page.toString());
     setSearchParams(searchParams);
   };
+
+  function closeDetailsModal() {
+    setDetailsModal({ isOpen: false, reqNo: null });
+  }
+
+  function closeDeclineModal() {
+    setDeclineModal({ isOpen: false, reqNo: null });
+  }
 
   function handleViewRequest(reqNo: number): void {
     setDetailsModal({ isOpen: true, reqNo });
@@ -219,7 +227,7 @@ function TopicApprovals() {
     <>
       {detailsModal.isOpen && (
         <RequestDetailsModal
-          onClose={() => setDetailsModal({ isOpen: false, reqNo: null })}
+          onClose={closeDetailsModal}
           actions={{
             primary: {
               text: "Approve",
@@ -236,7 +244,7 @@ function TopicApprovals() {
             secondary: {
               text: "Decline",
               onClick: () => {
-                setDetailsModal({ isOpen: false, reqNo: null });
+                closeDetailsModal();
                 setDeclineModal({
                   isOpen: true,
                   reqNo: detailsModal.reqNo,
@@ -256,8 +264,8 @@ function TopicApprovals() {
       )}
       {declineModal.isOpen && (
         <RequestDeclineModal
-          onClose={() => setDeclineModal({ isOpen: false, reqNo: null })}
-          onCancel={() => setDeclineModal({ isOpen: false, reqNo: null })}
+          onClose={closeDeclineModal}
+          onCancel={closeDeclineModal}
           onSubmit={(message: string) => {
             if (declineModal.reqNo === null) {
               setErrorQuickActions("reqNo is null, it should be a number");

--- a/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
@@ -497,6 +497,7 @@ describe("<TopicEditRequest />", () => {
         replicationfactor: mockTopicDetails.topicContents.noOfReplicas,
         topicname: TOPIC_NAME,
         topicpartitions: String(mockTopicDetails.topicContents.noOfPartitions),
+        topicId: mockTopicDetails.topicId,
       });
     });
 

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -99,7 +99,7 @@ function TopicEditRequest() {
     if (
       environmentIsFetched &&
       topicDetailsForEnvIsFetched &&
-      !topicDetailsForEnv?.topicExists
+      (!topicDetailsForEnv?.topicExists || !topicDetailsForEnv?.topicId)
     ) {
       navigate(Routes.TOPICS, { replace: true });
       toast({
@@ -172,7 +172,23 @@ function TopicEditRequest() {
       });
       return;
     }
-    edit(data);
+
+    // @TODO 2: when creating a request to update a topic, we need to set the topicId in the optional
+    // 'otherParams'. We will update the endpoint(s) to be better named and more precise (not having an
+    // important param be optional), that's why we're adding a bit of a messy fix here instead of updating
+    // forms schema etc.
+    if (topicDetailsForEnv?.topicId === undefined) {
+      // this case should never happen, as we redirect user and show an error
+      // if there is no `topicDetailsForEnv` or `topicDetailsForEnv.topicId`,
+      // so we want want to throw an Error here to not hide a bug
+      throw Error("No topicId set!");
+    } else {
+      const requestTopicEditParams = {
+        ...data,
+        topicId: topicDetailsForEnv.topicId,
+      };
+      edit(requestTopicEditParams);
+    }
   };
 
   function cancelRequest() {

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -145,10 +145,15 @@ const requestTopicPromotion = (
   >(API_PATHS.createTopicsCreateRequest, payload);
 };
 
+type RequestTopicEdit = Schema & { topicId: string };
 // @TODO this should use the createTopicsCreateRequest`endpoint, but it does not handle the UPDATE type yet
 // Update when backend changes are merged to handle UPDATE with createTopicsCreateRequest
+// @TODO 2: when creating a request to update a topic, we need to set the topicId in the optional
+// 'otherParams'. We will update the endpoint(s) to be better named and more precise (not having an
+// important param be optional), that's why we're adding a bit of a messy fix here instead of updating
+// forms schema etc.
 const requestTopicEdit = (
-  data: Schema
+  data: RequestTopicEdit
 ): Promise<KlawApiResponse<"createTopicsUpdateRequest">> => {
   const payload: KlawApiRequest<"createTopicsUpdateRequest"> = {
     description: data.description,
@@ -161,6 +166,7 @@ const requestTopicEdit = (
       data.advancedConfiguration
     ),
     requestOperationType: "UPDATE",
+    otherParams: data.topicId,
   };
   return api.post<
     KlawApiResponse<"createTopicsUpdateRequest">,


### PR DESCRIPTION
# Description

This is an interesting one, because the bug report  #1620  actually surfaced two unrelated bugs. 

1. Details / decline modals in approval process are not removed in error cases for `topic` and `acls` (worked in `schema` and `connector`)

2. when creating an edit request for a topic, we need to use the optional paramter `otherparams` and this needs to be the `topicid`. Otherwise the request is not saved in the database. This does _not_ return an error when creating the topic edit request!  

⚠️ we will create a follow up issue for 2. to update the API. This is why the fix for 2. for now is not very elaborated and well tested, since it's going to be replaced soon anyway.


### Fixes for `1. Modals`

🐛  When approving a topic through the details modal or declining a topic (where a "decline modal" is open), when there was an error, the modal was not removed from the view for topics and acls.

<img width="1094" alt="Screenshot 2023-08-15 at 09 56 35" src="https://github.com/Aiven-Open/klaw/assets/943800/859a68a0-be6d-48c2-bef8-cb3fe3142acb">


#### This PR
- removes modals always on `onSettle` as they should be removed for success as well as error cases
- adds tests for approve / decline from quick actions as well as from details modal for all entities (where it was missing)


### Fixes for `2. missing param in creating edit request`

- this PR adds `topicId` as required argument for `requestTopicEdit`
- in order to not change the `formSchema` etc, we're passing the topicId when we call the mutation:

```
const requestTopicEditParams = {
        ...data,
        topicId: topicDetailsForEnv.topicId,
      };
      edit(requestTopicEditParams);
```