### PR TITLE
bug(coral) - ACL request form : Fix error in Topic name field, only fetch `teamId` when needed

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest.test.tsx
@@ -913,19 +913,21 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: "aivtopic1",
-          environment: "1",
-          aclType: "PRODUCER",
-          requestOperationType: "CREATE",
-          transactionalId: undefined,
-          teamId: 1,
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: "aivtopic1",
+            environment: "1",
+            aclType: "PRODUCER",
+            requestOperationType: "CREATE",
+            transactionalId: undefined,
+            teamId: 1,
+          })
+        );
 
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
@@ -989,18 +991,20 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: "aivtopic1",
-          environment: "1",
-          aclType: "PRODUCER",
-          requestOperationType: "CREATE",
-          teamId: 1,
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: "aivtopic1",
+            environment: "1",
+            aclType: "PRODUCER",
+            requestOperationType: "CREATE",
+            teamId: 1,
+          })
+        );
         await waitFor(() => expect(mockedUseToast).toHaveBeenCalled());
       });
 
@@ -1064,7 +1068,7 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
 
         await waitFor(() => {
           expect(mockedNavigate).toHaveBeenLastCalledWith(
@@ -1268,19 +1272,21 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: "aivtopic1",
-          environment: "1",
-          aclType: "CONSUMER",
-          teamId: 1,
-          consumergroup: "group",
-          requestOperationType: "CREATE",
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: "aivtopic1",
+            environment: "1",
+            aclType: "CONSUMER",
+            teamId: 1,
+            consumergroup: "group",
+            requestOperationType: "CREATE",
+          })
+        );
 
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
@@ -1359,20 +1365,22 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: "aivtopic1",
-          environment: "1",
-          aclType: "CONSUMER",
-          teamId: 1,
-          consumergroup: "group",
-          requestOperationType: "CREATE",
-          transactionalId: undefined,
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: "aivtopic1",
+            environment: "1",
+            aclType: "CONSUMER",
+            teamId: 1,
+            consumergroup: "group",
+            requestOperationType: "CREATE",
+            transactionalId: undefined,
+          })
+        );
         await waitFor(() => expect(mockedUseToast).toHaveBeenCalled());
       });
 
@@ -1449,7 +1457,7 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
         await waitFor(() => {
           expect(mockedNavigate).toHaveBeenLastCalledWith(
             "/requests/acls?status=CREATED"
@@ -2333,19 +2341,21 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: "aivtopic1",
-          environment: "1",
-          aclType: "PRODUCER",
-          requestOperationType: "CREATE",
-          transactionalId: undefined,
-          teamId: 1,
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: "aivtopic1",
+            environment: "1",
+            aclType: "PRODUCER",
+            requestOperationType: "CREATE",
+            transactionalId: undefined,
+            teamId: 1,
+          })
+        );
 
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
@@ -2408,18 +2418,20 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: "aivtopic1",
-          environment: "1",
-          aclType: "PRODUCER",
-          requestOperationType: "CREATE",
-          teamId: 1,
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: "aivtopic1",
+            environment: "1",
+            aclType: "PRODUCER",
+            requestOperationType: "CREATE",
+            teamId: 1,
+          })
+        );
         await waitFor(() => expect(mockedUseToast).toHaveBeenCalled());
       });
 
