### PR TITLE
feat(coral): Show info to user when they temp can not edit a topic

### DIFF
--- a/coral/src/app/components/DisabledButtonTooltip.module.css
+++ b/coral/src/app/components/DisabledButtonTooltip.module.css
@@ -1,0 +1,11 @@
+.buttonWrapper button {
+  background-color: var(--aquarium-colors-primary-40);
+  cursor: not-allowed;
+}
+
+.buttonWrapper button:hover,
+.buttonWrapper button:focus,
+.buttonWrapper button:focus-visible {
+  background-color: var(--aquarium-colors-primary-40);
+  cursor: not-allowed;
+}

--- a/coral/src/app/components/DisabledButtonTooltip.test.tsx
+++ b/coral/src/app/components/DisabledButtonTooltip.test.tsx
@@ -1,0 +1,89 @@
+import { DisabledButtonTooltip } from "src/app/components/DisabledButtonTooltip";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const testTooltip = "There is a pending request.";
+const testChild = "Edit this!";
+describe("DisabledButtonTooltip", () => {
+  const user = userEvent.setup();
+
+  describe("renders all necessary elements for default (button)", () => {
+    beforeAll(() => {
+      render(
+        <DisabledButtonTooltip tooltip={testTooltip}>
+          {testChild}
+        </DisabledButtonTooltip>
+      );
+    });
+    afterAll(cleanup);
+
+    it("shows a disabled-looking button", () => {
+      const button = screen.getByRole("button");
+
+      expect(button).toHaveAttribute("aria-disabled", "true");
+      expect(button.parentElement).toHaveClass("buttonWrapper");
+    });
+
+    it("renders the tooltip text accessible for screen reader", () => {
+      const button = screen.getByRole("button");
+
+      expect(button).toHaveAccessibleName(`${testChild}. ${testTooltip}`);
+    });
+
+    it("shows a tooltip for visual user", async () => {
+      await user.tab();
+
+      const tooltip = screen.getByRole("tooltip");
+
+      // note: this is _not_ use able for the screen reader,
+      // see comments in component. Since we can't give the
+      // tooltip a testid, (mis)using the role for querying
+      // is used, but it's misleading, since it implied accessibility
+      expect(tooltip).toBeVisible();
+
+      await user.tab();
+
+      expect(tooltip).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders all necessary elements for role link", () => {
+    beforeAll(() => {
+      render(
+        <DisabledButtonTooltip tooltip={testTooltip} role={"link"}>
+          {testChild}
+        </DisabledButtonTooltip>
+      );
+    });
+    afterAll(cleanup);
+
+    it("shows a disabled-looking button as link", () => {
+      const link = screen.getByRole("link");
+
+      expect(link).toHaveAttribute("aria-disabled", "true");
+      expect(link.parentElement).toHaveClass("buttonWrapper");
+    });
+
+    it("renders the tooltip text accessible for screen reader", () => {
+      const button = screen.getByRole("link");
+
+      expect(button).toHaveAccessibleName(`${testChild}. ${testTooltip}`);
+    });
+
+    it("shows a tooltip for visual user", async () => {
+      await user.tab();
+
+      const tooltip = screen.getByRole("tooltip");
+
+      // note: this is _not_ use able for the screen reader,
+      // see comments in component. Since we can't give the
+      // tooltip a testid, (mis)using the role for querying
+      // is used, but it's misleading, since it implied accessibility
+      expect(tooltip).toBeVisible();
+
+      await user.tab();
+
+      expect(tooltip).not.toBeInTheDocument();
+    });
+  });
+});

--- a/coral/src/app/components/DisabledButtonTooltip.tsx
+++ b/coral/src/app/components/DisabledButtonTooltip.tsx
@@ -32,7 +32,7 @@ function DisabledButtonTooltip({
       // does not build a relation by using aria-describedby.
       aria-hidden="true"
       content={props.tooltip}
-      placement="left"
+      placement="bottom"
       isOpen={tooltipOpen}
       data-testid={"test"}
     >
@@ -43,7 +43,7 @@ function DisabledButtonTooltip({
           aria-label={`${children}. ${props.tooltip}`}
           // this event handling is not ideal, since a button in focus will
           // behave unexpected when mouse and keyboard are used. since it's
-          // an edgecase and we (hopefully) can use tooltip soon, it is ok
+          // an edge case and we (hopefully) can use tooltip soon, it is ok
           onMouseEnter={toggleTooltip}
           onMouseLeave={toggleTooltip}
           onFocus={toggleTooltip}

--- a/coral/src/app/components/DisabledButtonTooltip.tsx
+++ b/coral/src/app/components/DisabledButtonTooltip.tsx
@@ -1,0 +1,61 @@
+import { Button, Tooltip } from "@aivenio/aquarium";
+import { useState } from "react";
+import { ResolveIntersectionTypes } from "types/utils";
+import classes from "src/app/components/DisabledButtonTooltip.module.css";
+
+/** DisabledButtonTooltip shows a disabled looking Primary Button
+ * either with role link or button and a tooltip
+ * this workaround is needed since DS tooltip do not work in react
+ * strict mode at the moment. It also adds accessibility, which the
+ * DS Button with tooltip does not provide (since it's disabled and
+ * the tooltip text is not accessible for SR)
+ **/
+type DisabledButtonTooltipProps = ResolveIntersectionTypes<{
+  children: string;
+  tooltip: string;
+  role?: "button" | "link";
+}>;
+function DisabledButtonTooltip({
+  children,
+  ...props
+}: DisabledButtonTooltipProps) {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const toggleTooltip = () => setTooltipOpen(!tooltipOpen);
+  const elementRole = props.role ? props.role : "button";
+
+  return (
+    <Tooltip
+      // aria-hidden is currently not forwarded, but it is added for semantics purposes
+      // while the tooltip has role "tooltip", it's not in the text
+      // near the element, so screen reader won't be able to access the
+      // information correctly. Also the element related to the tooltip
+      // does not build a relation by using aria-describedby.
+      aria-hidden="true"
+      content={props.tooltip}
+      placement="left"
+      isOpen={tooltipOpen}
+      data-testid={"test"}
+    >
+      <div className={classes.buttonWrapper}>
+        <Button.Primary
+          role={elementRole}
+          aria-disabled={true}
+          aria-label={`${children}. ${props.tooltip}`}
+          // this event handling is not ideal, since a button in focus will
+          // behave unexpected when mouse and keyboard are used. since it's
+          // an edgecase and we (hopefully) can use tooltip soon, it is ok
+          onMouseEnter={toggleTooltip}
+          onMouseLeave={toggleTooltip}
+          onFocus={toggleTooltip}
+          onBlur={toggleTooltip}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          onClick={() => {}}
+        >
+          {children}
+        </Button.Primary>
+      </div>
+    </Tooltip>
+  );
+}
+
+export { DisabledButtonTooltip };

--- a/coral/src/app/features/components/EntityDetailsHeader.test.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.test.tsx
@@ -23,6 +23,7 @@ const defaultTopicProps = {
   entity: testTopic,
   entityEditLink: "/hello/topic",
   showEditButton: true,
+  hasPendingRequest: false,
   environments: testEnvironments,
   environmentId: undefined,
   setEnvironmentId: mockSetEnvironmentId,
@@ -34,6 +35,7 @@ const defaultConnectorProps = {
   entity: testConnector,
   entityEditLink: "/hello/connector",
   showEditButton: true,
+  hasPendingRequest: false,
   environments: testEnvironments,
   environmentId: undefined,
   setEnvironmentId: mockSetEnvironmentId,
@@ -413,6 +415,55 @@ describe("EntityDetailsHeader", () => {
     });
   });
 
+  describe("correctly disables Edit button when there is a pending request", () => {
+    describe("disables button for topic", () => {
+      beforeAll(() => {
+        customRender(
+          <EntityDetailsHeader
+            {...defaultTopicProps}
+            hasPendingRequest={true}
+          />,
+          { browserRouter: true }
+        );
+      });
+
+      afterAll(cleanup);
+
+      it("shows a disabled button to edit with information when there is a pending request", () => {
+        const link = screen.getByRole("link", { name: /Edit topic/ });
+
+        expect(link).toHaveAttribute("aria-disabled", "true");
+        expect(link).not.toHaveAttribute("href");
+        expect(link).toHaveAccessibleName(
+          "Edit topic. The topic has a pending request."
+        );
+      });
+    });
+
+    describe("disables button for connector", () => {
+      beforeAll(() => {
+        customRender(
+          <EntityDetailsHeader
+            {...defaultConnectorProps}
+            hasPendingRequest={true}
+          />,
+          { browserRouter: true }
+        );
+      });
+
+      afterAll(cleanup);
+
+      it("shows a disabled button to edit with information when there is a pending request", () => {
+        const link = screen.getByRole("link", { name: /Edit connector/ });
+
+        expect(link).toHaveAttribute("aria-disabled", "true");
+        expect(link).not.toHaveAttribute("href");
+        expect(link).toHaveAccessibleName(
+          "Edit connector. The connector has a pending request."
+        );
+      });
+    });
+  });
   describe("correctly hides Edit button", () => {
     it("hides Edit button for Topic", async () => {
       customRender(

--- a/coral/src/app/features/components/EntityDetailsHeader.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.tsx
@@ -9,11 +9,13 @@ import database from "@aivenio/aquarium/dist/src/icons/database";
 import { Dispatch, SetStateAction } from "react";
 import { EnvironmentInfo } from "src/domain/environment";
 import { InternalLinkButton } from "src/app/components/InternalLinkButton";
+import { DisabledButtonTooltip } from "src/app/components/DisabledButtonTooltip";
 
 type TopicOverviewHeaderProps = {
   entity: { name: string; type: "connector" | "topic" };
   entityEditLink: string;
   showEditButton: boolean;
+  hasPendingRequest: boolean;
   entityExists: boolean;
   entityUpdating: boolean;
   environments?: EnvironmentInfo[];
@@ -25,6 +27,7 @@ function EntityDetailsHeader(props: TopicOverviewHeaderProps) {
   const {
     entity,
     showEditButton,
+    hasPendingRequest,
     entityEditLink,
     environments,
     environmentId,
@@ -97,13 +100,22 @@ function EntityDetailsHeader(props: TopicOverviewHeaderProps) {
           </Box>
         )}
       </Box>
-      {showEditButton && (
+      {showEditButton && !hasPendingRequest && (
         <InternalLinkButton
           to={entityEditLink}
           disabled={!entityExists || entityUpdating}
         >
           {`Edit ${entity.type}`}
         </InternalLinkButton>
+      )}
+
+      {showEditButton && hasPendingRequest && (
+        <DisabledButtonTooltip
+          tooltip={`The ${entity.type} has a pending request.`}
+          role={"link"}
+        >
+          {`Edit ${entity.type}`}
+        </DisabledButtonTooltip>
       )}
     </Box>
   );

--- a/coral/src/app/features/connectors/details/ConnectorDetails.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.tsx
@@ -87,10 +87,8 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
         environments={connectorData?.availableEnvironments}
         environmentId={environmentId}
         setEnvironmentId={setEnvironmentId}
-        showEditButton={Boolean(
-          connectorData?.connectorInfo.showEditConnector &&
-            !connectorData?.connectorInfo.hasOpenRequest
-        )}
+        showEditButton={Boolean(connectorData?.connectorInfo.showEditConnector)}
+        hasPendingRequest={Boolean(connectorData?.connectorInfo.hasOpenRequest)}
       />
 
       <ConnectorOverviewResourcesTabs

--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -147,10 +147,8 @@ function TopicDetails(props: TopicOverviewProps) {
         entity={{ name: topicName, type: "topic" }}
         entityExists={Boolean(topicData?.topicExists)}
         entityEditLink={`/topic/${topicName}/request-update?env=${topicData?.topicInfo.envId}`}
-        showEditButton={Boolean(
-          topicData?.topicInfo.showEditTopic &&
-            !topicData?.topicInfo.hasOpenTopicRequest
-        )}
+        showEditButton={Boolean(topicData?.topicInfo.showEditTopic)}
+        hasPendingRequest={Boolean(topicData?.topicInfo.hasOpenTopicRequest)}
         entityUpdating={topicIsRefetching}
         environments={topicData?.availableEnvironments}
         environmentId={environmentId}

--- a/coral/src/app/pages/topics/acl-request.tsx
+++ b/coral/src/app/pages/topics/acl-request.tsx
@@ -13,7 +13,7 @@ const AclRequest = () => {
           topicName !== undefined ? `?topicName=${topicName}` : ""
         }`}
       />
-      <PageHeader title={"ACL (Access Control) Request"} />
+      <PageHeader title={"ACL (Access Control) request"} />
       <TopicAclRequest />
     </>
   );


### PR DESCRIPTION
# About this change - What it does

There are cases where a user is allowed to edit a topic/connector in general, because they are topic owner, but the edit functionality is currently blocked because there is an open request. Before now, we didn't show the button in that case. 

In line with e.g. promoting a topic, we don't want to hide the button "Edit topic/connector" anymore, but show it disabled and inform the user why they can't edit at the moment. We're doing that by showing a disabled button with a tooltip.

## Notes about implementation

_First: I sneaked in an unrelated type fix (really no need to make a new PR for one character 😅 ) -> https://github.com/Aiven-Open/klaw/pull/1637/commits/309495f1b0523f046d5e754645bd46bad9f5a1eb_ 

**Background**
- "Edit topic" and "Edit connectors" are links, not buttons (they just look like it)
- `<Tooltip />` from DS does not work in strict mode but also without strict mode, it is not really accessible. Screenreader user don't get any information about the tooltip and since we would need to use a `Primary.Button` with `disabled=true`, it also does not work for keyboard user. 

In order to get the result we want, there is a new (very specific) component `DisabledButtonTooltip` for this use case. It enables us to have a disabled button or link with accessible tooltips until DS components are updated (and we've disabled strict mode) to cover this use case in a way that it's usable by most users. 


## Recording

https://github.com/Aiven-Open/klaw/assets/943800/8293e28b-b7dc-49bf-8471-1b1b38ed12a8



Resolves: #1633 

