### PR TITLE
fix(coral): Remove unnecessary re-mounting

### DIFF
--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
@@ -115,7 +115,7 @@ function ConnectorOverviewResourcesTabs({
     );
   }
 
-  const ConnectorTabs = () => (
+  return (
     <Tabs
       value={currentTab}
       onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
@@ -141,8 +141,6 @@ function ConnectorOverviewResourcesTabs({
       })}
     </Tabs>
   );
-
-  return <ConnectorTabs />;
 }
 
 export { ConnectorOverviewResourcesTabs };

--- a/coral/src/app/features/team-info/SwitchTeamsDropdown.tsx
+++ b/coral/src/app/features/team-info/SwitchTeamsDropdown.tsx
@@ -37,7 +37,7 @@ function SwitchTeamsDropdown({
     updateTeam,
     {
       onSuccess: async () => {
-        await queryClient.refetchQueries();
+        await queryClient.invalidateQueries();
         toast({
           message: "Team changed successfully.",
           variant: "default",

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -10,7 +10,6 @@ import {
 import { TopicOverview } from "src/domain/topic";
 import { TopicSchemaOverview } from "src/domain/topic/topic-types";
 import { parseErrorMsg } from "src/services/mutation-utils";
-import { useEffect } from "react";
 
 type Props = {
   currentTab: TopicOverviewTabEnum;
@@ -40,9 +39,6 @@ function TopicOverviewResourcesTabs({
   const navigate = useNavigate();
   const topicName = topicOverview?.topicInfo.topicName;
 
-  useEffect(() => {
-    console.log("TopicOverviewResourcesTabs mounting");
-  }, []);
   function navigateToTab(
     navigate: NavigateFunction,
     resourceTypeId: unknown

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -10,6 +10,7 @@ import {
 import { TopicOverview } from "src/domain/topic";
 import { TopicSchemaOverview } from "src/domain/topic/topic-types";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import { useEffect } from "react";
 
 type Props = {
   currentTab: TopicOverviewTabEnum;
@@ -39,6 +40,9 @@ function TopicOverviewResourcesTabs({
   const navigate = useNavigate();
   const topicName = topicOverview?.topicInfo.topicName;
 
+  useEffect(() => {
+    console.log("TopicOverviewResourcesTabs mounting");
+  }, []);
   function navigateToTab(
     navigate: NavigateFunction,
     resourceTypeId: unknown
@@ -137,7 +141,7 @@ function TopicOverviewResourcesTabs({
     );
   };
 
-  const TopicTabs = () => (
+  return (
     <Tabs
       value={currentTab}
       onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
@@ -163,8 +167,6 @@ function TopicOverviewResourcesTabs({
       })}
     </Tabs>
   );
-
-  return <TopicTabs />;
 }
 
 export { TopicOverviewResourcesTabs };


### PR DESCRIPTION
# About this change - What it does

- [x]ResourceTabs component for Topic and Connector overview returned a function instead of a component, which causes the tab-content to be remounted every time
- `SwitchTeamDropdown` used `refetchQueries` -  I changed that to `invalidateQueries`. refetchQueries will try to refetch all queries on the spot, which will cause errors, cause for some parameters are not there yet. invalidateQueries will invalidate the queries and when the parameters have changed (indicating they need a new fetch) fetch the data


## Recordings

### Topic settings 

**before**

https://github.com/Aiven-Open/klaw/assets/943800/b443f6a7-01a9-4e69-8a62-9a8eac32d048


**after**

https://github.com/Aiven-Open/klaw/assets/943800/2effc374-0c13-491e-9580-4bd725408e40


### Topic overview

**before**

https://github.com/Aiven-Open/klaw/assets/943800/0ffa4786-1f7d-4770-995d-b30bc6a71d33


**after**

https://github.com/Aiven-Open/klaw/assets/943800/1cc32f22-ae1b-4d50-9154-2d584a1b1a32


Resolves: #1501 


