### PR TITLE
refactor(coral): Remove unnecessary tooltips

### DIFF
--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.tsx
@@ -230,7 +230,6 @@ export default function AclApprovalsTable({
             declineInProgress ||
             actionsDisabled ||
             request.requestStatus !== "CREATED",
-          tooltip: `Decline ACL request for topic ${request.topicname}`,
           icon: declineInProgress ? loadingIcon : deleteIcon,
           loading: declineInProgress,
         };

--- a/coral/src/app/layout/header/HeaderNavigation.tsx
+++ b/coral/src/app/layout/header/HeaderNavigation.tsx
@@ -30,10 +30,7 @@ function HeaderNavigation() {
         }}
       >
         <DropdownMenu.Trigger>
-          <PrimaryDropdownButton
-            aria-label="Request a new"
-            tooltip="Request a new"
-          >
+          <PrimaryDropdownButton aria-label="Request a new">
             Request a new
           </PrimaryDropdownButton>
         </DropdownMenu.Trigger>


### PR DESCRIPTION
# About this change - What it does

1. removes tooltip in decline button for ACL approvals
(It's the only button that has it. It's unecessary, since the connection between button and topic is visual. This is the screen reader text that is shown. And the tooltip is only working with mouse, so it's not really accessible anyway. 

https://user-images.githubusercontent.com/943800/262703207-5f15a00e-be25-46a9-9e38-68ce0b2e0d93.png


2. Remove tooltip for "Request new..." button. Has no effect whatsover.

Resolves: #1684 

