### PR TITLE
Update to use a type of String to make queries

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1590,9 +1590,10 @@ public class SelectDataJdbc {
       operationTypeCountsMap.put(RequestOperationType.CLAIM.value, assignedToClaimReqs);
       if (RequestMode.MY_APPROVALS == requestMode) {
         // Make sure to remove any requests which the requestor can not approve
+        // Using Integer.toString() as it seems to be the fastest method of changing it.
         Long topicApprovalCount =
             topicRequestsRepo.countRequestorsTopicRequestsGroupByStatusType(
-                teamId, tenantId, requestor, RequestStatus.CREATED.value);
+                teamId, Integer.toString(teamId), tenantId, requestor, RequestStatus.CREATED.value);
 
         statusCountsMap.put(
             RequestStatus.CREATED.value, topicApprovalCount == null ? 0L : topicApprovalCount);
@@ -1732,7 +1733,7 @@ public class SelectDataJdbc {
       // Make sure to remove any requests which the requestor can not approve
       Long connectorApprovalCount =
           kafkaConnectorRequestsRepo.countRequestorsConnectorRequestsGroupByStatusType(
-              teamId, tenantId, requestor, RequestStatus.CREATED.value);
+              teamId, Integer.toString(teamId), tenantId, requestor, RequestStatus.CREATED.value);
 
       statusCountsMap.put(
           RequestStatus.CREATED.value,

--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -79,10 +79,11 @@ public interface KwKafkaConnectorRequestsRepo
   @Query(
       value =
           "select count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
-              + " and (teamid = :teamId or approvingteamid = :teamId) and requestor != :requestor and connectorstatus = :connectorStatus group by connectorstatus",
+              + " and (teamid = :teamId or approvingteamid = :approvingTeamid) and requestor != :requestor and connectorstatus = :connectorStatus group by connectorstatus",
       nativeQuery = true)
   Long countRequestorsConnectorRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,
+      @Param("approvingTeamid") String approvingTeamid,
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,
       @Param("connectorStatus") String connectorStatus);

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -85,11 +85,12 @@ public interface TopicRequestsRepo
   @Query(
       value =
           "select count(*) from kwtopicrequests where tenantid = :tenantId"
-              + " and (teamid = :teamId or approvingteamid = :teamId) and requestor != :requestor "
+              + " and (teamid = :teamId or approvingteamid = :approvingTeamId) and requestor != :requestor "
               + "and topicstatus = :topicStatus  group by topicstatus",
       nativeQuery = true)
   Long countRequestorsTopicRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,
+      @Param("approvingTeamId") String approvingTeamId,
       @Param("tenantId") Integer tenantId,
       @Param("requestor") String requestor,
       @Param("topicStatus") String topicStatus);


### PR DESCRIPTION
About this change - What it does
This change uses a string for the approving team comparison as the kafka connector and topic requests have a string type for appronving team, but an integer type for the teamId
Resolves: #xxxxx
Why this way
This allows the queries to run against the H2 and postgres (and other dbs)

Tested this against a local postgres and local H2
