### PR TITLE
Introduce existsByTeamIdAndTenantId instead of getAll

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -239,6 +239,8 @@ public interface HandleDbRequests {
 
   List<UserInfo> getAllUsersInfoForTeam(Integer teamId, int tenantId);
 
+  boolean existsUsersInfoForTeam(Integer teamId, int tenantId);
+
   List<RegisterUserInfo> getAllRegisterUsersInfoForTenant(int tenantId);
 
   List<RegisterUserInfo> getAllRegisterUsersInformation();

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -541,6 +541,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public boolean existsUsersInfoForTeam(Integer teamId, int tenantId) {
+    return jdbcSelectHelper.existsUsersInfoForTeam(teamId, tenantId);
+  }
+
+  @Override
   public List<RegisterUserInfo> getAllRegisterUsersInfoForTenant(int tenantId) {
     return jdbcSelectHelper.selectAllRegisterUsersInfoForTenant(tenantId);
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -913,6 +913,10 @@ public class SelectDataJdbc {
     return userInfoRepo.findAllByTeamIdAndTenantId(teamId, tenantId);
   }
 
+  public boolean existsUsersInfoForTeam(Integer teamId, int tenantId) {
+    return userInfoRepo.existsByTeamIdAndTenantId(teamId, tenantId);
+  }
+
   public List<Env> selectAllEnvs(KafkaClustersType type, int tenantId) {
     if (KafkaClustersType.ALL == type) {
       return envRepo.findAllByTenantId(tenantId);

--- a/core/src/main/java/io/aiven/klaw/repository/UserInfoRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/UserInfoRepo.java
@@ -14,5 +14,7 @@ public interface UserInfoRepo extends CrudRepository<UserInfo, String> {
 
   List<UserInfo> findAllByTeamIdAndTenantId(Integer teamId, int tenantId);
 
+  boolean existsByTeamIdAndTenantId(Integer teamId, int tenantId);
+
   void deleteByTenantId(int tenantId);
 }

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -392,10 +392,9 @@ public class UsersTeamsControllerService {
                 (!manageDatabase
                         .getHandleDbRequests()
                         .existsComponentsCountForTeam(teamModel.getTeamId(), tenantId))
-                    && (manageDatabase
+                    && (!manageDatabase
                         .getHandleDbRequests()
-                        .getAllUsersInfoForTeam(teamModel.getTeamId(), tenantId)
-                        .isEmpty())
+                        .existsUsersInfoForTeam(teamModel.getTeamId(), tenantId))
                     && allUsersInfo.stream()
                         .noneMatch(
                             userInfo ->
@@ -448,7 +447,7 @@ public class UsersTeamsControllerService {
     }
 
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    if (manageDatabase.getHandleDbRequests().getAllUsersInfoForTeam(teamId, tenantId).size() > 0) {
+    if (manageDatabase.getHandleDbRequests().existsUsersInfoForTeam(teamId, tenantId)) {
       return ApiResponse.notOk(TEAMS_ERR_103);
     }
 

--- a/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
@@ -22,7 +22,6 @@ import io.aiven.klaw.model.response.ResetPasswordInfo;
 import io.aiven.klaw.model.response.TeamModelResponse;
 import io.aiven.klaw.model.response.UserInfoModelResponse;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -246,14 +245,11 @@ public class UsersTeamsControllerServiceTest {
     when(manageDatabase.getTeamObjForTenant(tenantId)).thenReturn(utilMethods.getTeams());
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(handleDbRequests.existsComponentsCountForTeam(teamId, tenantId)).thenReturn(false);
-    when(handleDbRequests.getAllUsersInfoForTeam(teamId, tenantId))
-        .thenReturn(Collections.emptyList());
+    when(handleDbRequests.existsUsersInfoForTeam(teamId, tenantId)).thenReturn(false);
     List<TeamModelResponse> teams = usersTeamsControllerService.getAllTeamsSU();
     assertThat(teams.get(0).isShowDeleteTeam()).isTrue();
 
     when(handleDbRequests.existsComponentsCountForTeam(teamId, tenantId)).thenReturn(true);
-    when(handleDbRequests.getAllUsersInfoForTeam(teamId, tenantId))
-        .thenReturn(Collections.emptyList());
     teams = usersTeamsControllerService.getAllTeamsSU();
     assertThat(teams.get(0).isShowDeleteTeam()).isFalse();
   }
@@ -268,8 +264,7 @@ public class UsersTeamsControllerServiceTest {
     when(mailService.getUserName(any())).thenReturn("testuser");
     when(manageDatabase.getRolesPermissionsPerTenant(anyInt()))
         .thenReturn(utilMethods.getRolesPermsMap());
-    when(handleDbRequests.getAllUsersInfoForTeam(teamId, tenantId))
-        .thenReturn(Collections.singletonList(new UserInfo()));
+    when(handleDbRequests.existsUsersInfoForTeam(teamId, tenantId)).thenReturn(true);
     ApiResponse apiResponse = usersTeamsControllerService.deleteTeam(teamId);
     assertThat(apiResponse.getMessage())
         .isEqualTo("Not allowed to delete this team, as there are associated users.");
@@ -277,7 +272,6 @@ public class UsersTeamsControllerServiceTest {
 
   @Test
   void deleteUserFailureHasRequests() throws KlawException {
-    UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);


### PR DESCRIPTION
In a couple of cases it's better to use `exists` rather than `getAll` to minimize amount of data transferring between db and the app