### PR TITLE
Add sleep for update cmp type

### DIFF
--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/ClusterApiControllerIT.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/ClusterApiControllerIT.java
@@ -200,6 +200,7 @@ public class ClusterApiControllerIT {
         .andExpect(status().isOk())
         .andReturn()
         .getResponse();
+    Thread.sleep(300);
 
     embeddedKafkaBroker.doWithAdmin(
         adminClient -> {


### PR DESCRIPTION
About this change - What it does

After updating the compression type, a sleep makes sure the update is completed

Resolves: #xxxxx
Why this way
