### PR TITLE
fix(coral):  fix focus style on focusable elements in modals

### DIFF
--- a/coral/src/app/components/Modal.module.css
+++ b/coral/src/app/components/Modal.module.css
@@ -10,3 +10,12 @@
   overflow: auto;
   max-height: 70vh;
 }
+
+/*Without margin, focus styles for full-width form elements in*/
+/*Modal will not be applied correctly, because the overflow in*/
+/*combination with w-100 element (e.g. DS <Textarea>) will not */
+/*leave room for focus border*/
+.modalTextBlock > *:first-child {
+  margin-left: 2px;
+  margin-right: 2px;
+}


### PR DESCRIPTION
# About this change - What it does

- adds a slight margin for the element settig the overflow for modal children, so the focus styles have anough room to show. 


## Screenshots before 

claim modal

<img width="748" alt="claim-before" src="https://github.com/Aiven-Open/klaw/assets/943800/ec19242d-7f99-45ea-907b-6a1d2aaf9876">

decline modal

<img width="674" alt="decline-before" src="https://github.com/Aiven-Open/klaw/assets/943800/f68de5ac-a765-4458-8eb0-a8e42969d728">

promote modal

<img width="731" alt="promote-before" src="https://github.com/Aiven-Open/klaw/assets/943800/f6b3c60f-5d9c-4ff2-91c6-303b479161ec">


## Screenshots after

promote modal

<img width="844" alt="promotion-after" src="https://github.com/Aiven-Open/klaw/assets/943800/c204e0a6-5479-4996-bafe-2f656877eb9f">

claim modal

<img width="764" alt="claim-after" src="https://github.com/Aiven-Open/klaw/assets/943800/fc19dd70-37a8-4dc8-b765-27ff3d4cf30c">

decline modal

<img width="764" alt="decline-after" src="https://github.com/Aiven-Open/klaw/assets/943800/63ea5f98-9b34-4246-973c-9520699f909c">



Resolves: #1683 
Why this way