@@ -2482,7 +2494,7 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
         await waitFor(() => {
           expect(mockedNavigate).toHaveBeenLastCalledWith(
             "/requests/acls?status=CREATED"
@@ -2686,19 +2698,21 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: mockedResponseTopicNames[0],
-          environment: "1",
-          aclType: "CONSUMER",
-          teamId: 1,
-          consumergroup: "group",
-          requestOperationType: "CREATE",
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: mockedResponseTopicNames[0],
+            environment: "1",
+            aclType: "CONSUMER",
+            teamId: 1,
+            consumergroup: "group",
+            requestOperationType: "CREATE",
+          })
+        );
 
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
@@ -2788,20 +2802,22 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
-        expect(spyPost).toHaveBeenCalledWith("/createAcl", {
-          remarks: "",
-          aclIpPrincipleType: "PRINCIPAL",
-          acl_ssl: ["Alice"],
-          aclPatternType: "LITERAL",
-          topicname: mockedResponseTopicNames[0],
-          environment: "1",
-          aclType: "CONSUMER",
-          teamId: 1,
-          consumergroup: "group",
-          requestOperationType: "CREATE",
-          transactionalId: undefined,
-        });
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(spyPost).toHaveBeenCalledWith("/createAcl", {
+            remarks: "",
+            aclIpPrincipleType: "PRINCIPAL",
+            acl_ssl: ["Alice"],
+            aclPatternType: "LITERAL",
+            topicname: mockedResponseTopicNames[0],
+            environment: "1",
+            aclType: "CONSUMER",
+            teamId: 1,
+            consumergroup: "group",
+            requestOperationType: "CREATE",
+            transactionalId: undefined,
+          })
+        );
         await waitFor(() => expect(mockedUseToast).toHaveBeenCalled());
       });
 
