### PR TITLE
fix(coral): Update handling for open CLAIM request in promotion.

### DIFF
--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -23,6 +23,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -40,6 +41,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -57,6 +59,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -74,6 +77,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -91,6 +95,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -108,6 +113,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -126,6 +132,7 @@ describe("PromotionBanner", () => {
           promotionDetails={promotionDetails}
           type={"schema"}
           promoteElement={<></>}
+          hasOpenClaimRequest={false}
           hasOpenRequest={true}
           hasError={false}
           errorMessage={""}
@@ -150,7 +157,7 @@ describe("PromotionBanner", () => {
       expect(link).toBeVisible();
       expect(link).toHaveAttribute(
         "href",
-        "/requests/schemas?search=my-test-topic&status=CREATED&page=1"
+        "/requests/schemas?search=my-test-topic&requestType=ALL&status=CREATED&page=1"
       );
     });
   });
@@ -163,6 +170,7 @@ describe("PromotionBanner", () => {
           promotionDetails={promotionDetails}
           type={"topic"}
           promoteElement={<></>}
+          hasOpenClaimRequest={false}
           hasOpenRequest={true}
           hasError={false}
           errorMessage={""}
@@ -187,7 +195,83 @@ describe("PromotionBanner", () => {
       expect(link).toBeVisible();
       expect(link).toHaveAttribute(
         "href",
-        "/requests/topics?search=my-test-topic&status=CREATED&page=1"
+        "/requests/topics?search=my-test-topic&requestType=ALL&status=CREATED&page=1"
+      );
+    });
+  });
+
+  describe("handles banner for entity with an open claim request (type schema)", () => {
+    beforeAll(() => {
+      customRender(
+        <PromotionBanner
+          entityName={testTopicName}
+          promotionDetails={promotionDetails}
+          type={"schema"}
+          promoteElement={<></>}
+          hasOpenClaimRequest={true}
+          hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
+        />,
+        { browserRouter: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `A claim request for ${testTopicName} is in progress.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByRole("link", { name: "View request" });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/approvals/schemas?search=my-test-topic&requestType=CLAIM&status=CREATED&page=1"
+      );
+    });
+  });
+
+  describe("handles banner for entity with an open claim request (type topic)", () => {
+    beforeAll(() => {
+      customRender(
+        <PromotionBanner
+          entityName={testTopicName}
+          promotionDetails={promotionDetails}
+          type={"topic"}
+          promoteElement={<></>}
+          hasOpenClaimRequest={true}
+          hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
+        />,
+        { browserRouter: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `A claim request for ${testTopicName} is in progress.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByRole("link", { name: "View request" });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/approvals/topics?search=my-test-topic&requestType=CLAIM&status=CREATED&page=1"
       );
     });
   });
@@ -200,6 +284,7 @@ describe("PromotionBanner", () => {
           promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
           type={"schema"}
           promoteElement={<></>}
+          hasOpenClaimRequest={false}
           hasOpenRequest={false}
           hasError={false}
           errorMessage={""}
@@ -238,6 +323,7 @@ describe("PromotionBanner", () => {
           type={"topic"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -277,6 +363,7 @@ describe("PromotionBanner", () => {
           promotionDetails={promotionDetails}
           type={"schema"}
           promoteElement={promoteElement}
+          hasOpenClaimRequest={false}
           hasOpenRequest={false}
           hasError={false}
           errorMessage={""}
@@ -314,6 +401,7 @@ describe("PromotionBanner", () => {
           type={"topic"}
           promoteElement={promoteElement}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={false}
           errorMessage={""}
         />,
@@ -360,6 +448,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={true}
           errorMessage={testErrorMessage}
         />,
@@ -381,6 +470,7 @@ describe("PromotionBanner", () => {
           type={"schema"}
           promoteElement={<></>}
           hasOpenRequest={false}
+          hasOpenClaimRequest={false}
           hasError={true}
           errorMessage={""}
         />,

--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -34,7 +34,12 @@ function TopicOverview() {
   } = useTopicDetails();
 
   const {
-    topicInfo: { topicOwner = false, hasOpenTopicRequest, clusterId },
+    topicInfo: {
+      topicOwner = false,
+      hasOpenTopicRequest,
+      hasOpenClaimRequest,
+      clusterId,
+    },
     topicPromotionDetails,
   } = topicOverview;
 
@@ -75,6 +80,7 @@ function TopicOverview() {
           <TopicPromotionBanner
             topicName={topicName}
             topicPromotionDetails={topicPromotionDetails}
+            hasOpenClaimRequest={hasOpenClaimRequest}
             hasOpenTopicRequest={hasOpenTopicRequest}
           />
         </GridItem>

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.test.tsx
@@ -13,6 +13,7 @@ const promotionDetailForPromote: TopicOverview["topicPromotionDetails"] = {
 const promoteProps = {
   topicPromotionDetails: promotionDetailForPromote,
   hasOpenTopicRequest: false,
+  hasOpenClaimRequest: false,
   topicName: "topic-hello",
 };
 
@@ -27,6 +28,14 @@ const promotionDetailForSeeOpenRequest: TopicOverview["topicPromotionDetails"] =
 const seeOpenRequestProps = {
   topicPromotionDetails: promotionDetailForSeeOpenRequest,
   hasOpenTopicRequest: true,
+  hasOpenClaimRequest: false,
+  topicName: "topic-hello",
+};
+
+const seeOpenClaimRequestProps = {
+  topicPromotionDetails: promotionDetailForSeeOpenRequest,
+  hasOpenTopicRequest: false,
+  hasOpenClaimRequest: true,
   topicName: "topic-hello",
 };
 
@@ -41,6 +50,7 @@ const promotionDetailForSeeOpenPromotionRequest: TopicOverview["topicPromotionDe
 const seeOpenPromotionRequestProps = {
   topicPromotionDetails: promotionDetailForSeeOpenPromotionRequest,
   hasOpenTopicRequest: false,
+  hasOpenClaimRequest: false,
   topicName: "topic-hello",
 };
 
@@ -51,6 +61,7 @@ const promotionDetailForNoPromotion: TopicOverview["topicPromotionDetails"] = {
 const nullProps = {
   topicPromotionDetails: promotionDetailForNoPromotion,
   hasOpenTopicRequest: false,
+  hasOpenClaimRequest: false,
   topicName: "topic-hello",
 };
 
@@ -88,7 +99,23 @@ describe("TopicPromotionBanner", () => {
     expect(link).toBeVisible();
     expect(link).toHaveAttribute(
       "href",
-      `/requests/topics?search=${promoteProps.topicName}&status=CREATED&page=1`
+      `/requests/topics?search=${promoteProps.topicName}&requestType=ALL&status=CREATED&page=1`
+    );
+  });
+
+  it("renders correct banner (see open claim request)", () => {
+    customRender(<TopicPromotionBanner {...seeOpenClaimRequestProps} />, {
+      browserRouter: true,
+    });
+
+    const link = screen.getByRole("link", {
+      name: "View request",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      `/approvals/topics?search=${promoteProps.topicName}&requestType=CLAIM&status=CREATED&page=1`
     );
   });
 

--- a/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/overview/components/TopicPromotionBanner.tsx
@@ -9,11 +9,13 @@ interface TopicPromotionBannerProps {
    * information to the user.
    */
   hasOpenTopicRequest: boolean;
+  hasOpenClaimRequest: boolean;
   topicName: string;
 }
 
 const TopicPromotionBanner = ({
   topicPromotionDetails,
+  hasOpenClaimRequest,
   hasOpenTopicRequest,
   topicName,
 }: TopicPromotionBannerProps) => {
@@ -23,6 +25,7 @@ const TopicPromotionBanner = ({
         entityName={topicName}
         promotionDetails={topicPromotionDetails}
         hasOpenRequest={hasOpenTopicRequest}
+        hasOpenClaimRequest={hasOpenClaimRequest}
         type={"topic"}
         promoteElement={
           <InternalLinkButton

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -55,7 +55,8 @@ function TopicDetailsSchema() {
 
   const toast = useToast();
 
-  const { topicOwner, hasOpenSchemaRequest } = topicOverview.topicInfo;
+  const { topicOwner, hasOpenSchemaRequest, hasOpenClaimRequest } =
+    topicOverview.topicInfo;
   const isTopicOwner = topicOwner;
   const noSchema =
     allSchemaVersions.length === 0 ||
@@ -208,6 +209,7 @@ function TopicDetailsSchema() {
         <SchemaPromotionBanner
           schemaPromotionDetails={schemaPromotionDetails}
           hasOpenSchemaRequest={hasOpenSchemaRequest}
+          hasOpenClaimRequest={hasOpenClaimRequest}
           topicName={topicName}
           setShowSchemaPromotionModal={() =>
             setShowSchemaPromotionModal(!showSchemaPromotionModal)

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
@@ -28,6 +28,7 @@ describe("SchemaPromotionBanner", () => {
         topicName={"my-test-topic"}
         setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
         hasOpenSchemaRequest={false}
+        hasOpenClaimRequest={false}
       />,
       { browserRouter: true }
     );
@@ -46,6 +47,7 @@ describe("SchemaPromotionBanner", () => {
         topicName={"my-test-topic"}
         setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
         hasOpenSchemaRequest={false}
+        hasOpenClaimRequest={false}
       />,
       { browserRouter: true }
     );
@@ -66,6 +68,7 @@ describe("SchemaPromotionBanner", () => {
         topicName={"my-test-topic"}
         setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
         hasOpenSchemaRequest={true}
+        hasOpenClaimRequest={false}
       />,
       { browserRouter: true }
     );
@@ -80,7 +83,34 @@ describe("SchemaPromotionBanner", () => {
     expect(linkSeeRequest).toBeVisible();
     expect(linkSeeRequest).toHaveAttribute(
       "href",
-      `/requests/schemas?search=my-test-topic&status=CREATED&page=1`
+      `/requests/schemas?search=my-test-topic&requestType=ALL&status=CREATED&page=1`
+    );
+    expect(buttonPromote).not.toBeInTheDocument();
+  });
+
+  it("renders correct banner (see open claim request)", () => {
+    customRender(
+      <SchemaPromotionBanner
+        schemaPromotionDetails={schemaPromotionDetailsBase}
+        topicName={"my-test-topic"}
+        setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
+        hasOpenSchemaRequest={true}
+        hasOpenClaimRequest={true}
+      />,
+      { browserRouter: true }
+    );
+
+    const buttonPromote = screen.queryByRole("button", {
+      name: "Promote",
+    });
+    const linkSeeRequest = screen.getByRole("link", {
+      name: "View request",
+    });
+
+    expect(linkSeeRequest).toBeVisible();
+    expect(linkSeeRequest).toHaveAttribute(
+      "href",
+      `/approvals/schemas?search=my-test-topic&requestType=CLAIM&status=CREATED&page=1`
     );
     expect(buttonPromote).not.toBeInTheDocument();
   });
@@ -95,6 +125,7 @@ describe("SchemaPromotionBanner", () => {
         topicName={"my-test-topic"}
         setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
         hasOpenSchemaRequest={false}
+        hasOpenClaimRequest={false}
       />,
       { browserRouter: true }
     );
@@ -124,6 +155,7 @@ describe("SchemaPromotionBanner", () => {
         topicName={"my-test-topic"}
         setShowSchemaPromotionModal={mockSetShowSchemaPromotionModal}
         hasOpenSchemaRequest={false}
+        hasOpenClaimRequest={false}
       />,
       { browserRouter: true }
     );

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@aivenio/aquarium";
 import { TopicSchemaOverview } from "src/domain/topic";
 import { PromotionBanner } from "src/app/features/topics/details/components/PromotionBanner";
+import { useEffect } from "react";
 
 interface SchemaPromotionBannerProps {
   schemaPromotionDetails: TopicSchemaOverview["schemaPromotionDetails"];
@@ -9,6 +10,7 @@ interface SchemaPromotionBannerProps {
    * information to the user.
    */
   hasOpenSchemaRequest: boolean;
+  hasOpenClaimRequest: boolean;
   topicName: string;
   setShowSchemaPromotionModal: () => void;
   hasError?: boolean;
@@ -18,17 +20,23 @@ interface SchemaPromotionBannerProps {
 const SchemaPromotionBanner = ({
   schemaPromotionDetails,
   hasOpenSchemaRequest,
+  hasOpenClaimRequest,
   topicName,
   setShowSchemaPromotionModal,
   hasError = false,
   errorMessage = "",
 }: SchemaPromotionBannerProps) => {
+  useEffect(() => {
+    console.log("hasOpenClaimRequest", hasOpenClaimRequest);
+    console.log("hasOpenSchemaRequest", hasOpenSchemaRequest);
+  });
   return (
     <div data-testid={"schema-promotion-banner"}>
       <PromotionBanner
         entityName={topicName}
         promotionDetails={schemaPromotionDetails}
         hasOpenRequest={hasOpenSchemaRequest}
+        hasOpenClaimRequest={hasOpenClaimRequest}
         type={"schema"}
         hasError={hasError}
         errorMessage={errorMessage}

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@aivenio/aquarium";
 import { TopicSchemaOverview } from "src/domain/topic";
 import { PromotionBanner } from "src/app/features/topics/details/components/PromotionBanner";
-import { useEffect } from "react";
 
 interface SchemaPromotionBannerProps {
   schemaPromotionDetails: TopicSchemaOverview["schemaPromotionDetails"];
@@ -26,10 +25,6 @@ const SchemaPromotionBanner = ({
   hasError = false,
   errorMessage = "",
 }: SchemaPromotionBannerProps) => {
-  useEffect(() => {
-    console.log("hasOpenClaimRequest", hasOpenClaimRequest);
-    console.log("hasOpenSchemaRequest", hasOpenSchemaRequest);
-  });
   return (
     <div data-testid={"schema-promotion-banner"}>
       <PromotionBanner


### PR DESCRIPTION
# About this change - What it does

Updates `PromotionBanner` to take property `hasOpenClaimRequest`: 

- if there is an open claim request, we show a link to `/approvals` (type CLAIM) and inform user that there is an open claim request
- if there is an open promotion request, we show a link to `/request` (type PROMOTE) and inform user that there is an open promotion request
- if there is another open request (e.g. update), we show a link to `/request` (type ALL) and inform user that there is a pending request
 
## Recording for topic

https://github.com/Aiven-Open/klaw/assets/943800/39939a38-bd08-4958-a84b-df6107d28e42

## Recording for schema

NOTE: In this recording, a little inconsistency is visible: I (as part of another team) did the claim request for the schema I wanted to show. If I'm the one making the request, I won't see it in `/approvals` because I can not approve my own requests (even if they are from another team). We currently don't have a way to avoid that, but it is not a common use case anyway.

https://github.com/Aiven-Open/klaw/assets/943800/d045098b-f397-43b6-a72a-fc899ad6b421


Resolves #1643