### PR TITLE
fix(coral): Use right parameter for `getAivenServiceAccountDetails`.

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.tsx
@@ -89,6 +89,7 @@ const TopicAclRequest = () => {
     aclType === "PRODUCER"
       ? topicProducerForm.watch("topicname")
       : topicConsumerForm.watch("topicname");
+
   useQuery<TopicTeam, Error>(
     ["topicTeam", selectedTopicName, selectedPatternType, aclType],
     {

--- a/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/components/TopicSubscriptionsDetailsModal.tsx
@@ -11,7 +11,6 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Modal } from "src/app/components/Modal";
-import { useAuthContext } from "src/app/context-provider/AuthProvider";
 import {
   getAivenServiceAccountDetails,
   getConsumerOffsets,
@@ -37,7 +36,6 @@ const TopicSubscriptionsDetailsModal = ({
   isAivenCluster,
   selectedSubscription,
 }: TopicSubscriptionsDetailsModalProps) => {
-  const user = useAuthContext();
   const {
     environment,
     consumergroup,
@@ -76,19 +74,13 @@ const TopicSubscriptionsDetailsModal = ({
     error: serviceAccountError,
     isFetched: serviceAccountDataFetched,
   } = useQuery<ServiceAccountDetails, HTTPError>(
-    [
-      "getAivenServiceAccountDetails",
-      environment,
-      topicname,
-      user?.username,
-      req_no,
-    ],
+    ["getAivenServiceAccountDetails", environment, topicname, acl_ssl, req_no],
     {
       queryFn: () => {
         return getAivenServiceAccountDetails({
           env: environment,
           topicName: topicname,
-          userName: user?.username || "",
+          serviceName: acl_ssl || "",
           aclReqNo: req_no,
         });
       },

--- a/coral/src/domain/acl/acl-api.ts
+++ b/coral/src/domain/acl/acl-api.ts
@@ -16,6 +16,7 @@ import {
   KlawApiRequest,
   KlawApiRequestQueryParameters,
   KlawApiResponse,
+  ResolveIntersectionTypes,
 } from "types/utils";
 
 const createAclRequest = (
@@ -137,16 +138,37 @@ function getAivenServiceAccounts(
   );
 }
 
-type GetAivenServiceAccountDetailsParams =
-  KlawApiRequestQueryParameters<"getAivenServiceAccountDetails">;
+/*** The parameter "userName" that the endpoint expects is actually
+ * the name of the service (acl_ssl). Since this is very confusing
+ * and error-prone, we name it different for the params of our
+ * api call function
+ * Will be renamed in Backend after release 2.5.
+ */
+type GetAivenServiceAccountDetailsParams = ResolveIntersectionTypes<
+  Omit<
+    KlawApiRequestQueryParameters<"getAivenServiceAccountDetails">,
+    "userName"
+  > & {
+    serviceName: KlawApiRequestQueryParameters<"getAivenServiceAccountDetails">["userName"];
+  }
+>;
+
 type getAivenServiceAccountDetailsResponse =
   KlawApiResponse<"getAivenServiceAccountDetails">;
 function getAivenServiceAccountDetails(
   params: GetAivenServiceAccountDetailsParams
 ): Promise<getAivenServiceAccountDetailsResponse> {
+  const apiParams: KlawApiRequestQueryParameters<"getAivenServiceAccountDetails"> =
+    {
+      aclReqNo: params.aclReqNo,
+      env: params.env,
+      topicName: params.topicName,
+      userName: params.serviceName,
+    };
+
   return api.get<getAivenServiceAccountDetailsResponse>(
     API_PATHS.getAivenServiceAccountDetails,
-    new URLSearchParams(params)
+    new URLSearchParams(apiParams)
   );
 }
 


### PR DESCRIPTION
# About this change - What it does

in topic-overview -> subscriptions when opening the details modal, the password was not shown for users that did have permission to see it. 

This PR updates a (very misleading named :D) parameter `userName` to actually be the `serviceName` to fix this. 


### Screenshots

#### Staging (before change)

1. user without permission
<img width="1154" alt="staging-no-auth" src="https://github.com/Aiven-Open/klaw/assets/943800/ca9eb152-6d1f-4c26-9356-395c3d2892bf">

2. user with permission
<img width="1119" alt="staging-do-have-auth" src="https://github.com/Aiven-Open/klaw/assets/943800/2f75b7ee-b74c-4ec9-8ab6-35fce337f2f2">


#### Local dev (including this change)

1. user without permission
<img width="1180" alt="localhost-no-auth" src="https://github.com/Aiven-Open/klaw/assets/943800/54b79857-84ec-4235-bb5e-eb465fe919f5">


2. user with permission

<img width="1158" alt="localhost-do-have-auth" src="https://github.com/Aiven-Open/klaw/assets/943800/dde8e920-32e8-40dd-93fb-db1a4cf2a453">

Resolves: #1668 