@@ -2889,7 +2905,7 @@ describe("<TopicAclRequest />", () => {
         await waitFor(() => expect(submitButton).toBeEnabled());
         await userEvent.click(submitButton);
 
-        expect(spyPost).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(spyPost).toHaveBeenCalledTimes(1));
         await waitFor(() => {
           expect(mockedNavigate).toHaveBeenLastCalledWith(
             "/requests/acls?status=CREATED"

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -84,7 +84,7 @@ const TopicConsumerForm = ({
         const errorMessage =
           error || "There was an error fetching the topic team.";
         // We need to throw an error here instead of setting an error on the field for two reasons:
-        // - we need to prevent the useMutatino to reach onSuccess (which would navigate away)
+        // - we need to prevent the useMutation to reach onSuccess (which would navigate away)
         // - the error is a response from the getTopicTeam call, so is treated like a form submission error...
         // ... even if it's not strictly a form submission error
         throw new Error(errorMessage);

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -70,7 +70,7 @@ const TopicConsumerForm = ({
     topicConsumerForm.resetField("acl_ssl");
   }, [aclIpPrincipleType]);
 
-  const { mutateAsync, isLoading, isError, error } = useMutation({
+  const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: async (payload: TopicConsumerFormSchema) => {
       const { teamId, error } = await getTopicTeam({
         topicName: payload.topicname,
@@ -105,7 +105,7 @@ const TopicConsumerForm = ({
   const onSubmitTopicConsumer: SubmitHandler<TopicConsumerFormSchema> = (
     formData
   ) => {
-    return mutateAsync(formData);
+    return mutate(formData);
   };
 
   function cancelRequest() {

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -77,9 +77,10 @@ const TopicConsumerForm = ({
         patternType: payload.aclPatternType,
       });
 
-      // teamId will actually never be undefined, but will be 0 when there is an error
+      // When error !== undefined, teamId will not be undefined, but will be 0
       // However, the openapi.yaml definition doesn't reflect that, so we need to check for undefined
       // So that teamId in the happy path can be typed properly
+      // Related issue: https://github.com/Aiven-Open/klaw/issues/1710
       if (error !== undefined || teamId === undefined) {
         const errorMessage =
           error || "There was an error fetching the topic team.";

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.tsx
@@ -1,11 +1,11 @@
 import {
   Alert,
   Box,
+  Button,
   Divider,
   Grid,
   GridItem,
   Input,
-  Button,
   useToast,
 } from "@aivenio/aquarium";
 import { useMutation } from "@tanstack/react-query";
@@ -27,6 +27,7 @@ import TopicNameField from "src/app/features/topics/acl-request/fields/TopicName
 import { TopicConsumerFormSchema } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-consumer";
 import { ExtendedEnvironment } from "src/app/features/topics/acl-request/queries/useExtendedEnvironments";
 import { createAclRequest } from "src/domain/acl/acl-api";
+import { getTopicTeam } from "src/domain/topic";
 import { parseErrorMsg } from "src/services/mutation-utils";
 
 // eslint-disable-next-line import/exports-last
@@ -69,8 +70,28 @@ const TopicConsumerForm = ({
     topicConsumerForm.resetField("acl_ssl");
   }, [aclIpPrincipleType]);
 
-  const { mutate, isLoading, isError, error } = useMutation({
-    mutationFn: createAclRequest,
+  const { mutateAsync, isLoading, isError, error } = useMutation({
+    mutationFn: async (payload: TopicConsumerFormSchema) => {
+      const { teamId, error } = await getTopicTeam({
+        topicName: payload.topicname,
+        patternType: payload.aclPatternType,
+      });
+
+      // teamId will actually never be undefined, but will be 0 when there is an error
+      // However, the openapi.yaml definition doesn't reflect that, so we need to check for undefined
+      // So that teamId in the happy path can be typed properly
+      if (error !== undefined || teamId === undefined) {
+        const errorMessage =
+          error || "There was an error fetching the topic team.";
+        // We need to throw an error here instead of setting an error on the field for two reasons:
+        // - we need to prevent the useMutatino to reach onSuccess (which would navigate away)
+        // - the error is a response from the getTopicTeam call, so is treated like a form submission error...
+        // ... even if it's not strictly a form submission error
+        throw new Error(errorMessage);
+      }
+
+      return createAclRequest({ ...payload, teamId });
+    },
     onSuccess: () => {
       navigate("/requests/acls?status=CREATED");
       toast({
@@ -84,7 +105,7 @@ const TopicConsumerForm = ({
   const onSubmitTopicConsumer: SubmitHandler<TopicConsumerFormSchema> = (
     formData
   ) => {
-    mutate(formData);
+    return mutateAsync(formData);
   };
 
   function cancelRequest() {
@@ -92,7 +113,7 @@ const TopicConsumerForm = ({
     navigate(-1);
   }
 
-  // The consumer group field is irrelevant if the Environment is an Aiven cluster
+  // The consumergroup field is irrelevant if the Environment is an Aiven cluster
   // So we hide it when:
   // - we don't know if the Environment is an Aiven cluster (user has not selected an environment yet)
   // - the selected Environment is an Aiven cluster

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -102,7 +102,7 @@ const TopicProducerForm = ({
         const errorMessage =
           error || "There was an error fetching the topic team.";
         // We need to throw an error here instead of setting an error on the field for two reasons:
-        // - we need to prevent the useMutatino to reach onSuccess (which would navigate away)
+        // - we need to prevent the useMutation to reach onSuccess (which would navigate away)
         // - the error is a response from the getTopicTeam call, so is treated like a form submission error...
         // ... even if it's not strictly a form submission error
         throw new Error(errorMessage);

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -95,9 +95,10 @@ const TopicProducerForm = ({
         patternType: payload.aclPatternType,
       });
 
-      // teamId will actually never be undefined, but will be 0 when there is an error
+      // When error !== undefined, teamId will not be undefined, but will be 0
       // However, the openapi.yaml definition doesn't reflect that, so we need to check for undefined
       // So that teamId in the happy path can be typed properly
+      // Related issue: https://github.com/Aiven-Open/klaw/issues/1710
       if (error !== undefined || teamId === undefined) {
         const errorMessage =
           error || "There was an error fetching the topic team.";

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -1,17 +1,18 @@
 import {
   Alert,
+  RadioButton as BaseRadioButton,
   Box,
+  Button,
   Divider,
   Grid,
   GridItem,
-  RadioButton as BaseRadioButton,
-  Button,
   useToast,
 } from "@aivenio/aquarium";
 import { useMutation } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { UseFormReturn } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import { Dialog } from "src/app/components/Dialog";
 import {
   Form,
   RadioButtonGroup,
@@ -25,10 +26,10 @@ import IpOrPrincipalField from "src/app/features/topics/acl-request/fields/IpOrP
 import RemarksField from "src/app/features/topics/acl-request/fields/RemarksField";
 import TopicNameOrPrefixField from "src/app/features/topics/acl-request/fields/TopicNameOrPrefixField";
 import { TopicProducerFormSchema } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-producer";
-import { createAclRequest } from "src/domain/acl/acl-api";
-import { parseErrorMsg } from "src/services/mutation-utils";
-import { Dialog } from "src/app/components/Dialog";
 import { ExtendedEnvironment } from "src/app/features/topics/acl-request/queries/useExtendedEnvironments";
+import { createAclRequest } from "src/domain/acl/acl-api";
+import { getTopicTeam } from "src/domain/topic";
+import { parseErrorMsg } from "src/services/mutation-utils";
 
 // eslint-disable-next-line import/exports-last
 export interface TopicProducerFormProps {
@@ -81,11 +82,34 @@ const TopicProducerForm = ({
     ) {
       return;
     }
-    return topicProducerForm.setValue("topicname", topicNames[0]);
+    // Reset default value of topicname field
+    // And trigger validation to ensure no error remains displayed
+    topicProducerForm.setValue("topicname", topicNames[0]);
+    topicProducerForm.trigger("topicname");
   }, [aclPatternType]);
 
-  const { mutate, isLoading, isError, error } = useMutation({
-    mutationFn: createAclRequest,
+  const { mutateAsync, isLoading, isError, error } = useMutation({
+    mutationFn: async (payload: TopicProducerFormSchema) => {
+      const { teamId, error } = await getTopicTeam({
+        topicName: payload.topicname,
+        patternType: payload.aclPatternType,
+      });
+
+      // teamId will actually never be undefined, but will be 0 when there is an error
+      // However, the openapi.yaml definition doesn't reflect that, so we need to check for undefined
+      // So that teamId in the happy path can be typed properly
+      if (error !== undefined || teamId === undefined) {
+        const errorMessage =
+          error || "There was an error fetching the topic team.";
+        // We need to throw an error here instead of setting an error on the field for two reasons:
+        // - we need to prevent the useMutatino to reach onSuccess (which would navigate away)
+        // - the error is a response from the getTopicTeam call, so is treated like a form submission error...
+        // ... even if it's not strictly a form submission error
+        throw new Error(errorMessage);
+      }
+
+      return createAclRequest({ ...payload, teamId });
+    },
     onSuccess: () => {
       navigate("/requests/acls?status=CREATED");
       toast({
@@ -99,7 +123,7 @@ const TopicProducerForm = ({
   const onSubmitTopicProducer: SubmitHandler<TopicProducerFormSchema> = (
     formData
   ) => {
-    mutate(formData);
+    return mutateAsync(formData);
   };
 
   function cancelRequest() {

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.tsx
@@ -88,7 +88,7 @@ const TopicProducerForm = ({
     topicProducerForm.trigger("topicname");
   }, [aclPatternType]);
 
-  const { mutateAsync, isLoading, isError, error } = useMutation({
+  const { mutate, isLoading, isError, error } = useMutation({
     mutationFn: async (payload: TopicProducerFormSchema) => {
       const { teamId, error } = await getTopicTeam({
         topicName: payload.topicname,
@@ -123,7 +123,7 @@ const TopicProducerForm = ({
   const onSubmitTopicProducer: SubmitHandler<TopicProducerFormSchema> = (
     formData
   ) => {
-    return mutateAsync(formData);
+    mutate(formData);
   };
 
   function cancelRequest() {


### PR DESCRIPTION
## About this change - What it does

- fix error message not cleared properly when switching between Literal and Prefixed pattern types
- only fetch `teamId` when submitting the request, not on every change of `topicname` and other dependencies.

https://github.com/Aiven-Open/klaw/assets/20607294/0a365b01-bf3c-4050-b8f7-ececf3661a0b



Resolves: #1669 
