### PR TITLE
feat(coral): Add and update preview links in Angular

### DIFF
--- a/core/src/main/resources/static/js/editTopicRequest.js
+++ b/core/src/main/resources/static/js/editTopicRequest.js
@@ -430,12 +430,12 @@ app.controller("editTopicRequestCtrl", function($scope, $http, $location, $windo
                 if(output != null && output !== ''){
                     $scope.addTopic = $scope.topicRequestDetail;
                     if($scope.addTopic.requestOperationType === 'CREATE'){
-                        $scope.requestTitle = "Topic Create Request";
+                        $scope.requestTitle = "Edit Topic Create Request";
                     }
                     else if($scope.addTopic.requestOperationType === 'UPDATE'){
-                        $scope.requestTitle = "Topic Update Request";
+                        $scope.requestTitle = "Edit Topic Update Request";
                     }else if($scope.addTopic.requestOperationType === 'PROMOTE'){
-                        $scope.requestTitle = "Topic Promote Request";
+                        $scope.requestTitle = "Edit Topic Promote Request";
                     }
                     $scope.getEnvTopicPartitions($scope.addTopic.environment);
 

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -430,6 +430,15 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
+					<div class="ribbon ribbon-success">New user interface available</div>
+					<p class="ribbon-content">
+						Check out the new interface for <a href="coral/topic/{{ topicSelectedParam }}/overview">topic overview.
+						</a>
+					</p>
+				</div>
+			</div>
 
 			<div class="row" ng-show="alertTopicDelete != null && alertTopicDelete != ''">
 				<div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >

--- a/core/src/main/resources/templates/connectorOverview.html
+++ b/core/src/main/resources/templates/connectorOverview.html
@@ -430,16 +430,17 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
-			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
-				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
-					<div class="ribbon ribbon-success">New user interface available</div>
-					<p class="ribbon-content">
-						Check out the new interface for <a
-							href="coral/connector/{{ topicSelectedParam }}/overview">connector overview.
-					</a>
-					</p>
-				</div>
-			</div>
+<!--			//@TODO comment back in when feature flag for connector overview is removed-->
+<!--			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">-->
+<!--				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">-->
+<!--					<div class="ribbon ribbon-success">New user interface available</div>-->
+<!--					<p class="ribbon-content">-->
+<!--						Check out the new interface for <a-->
+<!--							href="coral/connector/{{ topicSelectedParam }}/overview">connector overview.-->
+<!--					</a>-->
+<!--					</p>-->
+<!--				</div>-->
+<!--			</div>-->
 
 			<div class="row" ng-show="alertTopicDelete != null && alertTopicDelete != ''">
 				<div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >

--- a/core/src/main/resources/templates/connectorOverview.html
+++ b/core/src/main/resources/templates/connectorOverview.html
@@ -430,6 +430,16 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
+					<div class="ribbon ribbon-success">New user interface available</div>
+					<p class="ribbon-content">
+						Check out the new interface for <a
+							href="coral/connector/{{ topicSelectedParam }}/overview">connector overview.
+					</a>
+					</p>
+				</div>
+			</div>
 
 			<div class="row" ng-show="alertTopicDelete != null && alertTopicDelete != ''">
 				<div  class="col-lg-12 col-md-6 col-xlg-2 col-xs-12" >

--- a/core/src/main/resources/templates/editTopicRequest.html
+++ b/core/src/main/resources/templates/editTopicRequest.html
@@ -430,15 +430,6 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
-			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
-				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
-					<div class="ribbon ribbon-success">New user interface available</div>
-					<p class="ribbon-content">
-						Check out the new interface for <a
-							href="coral/topic/{{ addTopic.topicname }}/request-update?env={{ addTopic.envId }}">edit topic.</a>
-					</p>
-				</div>
-			</div>
 
 			<!-- Row -->
 

--- a/core/src/main/resources/templates/editTopicRequest.html
+++ b/core/src/main/resources/templates/editTopicRequest.html
@@ -434,7 +434,8 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/topics/request">topic request.</a>
+						Check out the new interface for <a
+							href="coral/topic/{{ addTopic.topicname }}/request-update?env={{ addTopic.envId }}">edit topic.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/execAcls.html
+++ b/core/src/main/resources/templates/execAcls.html
@@ -462,7 +462,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/approvals/acls">Subscription Approvals.</a>
+						Check out the new interface for <a href="coral/approvals/acls">subscription approvals.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/execConnectors.html
+++ b/core/src/main/resources/templates/execConnectors.html
@@ -461,7 +461,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/approvals/connectors">Connectors approvals.</a>
+						Check out the new interface for <a href="coral/approvals/connectors">connectors approvals.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/execSchemas.html
+++ b/core/src/main/resources/templates/execSchemas.html
@@ -463,7 +463,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/approvals/schemas">Schema Approvals.</a>
+						Check out the new interface for <a href="coral/approvals/schemas">schema approvals.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/execTopics.html
+++ b/core/src/main/resources/templates/execTopics.html
@@ -461,7 +461,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/approvals/topics">Topic Approvals.</a>
+						Check out the new interface for <a href="coral/approvals/topics">topic approvals.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/kafkaConnectors.html
+++ b/core/src/main/resources/templates/kafkaConnectors.html
@@ -464,7 +464,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/connectors">Connectors.</a>
+						Check out the new interface for <a href="coral/connectors">connectors.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/myAclRequests.html
+++ b/core/src/main/resources/templates/myAclRequests.html
@@ -439,7 +439,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/requests/acls">My team's requests.</a>
+						Check out the new interface for <a href="coral/requests/acls">my team's requests.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/myConnectorRequests.html
+++ b/core/src/main/resources/templates/myConnectorRequests.html
@@ -446,7 +446,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/requests/connectors">Connectors requests.</a>
+						Check out the new interface for <a href="coral/requests/connectors">connectors requests.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/mySchemaRequests.html
+++ b/core/src/main/resources/templates/mySchemaRequests.html
@@ -435,7 +435,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/requests/schemas">My team's requests.</a>
+						Check out the new interface for <a href="coral/requests/schemas">my team's requests.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/myTopicRequests.html
+++ b/core/src/main/resources/templates/myTopicRequests.html
@@ -435,7 +435,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/requests/topics">My team's requests.</a>
+						Check out the new interface for <a href="coral/requests/topics">my team's requests.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/requestAcls.html
+++ b/core/src/main/resources/templates/requestAcls.html
@@ -433,7 +433,8 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/topic/{{ addAcl.topicname }}/subscribe?env={{addAcl.envId}}">ACL requests.</a>
+						Check out the new interface for <a
+							href="coral/topic/{{ addAcl.topicname }}/subscribe?env={{addAcl.envId}}">requesting ACLs.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/requestConnector.html
+++ b/core/src/main/resources/templates/requestConnector.html
@@ -435,7 +435,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/connectors/request">Connector requests.</a>
+						Check out the new interface for <a href="coral/connectors/request">connector requests.</a>
 					</p>
 				</div>
 			</div>

--- a/core/src/main/resources/templates/requestSchema.html
+++ b/core/src/main/resources/templates/requestSchema.html
@@ -433,7 +433,7 @@
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
-						Check out the new interface for <a href="coral/topic/{{ addSchema.topicname }}/request-schema">Schema
+						Check out the new interface for <a href="coral/topic/{{ addSchema.topicname }}/request-schema">schema
 						requests.</a>
 					</p>
 				</div>

--- a/core/src/main/resources/templates/requestTopics.html
+++ b/core/src/main/resources/templates/requestTopics.html
@@ -10,12 +10,14 @@
 	<meta name="author" content="">
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-YQB8J8J690"></script>
+
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
   gtag('config', 'G-YQB8J8J690');
+
 </script>
 
 	<!-- Favicon icon -->
@@ -430,11 +432,20 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
-			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true' && requestType == 'CreateTopic'">
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">
 						Check out the new interface for <a href="coral/topics/request">topic request.</a>
+					</p>
+				</div>
+			</div>
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true' && requestType == 'EditTopic'">
+				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
+					<div class="ribbon ribbon-success">New user interface available</div>
+					<p class="ribbon-content">
+						Check out the new interface for <a
+							href="coral/topic/{{ addTopic.topicname }}/request-update?env={{ addTopic.envName }}">edit topic.</a>
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
# About this change - What it does

- aligns copy for preview banner (capitalisation etc.)
- adds preview banner with links for topic overview
- updates link and link text for editing a topic (linked to /request before)
- updates link text for requesting an ACL ("ACL request" was ambiguous)
- NOTE: This also adds preview banner for connector overview, but commented out, because initially we wanted to release them. Thought I can leave it for next release. 


Resolves: #1227 

