### PR TITLE
Update to provide a better error message to users creating ACLs.

### DIFF
--- a/core/src/main/java/io/aiven/klaw/model/requests/AclRequestsModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/AclRequestsModel.java
@@ -30,7 +30,10 @@ public class AclRequestsModel extends BaseRequestModel implements Serializable {
       acl_ip;
 
   private ArrayList<
-          @Pattern(message = "Invalid Principle", regexp = "^$|^[a-zA-Z 0-9_.,=-]{3,}$") String>
+          @Pattern(
+              message = "Invalid Principle, Username or Service Account",
+              regexp = "^$|^[a-zA-Z 0-9_.,=-]{3,}$")
+          String>
       acl_ssl;
 
   // prefixed acls or Literal(default)


### PR DESCRIPTION
About this change - What it does
Add username or Service Account as the invalid object as it depends on the kafka provider as to the name provided to this value.
Resolves: #1670
Why this way
