### PR TITLE
Add user switch team fix

### DIFF
--- a/core/src/main/resources/static/js/manageUsers.js
+++ b/core/src/main/resources/static/js/manageUsers.js
@@ -390,7 +390,7 @@ app.controller("manageUsersCtrl", function($scope, $http, $location, $window) {
                     $scope.showAlertToast();
                     return;
                 }
-                if(!$scope.updatedTeamsSwitchList.includes($scope.addNewUser.team.teamId)){
+                if(!$scope.updatedTeamsSwitchList.includes($scope.addNewUser.team)){
                     $scope.alertnote = "Please select your own team, in the switch teams list.";
                     $scope.showAlertToast();
                     return;


### PR DESCRIPTION
About this change - What it does

When adding a new user, and enabling switch teams, even after selecting own team, validation fails

Resolves: #xxxxx
Why this way
