### PR TITLE
fix(coral) Remove "User requests" and "Settings" from nav.

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -32,12 +32,9 @@ const navLinks = [
   { name: "Approve requests", linkTo: "/approvals" },
   { name: "My team's requests", linkTo: "/requests" },
   { name: "Audit log", linkTo: "/activityLog" },
-  { name: "Settings", linkTo: "/serverConfig" },
 ];
 
-const submenuItems = [
-  { name: "Users and teams", links: ["Users", "Teams", "User requests"] },
-];
+const submenuItems = [{ name: "Users and teams", links: ["Users", "Teams"] }];
 
 const navOrderFirstLevel = [
   { name: "Dashboard", isSubmenu: false },
@@ -47,7 +44,6 @@ const navOrderFirstLevel = [
   { name: "Approve requests", isSubmenu: false },
   { name: "My team's requests", isSubmenu: false },
   { name: "Audit log", isSubmenu: false },
-  { name: "Settings", isSubmenu: false },
 ];
 
 describe("MainNavigation.tsx", () => {

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -1,6 +1,5 @@
 import { Box, Divider } from "@aivenio/aquarium";
 import codeBlock from "@aivenio/aquarium/dist/src/icons/codeBlock";
-import cog from "@aivenio/aquarium/dist/src/icons/cog";
 import add from "@aivenio/aquarium/dist/src/icons/add";
 import database from "@aivenio/aquarium/dist/src/icons/database";
 import dataflow02 from "@aivenio/aquarium/dist/src/icons/dataflow02";
@@ -65,7 +64,6 @@ function MainNavigation() {
           <MainNavigationSubmenuList icon={people} text={"Users and teams"}>
             <MainNavigationLink to={`/users`} linkText={"Users"} />
             <MainNavigationLink to={`/teams`} linkText={"Teams"} />
-            <MainNavigationLink to={`/execUsers`} linkText={"User requests"} />
           </MainNavigationSubmenuList>
         </li>
         <li>
@@ -89,16 +87,6 @@ function MainNavigation() {
             icon={list}
             to={`/activityLog`}
             linkText={"Audit log"}
-          />
-        </li>
-        <li>
-          <Box aria-hidden={"true"} paddingTop={"l1"} paddingBottom={"l2"}>
-            <Divider direction="horizontal" size={2} />
-          </Box>
-          <MainNavigationLink
-            icon={cog}
-            to={`/serverConfig`}
-            linkText={"Settings"}
           />
         </li>
       </ul>


### PR DESCRIPTION
# About this change - What it does

- both are links to pages that only superadmin has access to, so they are removed from coral (currently only supporting views for users)

## Screenshot nav after change

<img width="642" alt="updated-nav" src="https://github.com/Aiven-Open/klaw/assets/943800/0912d4c6-265d-4535-9311-af2b3329d401">


Resolves: #1655 



