### PR TITLE
fix(coral): Update validation for service accounts field

### DIFF
--- a/coral/src/app/features/topics/acl-request/form-schemas/topic-acl-request-shared-fields.ts
+++ b/coral/src/app/features/topics/acl-request/form-schemas/topic-acl-request-shared-fields.ts
@@ -41,10 +41,10 @@ const acl_ssl = z
   .max(5, { message: "Maximum 5 elements allowed." })
   .refine(
     (values) => {
-      return values.find((value) => value.length < 4) === undefined;
+      return values.find((value) => value.length < 3) === undefined;
     },
     {
-      message: "Every element must be more than 3 characters.",
+      message: "Every element must have at least 3 characters.",
     }
   )
   .optional();


### PR DESCRIPTION
# About this change - What it does

Backend has validation for service account names to have at least 3 characters (3 and more) but we checked for more then 3 characters (4 and more). This caused valid service accounts that user could chose from the list to cause a validation error in frontend so users could not submit there request. 

This PR changes the min characters and updates the message in wording, too, so it's less confusing.

(I said "should have more than 3 characters" and there's a high chance user don't register "more than" and focus on 3, which was wrong)

I created a follow up ticket for more validation, too: https://github.com/Aiven-Open/klaw/issues/1675


### Recording


https://github.com/Aiven-Open/klaw/assets/943800/42e02602-96da-4c98-91f0-1c1fdc8fb794




Resolves  #1671 

