### PR TITLE
feact(coral): Add form to request connector promotion

### DIFF
--- a/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
@@ -1,0 +1,668 @@
+import { Context as AquariumContext } from "@aivenio/aquarium";
+import { ConnectorPromotionRequest } from "src/app/features/connectors/request/ConnectorPromotionRequest";
+import { cleanup, waitFor, screen } from "@testing-library/react";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { Route, Routes } from "react-router-dom";
+import {
+  Environment,
+  getAllEnvironmentsForConnector,
+} from "src/domain/environment";
+import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import {
+  ConnectorDetailsForEnv,
+  getConnectorDetailsPerEnv,
+  requestConnectorPromotion,
+} from "src/domain/connector";
+import { waitForElementToBeRemoved, within } from "@testing-library/react/pure";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("src/domain/environment/environment-api.ts");
+const mockGetConnectorEnvironmentRequest =
+  getAllEnvironmentsForConnector as jest.MockedFunction<
+    typeof getAllEnvironmentsForConnector
+  >;
+
+jest.mock("src/domain/connector/connector-api.ts");
+const mockGetConnectorDetailsPerEnv =
+  getConnectorDetailsPerEnv as jest.MockedFunction<
+    typeof getConnectorDetailsPerEnv
+  >;
+
+const mockRequestConnectorPromotion =
+  requestConnectorPromotion as jest.MockedFunction<
+    typeof requestConnectorPromotion
+  >;
+
+const testConnectorName = "test-connector-name";
+const defaultSourceEnv = "111";
+const defaultTargetEnv = "999";
+const defaultEnvironments: Environment[] = [
+  createEnvironment({ name: "DEV", id: defaultSourceEnv }),
+  createEnvironment({ name: "TST", id: defaultTargetEnv }),
+];
+
+const testConnectorConfig =
+  '{\n"connector.class":"io.confluent.connect.storage.tools.SchemaSourceConnector",\n' +
+  '  "tasks.max" : "1",\n  "name" : "test-connector-name",\n  "topic" : "NewTopic",\n  "topics.regex" : "*"\n}';
+const testConnectorDetails: ConnectorDetailsForEnv = {
+  connectorExists: true,
+  connectorId: 1,
+  connectorContents: {
+    connectorName: testConnectorName,
+    environmentId: defaultTargetEnv,
+    connectorConfig: testConnectorConfig,
+    description: "Just a description",
+  } as ConnectorDetailsForEnv["connectorContents"],
+};
+
+function renderConnectorPromotionRequest({
+  sourceEnv = defaultSourceEnv,
+  targetEnv = defaultTargetEnv,
+}: {
+  sourceEnv?: string | null;
+  targetEnv?: string | null;
+}) {
+  return customRender(
+    <Routes>
+      <Route
+        path="/connector/:connectorName/request-promotion"
+        element={
+          <AquariumContext>
+            <ConnectorPromotionRequest />
+          </AquariumContext>
+        }
+      />
+    </Routes>,
+    {
+      queryClient: true,
+      memoryRouter: true,
+      customRoutePath: `/connector/${testConnectorName}/request-promotion?${
+        sourceEnv ? `sourceEnv=${sourceEnv}` : ""
+      }${targetEnv ? `&targetEnv=${targetEnv}` : ""}`,
+    }
+  );
+}
+
+const mockedUsedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
+const mockedUseToast = jest.fn();
+jest.mock("@aivenio/aquarium", () => ({
+  ...jest.requireActual("@aivenio/aquarium"),
+  useToast: () => mockedUseToast,
+}));
+
+describe("ConnectorPromotionRequest", () => {
+  const user = userEvent.setup();
+
+  describe("handles passing of correct params via url", () => {
+    beforeEach(() => {
+      mockGetConnectorDetailsPerEnv.mockResolvedValue({});
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("redirects user and shows error when there is no source env", () => {
+      renderConnectorPromotionRequest({ sourceEnv: null });
+
+      expect(mockedUseToast).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Missing url parameter" })
+      );
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(
+        "/connector/test-connector-name",
+        { replace: true }
+      );
+    });
+
+    it("redirects user and shows error when there is no target env", () => {
+      renderConnectorPromotionRequest({ targetEnv: null });
+
+      expect(mockedUseToast).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Missing url parameter" })
+      );
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(
+        "/connector/test-connector-name",
+        { replace: true }
+      );
+    });
+  });
+
+  describe("loads and handles available environments", () => {
+    const originalConsoleError = console.error;
+
+    beforeEach(() => {
+      mockGetConnectorDetailsPerEnv.mockResolvedValue({});
+      console.error = jest.fn();
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("fetches available environments on page load", () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+
+      renderConnectorPromotionRequest({});
+
+      expect(mockGetConnectorEnvironmentRequest).toHaveBeenCalledTimes(1);
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("informs and redirects user when sourceEnv does not exist", async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ name: "TST", id: defaultTargetEnv }),
+      ]);
+
+      renderConnectorPromotionRequest({});
+
+      expect(mockGetConnectorEnvironmentRequest).toHaveBeenCalledTimes(1);
+
+      await waitFor(() =>
+        expect(mockedUseToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: `No source environment was found with ID ${defaultSourceEnv}`,
+          })
+        )
+      );
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(
+        "/connector/test-connector-name",
+        { replace: true }
+      );
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("informs and redirects user when targetEnv does not exist", async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue([
+        createEnvironment({ name: "DEV", id: defaultSourceEnv }),
+      ]);
+
+      renderConnectorPromotionRequest({});
+
+      expect(mockGetConnectorEnvironmentRequest).toHaveBeenCalledTimes(1);
+
+      await waitFor(() =>
+        expect(mockedUseToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: `No target environment was found with ID ${defaultTargetEnv}`,
+          })
+        )
+      );
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(
+        "/connector/test-connector-name",
+        { replace: true }
+      );
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("informs and redirects user when an error occurs with fetching", async () => {
+      mockGetConnectorEnvironmentRequest.mockRejectedValue({
+        message: "Oh no",
+      });
+
+      renderConnectorPromotionRequest({});
+
+      expect(mockGetConnectorEnvironmentRequest).toHaveBeenCalledTimes(1);
+
+      await waitFor(() =>
+        expect(mockedUseToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Error while fetching available environments: Oh no",
+          })
+        )
+      );
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(
+        "/connector/test-connector-name",
+        { replace: true }
+      );
+      expect(console.error).toHaveBeenCalledWith({ message: "Oh no" });
+    });
+  });
+
+  describe("loads and handles connector details", () => {
+    const originalConsoleError = console.error;
+
+    beforeEach(() => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+
+      console.error = jest.fn();
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("fetches connector details on load", () => {
+      mockGetConnectorDetailsPerEnv.mockResolvedValue({});
+
+      renderConnectorPromotionRequest({});
+
+      expect(mockGetConnectorDetailsPerEnv).toHaveBeenCalledTimes(1);
+      expect(mockGetConnectorDetailsPerEnv).toHaveBeenCalledWith({
+        connectorName: testConnectorName,
+        envSelected: defaultSourceEnv,
+      });
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("informs and redirects user when connector details does not exist", async () => {
+      mockGetConnectorDetailsPerEnv.mockResolvedValue({});
+
+      renderConnectorPromotionRequest({});
+
+      expect(mockGetConnectorDetailsPerEnv).toHaveBeenCalledTimes(1);
+
+      await waitFor(() =>
+        expect(mockedUseToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: `No connector was found with name ${testConnectorName}`,
+          })
+        )
+      );
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith("/connector", {
+        replace: true,
+      });
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it("informs and redirects user when an error occurs with fetching", async () => {
+      mockGetConnectorDetailsPerEnv.mockRejectedValue({
+        message: "Oh no",
+      });
+
+      renderConnectorPromotionRequest({});
+
+      expect(mockGetConnectorDetailsPerEnv).toHaveBeenCalledTimes(1);
+
+      await waitFor(() =>
+        expect(mockedUseToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message:
+              "Error while fetching connector test-connector-name: Oh no",
+          })
+        )
+      );
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith("/connector", {
+        replace: true,
+      });
+      expect(console.error).toHaveBeenCalledWith({ message: "Oh no" });
+    });
+  });
+
+  describe("renders form to request promotion", () => {
+    beforeAll(async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+      mockGetConnectorDetailsPerEnv.mockResolvedValue(testConnectorDetails);
+
+      renderConnectorPromotionRequest({});
+
+      await waitForElementToBeRemoved(screen.getByText("Form is loading."));
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows a form", () => {
+      const form = screen.getByRole("form", {
+        name: "Request connector promotion",
+      });
+
+      expect(form).toBeVisible();
+    });
+
+    it("shows a prefilled, readonly select for environments", () => {
+      const select = screen.getByRole("combobox", {
+        name: "Environment (read-only)",
+      });
+
+      expect(select).toBeDisabled();
+      expect(select).toHaveAttribute("aria-readonly", "true");
+      expect(select).toHaveValue(defaultTargetEnv);
+    });
+
+    it("shows a prefilled, readonly text input for name", () => {
+      const textInput = screen.getByRole("textbox", {
+        name: "Connector name (read-only)",
+      });
+
+      expect(textInput).toBeVisible();
+      expect(textInput).toHaveAttribute("readonly");
+      expect(textInput).toHaveValue(testConnectorName);
+    });
+
+    it("shows a prefilled editor for configuration", () => {
+      const editor = screen.getByTestId("connector-config");
+
+      expect(editor).toBeVisible();
+      expect(editor).toHaveDisplayValue(testConnectorConfig);
+    });
+
+    it("shows a prefilled, readonly textarea for description", () => {
+      const textarea = screen.getByRole("textbox", {
+        name: "Connector description (read-only)",
+      });
+
+      expect(textarea).toBeVisible();
+      expect(textarea).toHaveAttribute("readonly");
+      expect(textarea).toHaveValue("Just a description");
+    });
+
+    it("shows an optional textarea for user to add comment", () => {
+      const textarea = screen.getByRole("textbox", {
+        name: "Message for approval",
+      });
+
+      expect(textarea).toBeEnabled();
+    });
+  });
+
+  describe("enables user to request promotion with no changes", () => {
+    beforeEach(async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+      mockGetConnectorDetailsPerEnv.mockResolvedValue(testConnectorDetails);
+      mockRequestConnectorPromotion.mockResolvedValue({
+        success: true,
+        message: "yey",
+      });
+
+      renderConnectorPromotionRequest({});
+      await waitForElementToBeRemoved(screen.getByText("Form is loading."));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("sends a request to promote a connector", async () => {
+      const submitButton = screen.getByRole("button", {
+        name: "Submit promotion request",
+      });
+
+      await user.click(submitButton);
+
+      expect(mockRequestConnectorPromotion).toHaveBeenCalledWith({
+        connectorName: testConnectorName,
+        environment: defaultTargetEnv,
+        description: "Just a description",
+        connectorConfig: testConnectorConfig,
+        remarks: "",
+      });
+    });
+
+    it("shows success message and redirects user", async () => {
+      const submitButton = screen.getByRole("button", {
+        name: "Submit promotion request",
+      });
+
+      await user.click(submitButton);
+
+      expect(mockedUseToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Connector update request successfully created",
+        })
+      );
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe("enables user to request promotion updated configuration", () => {
+    const updatedConfig =
+      '{ "connector.class" : "someclass" , "tasks.max" : "1", "name" : "test-connector-name",' +
+      ' "topic" : "my-nice-topic", "topics.regex" : "*" }';
+
+    beforeEach(async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+      mockGetConnectorDetailsPerEnv.mockResolvedValue(testConnectorDetails);
+
+      renderConnectorPromotionRequest({});
+      await waitForElementToBeRemoved(screen.getByText("Form is loading."));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("updates existing configuration on user input", async () => {
+      const editor = await screen.findByTestId("connector-config");
+
+      await user.clear(editor);
+      // first { is needed to avoid error from userEvent
+      // (error was: Expected repeat modifier or release modifier or "}" but found """ )
+      await user.type(editor, `{${updatedConfig}`);
+      await user.tab();
+
+      expect(editor).toHaveValue(updatedConfig);
+    });
+
+    it("requests the promotion with the updated configuration", async () => {
+      const editor = await screen.findByTestId("connector-config");
+
+      await user.clear(editor);
+      // first { is needed to avoid error from userEvent
+      // (error was: Expected repeat modifier or release modifier or "}" but found """ )
+      await user.type(editor, `{${updatedConfig}`);
+      await user.tab();
+
+      const submitButton = screen.getByRole("button", {
+        name: "Submit promotion request",
+      });
+
+      await user.click(submitButton);
+
+      expect(mockRequestConnectorPromotion).toHaveBeenCalledWith({
+        connectorName: testConnectorName,
+        environment: defaultTargetEnv,
+        description: "Just a description",
+        connectorConfig: updatedConfig,
+        remarks: "",
+      });
+    });
+  });
+
+  describe("enables user to request promotion with message for approval", () => {
+    beforeEach(async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+      mockGetConnectorDetailsPerEnv.mockResolvedValue(testConnectorDetails);
+
+      renderConnectorPromotionRequest({});
+      await waitForElementToBeRemoved(screen.getByText("Form is loading."));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("sends message for approval with promote request", async () => {
+      const testMessage = "Please approve 🥺";
+      const textarea = screen.getByRole("textbox", {
+        name: "Message for approval",
+      });
+      const submitButton = screen.getByRole("button", {
+        name: "Submit promotion request",
+      });
+
+      await user.type(textarea, testMessage);
+      await user.click(submitButton);
+
+      expect(mockRequestConnectorPromotion).toHaveBeenCalledWith({
+        connectorName: testConnectorName,
+        environment: defaultTargetEnv,
+        description: "Just a description",
+        connectorConfig: testConnectorConfig,
+        remarks: testMessage,
+      });
+    });
+  });
+
+  describe("handles errors when requesting promotion", () => {
+    const testErrorMessage = "OH NO 😭";
+    const originalConsoleError = console.error;
+
+    beforeEach(async () => {
+      console.error = jest.fn();
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+      mockGetConnectorDetailsPerEnv.mockResolvedValue(testConnectorDetails);
+      mockRequestConnectorPromotion.mockRejectedValue({
+        success: false,
+        message: testErrorMessage,
+      });
+
+      renderConnectorPromotionRequest({});
+      await waitForElementToBeRemoved(screen.getByText("Form is loading."));
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows an error message to the user", async () => {
+      const anyAlert = screen.queryByRole("alert");
+      expect(anyAlert).not.toBeInTheDocument();
+
+      const submitButton = screen.getByRole("button", {
+        name: "Submit promotion request",
+      });
+
+      await user.click(submitButton);
+
+      const alertError = screen.getByRole("alert");
+
+      expect(alertError).toBeVisible();
+      expect(alertError).toHaveTextContent(testErrorMessage);
+      expect(console.error).toHaveBeenCalledWith({
+        message: testErrorMessage,
+        success: false,
+      });
+    });
+
+    it("does not show success message and redirects user", async () => {
+      const submitButton = screen.getByRole("button", {
+        name: "Submit promotion request",
+      });
+
+      await user.click(submitButton);
+
+      expect(mockedUseToast).not.toHaveBeenCalled();
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enables user to cancel promotion", () => {
+    beforeEach(async () => {
+      mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
+      mockGetConnectorDetailsPerEnv.mockResolvedValue(testConnectorDetails);
+      mockRequestConnectorPromotion.mockResolvedValue({
+        success: true,
+        message: "yey",
+      });
+
+      renderConnectorPromotionRequest({});
+      await waitForElementToBeRemoved(screen.getByText("Form is loading."));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("redirects user when they didn't change anything", async () => {
+      const cancelButton = screen.getByRole("button", {
+        name: "Cancel",
+      });
+
+      await user.click(cancelButton);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+      expect(mockRequestConnectorPromotion).not.toHaveBeenCalled();
+    });
+
+    it("shows dialog to user user when they had changes", async () => {
+      const textarea = screen.getByRole("textbox", {
+        name: "Message for approval",
+      });
+      await user.type(textarea, "this is a message");
+
+      const cancelButton = screen.getByRole("button", {
+        name: "Cancel",
+      });
+
+      await user.click(cancelButton);
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toBeVisible();
+      expect(dialog).toHaveTextContent("Cancel connector request?");
+
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+      expect(mockRequestConnectorPromotion).not.toHaveBeenCalled();
+    });
+
+    it("closes modal and shows form again when user wants to continue with request", async () => {
+      const textarea = screen.getByRole("textbox", {
+        name: "Message for approval",
+      });
+      await user.type(textarea, "this is a message");
+
+      const cancelButton = screen.getByRole("button", {
+        name: "Cancel",
+      });
+
+      await user.click(cancelButton);
+
+      const dialog = screen.getByRole("dialog");
+      const continueButton = within(dialog).getByRole("button", {
+        name: "Continue with request",
+      });
+
+      await user.click(continueButton);
+
+      expect(dialog).not.toBeVisible();
+      expect(mockedUsedNavigate).not.toHaveBeenCalled();
+      expect(mockRequestConnectorPromotion).not.toHaveBeenCalled();
+    });
+
+    it("cancels process and redirects user when they confirm cancel", async () => {
+      const textarea = screen.getByRole("textbox", {
+        name: "Message for approval",
+      });
+      await user.type(textarea, "this is a message");
+
+      const cancelButton = screen.getByRole("button", {
+        name: "Cancel",
+      });
+
+      await user.click(cancelButton);
+
+      const dialog = screen.getByRole("dialog");
+      const confirmCancel = within(dialog).getByRole("button", {
+        name: "Cancel request",
+      });
+
+      await user.click(confirmCancel);
+
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+      expect(mockRequestConnectorPromotion).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/coral/src/app/features/connectors/request/ConnectorPromotionRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorPromotionRequest.tsx
@@ -1,0 +1,364 @@
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  BorderBox,
+  Box,
+  Button,
+  Grid,
+  Label,
+  Option,
+  Typography,
+  useToast,
+} from "@aivenio/aquarium";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  Environment,
+  getAllEnvironmentsForConnector,
+} from "src/domain/environment";
+import {
+  Form,
+  NativeSelect,
+  SubmitButton,
+  Textarea,
+  TextInput,
+  useForm,
+} from "src/app/components/Form";
+import {
+  ConnectorRequestFormSchema,
+  connectorRequestFormSchema,
+} from "src/app/features/connectors/request/schemas/connector-request-form";
+import { Controller as _Controller, SubmitHandler } from "react-hook-form";
+import MonacoEditor from "@monaco-editor/react";
+import {
+  ConnectorDetailsForEnv,
+  getConnectorDetailsPerEnv,
+  requestConnectorPromotion,
+} from "src/domain/connector";
+import { HTTPError } from "src/services/api";
+import { parseErrorMsg } from "src/services/mutation-utils";
+import { ConnectorSkeletonForm } from "src/app/features/connectors/request/components/ConnectorSkeletonForm";
+import { Dialog } from "src/app/components/Dialog";
+import isEmpty from "lodash/isEmpty";
+
+function ConnectorPromotionRequest() {
+  const [targetEnv, setTargetEnv] = useState<Environment | undefined>(
+    undefined
+  );
+
+  const [sourceEnv, setSourceEnv] = useState<Environment | undefined>(
+    undefined
+  );
+
+  const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
+
+  const { connectorName } = useParams();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  const sourceEnvId = searchParams.get("sourceEnv");
+  const targetEnvId = searchParams.get("targetEnv");
+
+  function showErrorToast(message: string) {
+    toast({
+      message: message,
+      position: "bottom-left",
+      variant: "danger",
+    });
+  }
+
+  // redirect user in case source or target env id are not set
+  useEffect(() => {
+    if (!targetEnvId || !sourceEnvId) {
+      showErrorToast(`Missing url parameter`);
+      navigate(`/connector/${connectorName}`, { replace: true });
+      return;
+    }
+  }, [sourceEnvId, targetEnvId]);
+
+  const {
+    data: environments,
+    isFetched: isFetchedEnvironments,
+    isError: isErrorEnvironments,
+    error: errorEnvironments,
+  } = useQuery<Environment[], Error>({
+    queryKey: ["getAllEnvironmentsForConnector"],
+    queryFn: () => getAllEnvironmentsForConnector(),
+  });
+
+  useEffect(() => {
+    if (isFetchedEnvironments) {
+      // redirect user back in case there is an error
+      if (isErrorEnvironments) {
+        showErrorToast(
+          `Error while fetching available environments: ${parseErrorMsg(
+            errorEnvironments
+          )}`
+        );
+        navigate(`/connector/${connectorName}`, { replace: true });
+        return;
+      }
+
+      // redirect user back in case source or target env do not exist
+      // e.g. because user came from old url
+      const sourceEnvFromUrl = environments?.find((env) => {
+        return env.id === sourceEnvId;
+      });
+
+      const targetEnvFromUrl = environments?.find((env) => {
+        return env.id === targetEnvId;
+      });
+
+      if (!sourceEnvFromUrl) {
+        showErrorToast(
+          `No source environment was found with ID ${sourceEnvId}`
+        );
+        navigate(`/connector/${connectorName}`, { replace: true });
+        return;
+      }
+
+      if (!targetEnvFromUrl) {
+        showErrorToast(
+          `No target environment was found with ID ${targetEnvId}`
+        );
+        navigate(`/connector/${connectorName}`, { replace: true });
+        return;
+      }
+
+      setTargetEnv(targetEnvFromUrl);
+      setSourceEnv(sourceEnvFromUrl);
+    }
+  }, [isFetchedEnvironments]);
+
+  const {
+    data: connectorDetails,
+    isFetched: isFetchedConnectorDetails,
+    isError: isErrorConnectorDetails,
+    error: errorConnectorDetails,
+  } = useQuery<ConnectorDetailsForEnv, HTTPError>(
+    ["getConnectorDetailsPerEnv", connectorName],
+    {
+      queryFn: () =>
+        getConnectorDetailsPerEnv({
+          connectorName: connectorName || "",
+          envSelected: sourceEnvId || "",
+        }),
+      enabled: sourceEnv !== null,
+    }
+  );
+
+  useEffect(() => {
+    if (isFetchedConnectorDetails) {
+      // redirect user back in case there is an error
+      if (isErrorConnectorDetails) {
+        showErrorToast(
+          `Error while fetching connector ${connectorName}: ${parseErrorMsg(
+            errorConnectorDetails
+          )}`
+        );
+        navigate(`/connector`, { replace: true });
+        return;
+      }
+
+      // redirect user back in case the connector does not exists
+      // e.g. in case they followed an old url
+      if (!connectorDetails?.connectorExists) {
+        showErrorToast(`No connector was found with name ${connectorName}`);
+        navigate(`/connector`, { replace: true });
+        return;
+      }
+    }
+  }, [isFetchedConnectorDetails]);
+
+  const {
+    mutate: requestPromotion,
+    isLoading: isLoadingRequestPromotion,
+    isError: isErrorRequestPromotion,
+    error: errorRequestPromotion,
+  } = useMutation(requestConnectorPromotion, {
+    onSuccess: () => {
+      navigate(-1);
+      toast({
+        message: "Connector update request successfully created",
+        position: "bottom-left",
+        variant: "default",
+      });
+    },
+  });
+
+  const form = useForm<ConnectorRequestFormSchema>({
+    schema: connectorRequestFormSchema,
+    values: {
+      connectorConfig:
+        connectorDetails?.connectorContents?.connectorConfig || "",
+      connectorName: connectorName || "",
+      environment: targetEnv?.id || "",
+      description: connectorDetails?.connectorContents?.description || "",
+    },
+  });
+
+  const onSubmit: SubmitHandler<ConnectorRequestFormSchema> = (data) => {
+    requestPromotion(data);
+  };
+
+  function cancelRequest() {
+    form.reset();
+    navigate(-1);
+  }
+
+  if (!isFetchedConnectorDetails || !isFetchedEnvironments) {
+    return <ConnectorSkeletonForm />;
+  }
+
+  return (
+    <>
+      <Box>
+        {isErrorRequestPromotion && (
+          <Box marginBottom={"l1"}>
+            <Alert type="error">{parseErrorMsg(errorRequestPromotion)}</Alert>
+          </Box>
+        )}
+
+        <Form
+          {...form}
+          ariaLabel={"Request connector promotion"}
+          onSubmit={onSubmit}
+        >
+          {targetEnv && (
+            <NativeSelect<ConnectorRequestFormSchema>
+              name="environment"
+              labelText={"Environment (read-only)"}
+              readOnly
+            >
+              <Option key={targetEnv.id} value={targetEnv.id}>
+                {targetEnv.name}
+              </Option>
+            </NativeSelect>
+          )}
+
+          <TextInput<ConnectorRequestFormSchema>
+            name={"connectorName"}
+            value={connectorName}
+            labelText={"Connector name (read-only)"}
+            readOnly
+          />
+
+          <div aria-hidden={"true"}>
+            <Label labelText="Connector configuration" required />
+          </div>
+          <_Controller<ConnectorRequestFormSchema>
+            name={"connectorConfig"}
+            control={form.control}
+            render={({ field, fieldState: { error } }) => {
+              return (
+                <>
+                  <BorderBox
+                    borderColor="grey-20"
+                    borderWidth={1}
+                    paddingY={"3"}
+                    borderRadius={2}
+                  >
+                    <MonacoEditor
+                      data-testid="connector-config"
+                      height="200px"
+                      language="json"
+                      theme={"light"}
+                      onChange={(value) => {
+                        value !== undefined &&
+                          form.setValue("connectorConfig", value, {
+                            shouldValidate: true,
+                          });
+                      }}
+                      options={{
+                        language: "json",
+                        ariaLabel: "Connector configuration, required",
+                        renderControlCharacters: false,
+                        minimap: { enabled: false },
+                        folding: false,
+                        lineNumbers: "off",
+                        scrollBeyondLastLine: false,
+                        renderLineHighlight: "none",
+                        cursorBlinking: "solid",
+                        overviewRulerLanes: 0,
+                        wordBasedSuggestions: false,
+                        lineNumbersMinChars: 3,
+                        glyphMargin: false,
+                        cursorStyle: "line-thin",
+                        scrollbar: {
+                          useShadows: false,
+                          verticalScrollbarSize: 2,
+                        },
+                        fixedOverflowWidgets: true,
+                      }}
+                      value={field.value}
+                    />
+                  </BorderBox>
+                  <Box marginTop={"1"} marginBottom={"3"} aria-hidden={"true"}>
+                    <Typography.Caption color={"error-50"}>
+                      {error !== undefined ? error.message : <>&nbsp;</>}
+                    </Typography.Caption>
+                  </Box>
+                </>
+              );
+            }}
+          />
+
+          <Grid colGap={"l1"} marginTop={"3"} cols={"2"}>
+            <Textarea<ConnectorRequestFormSchema>
+              name={"description"}
+              value={connectorDetails?.connectorContents?.description}
+              labelText={"Connector description (read-only)"}
+              readOnly={true}
+            />
+            <Textarea<ConnectorRequestFormSchema>
+              name={"remarks"}
+              labelText={"Message for approval"}
+            />
+          </Grid>
+
+          <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
+            <SubmitButton loading={isLoadingRequestPromotion}>
+              Submit promotion request
+            </SubmitButton>
+            <Button
+              type="button"
+              kind={"secondary"}
+              disabled={isLoadingRequestPromotion}
+              onClick={() => {
+                if (!isEmpty(form.formState.touchedFields)) {
+                  setCancelDialogVisible(true);
+                  return;
+                }
+                cancelRequest();
+              }}
+            >
+              Cancel
+            </Button>
+          </Box>
+        </Form>
+      </Box>
+      {cancelDialogVisible && (
+        <Dialog
+          title={"Cancel connector request?"}
+          primaryAction={{
+            text: "Cancel request",
+            onClick: () => {
+              form.reset();
+              navigate(-1);
+            },
+          }}
+          secondaryAction={{
+            text: "Continue with request",
+            onClick: () => setCancelDialogVisible(false),
+          }}
+          type={"warning"}
+        >
+          Do you want to cancel this request? The data added will be lost.
+        </Dialog>
+      )}
+    </>
+  );
+}
+
+export { ConnectorPromotionRequest };

--- a/coral/src/app/features/connectors/request/ConnectorPromotionRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorPromotionRequest.tsx
@@ -129,7 +129,7 @@ function ConnectorPromotionRequest() {
       setTargetEnv(targetEnvFromUrl);
       setSourceEnv(sourceEnvFromUrl);
     }
-  }, [isFetchedEnvironments]);
+  }, [isFetchedEnvironments, isErrorEnvironments]);
 
   const {
     data: connectorDetails,

--- a/coral/src/app/features/connectors/request/components/ConnectorSkeletonForm.tsx
+++ b/coral/src/app/features/connectors/request/components/ConnectorSkeletonForm.tsx
@@ -1,0 +1,33 @@
+import { Grid, GridItem } from "@aivenio/aquarium";
+import { NativeSelect, Textarea, TextInput } from "src/app/components/Form";
+
+const ConnectorSkeletonForm = () => {
+  return (
+    <div data-testid={"connector-form-skeleton-skeleton"}>
+      <span className={"visually-hidden"}>Form is loading.</span>
+      <div aria-hidden={true}>
+        <Grid cols={"2"} minWidth={"fit"} colGap={"9"}>
+          <GridItem colSpan={"span-2"}>
+            <NativeSelect.Skeleton />
+          </GridItem>
+          <GridItem colSpan={"span-2"}>
+            <TextInput.Skeleton />
+          </GridItem>
+
+          <GridItem colSpan={"span-2"} rowSpan={"span-2"}>
+            <Textarea.Skeleton />
+          </GridItem>
+
+          <GridItem>
+            <Textarea.Skeleton />
+          </GridItem>
+          <GridItem>
+            <Textarea.Skeleton />
+          </GridItem>
+        </Grid>
+      </div>
+    </div>
+  );
+};
+
+export { ConnectorSkeletonForm };

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -2,7 +2,7 @@ import { Alert, Banner, Box, Spacing } from "@aivenio/aquarium";
 import { ReactElement } from "react";
 import { InternalLinkButton } from "src/app/components/InternalLinkButton";
 import illustration from "src/app/images/topic-details-banner-Illustration.svg";
-import { PromotionStatus } from "src/domain/topic";
+import { PromotionStatus } from "src/domain/promotion";
 
 type RequestTypeLocal = "CLAIM" | "ALL" | "PROMOTE";
 type EntityTypeLocal = "schema" | "topic" | "connector";

--- a/coral/src/app/pages/connectors/promotion-request.tsx
+++ b/coral/src/app/pages/connectors/promotion-request.tsx
@@ -1,0 +1,26 @@
+import { PageHeader } from "@aivenio/aquarium";
+import { useNavigate, useParams } from "react-router-dom";
+import PreviewBanner from "src/app/components/PreviewBanner";
+import { ConnectorPromotionRequest } from "src/app/features/connectors/request/ConnectorPromotionRequest";
+
+const ConnectorPromotionRequestPage = () => {
+  const navigate = useNavigate();
+  const { connectorName } = useParams();
+
+  if (connectorName === undefined) {
+    navigate(-1);
+    return <></>;
+  }
+
+  return (
+    <>
+      <PreviewBanner
+        linkTarget={`/connectorOverview?connectorName=${connectorName}`}
+      />
+      <PageHeader title={"Request connector promotion"} />
+      <ConnectorPromotionRequest />
+    </>
+  );
+};
+
+export { ConnectorPromotionRequestPage };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -48,6 +48,7 @@ import {
 import { getRouterBasename } from "src/config";
 import { createRouteBehindFeatureFlag } from "src/services/feature-flags/route-utils";
 import { FeatureFlag } from "src/services/feature-flags/types";
+import { ConnectorPromotionRequestPage } from "src/app/pages/connectors/promotion-request";
 
 const routes: Array<RouteObject> = [
   // Login is currently the responsibility of the
@@ -247,6 +248,13 @@ const routes: Array<RouteObject> = [
         path: Routes.CONNECTOR_EDIT_REQUEST,
         element: <ConnectorEditRequest />,
         featureFlag: FeatureFlag.FEATURE_FLAG_EDIT_CONNECTOR,
+        redirectRouteWithoutFeatureFlag: Routes.CONNECTORS,
+      }),
+
+      createRouteBehindFeatureFlag({
+        path: Routes.CONNECTOR_PROMOTION_REQUEST,
+        element: <ConnectorPromotionRequestPage />,
+        featureFlag: FeatureFlag.FEATURE_FLAG_CONNECTOR_OVERVIEW,
         redirectRouteWithoutFeatureFlag: Routes.CONNECTORS,
       }),
     ],

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -7,6 +7,7 @@ enum Routes {
   CONNECTOR_OVERVIEW = "/connector/:connectorName",
   CONNECTOR_REQUEST = "/connectors/request",
   CONNECTOR_EDIT_REQUEST = "/connector/:connectorName/request-update",
+  CONNECTOR_PROMOTION_REQUEST = "/connector/:connectorName/request-promotion",
   TOPIC_REQUEST = "/topics/request",
   TOPIC_ACL_REQUEST = "/topic/:topicName/subscribe",
   TOPIC_SCHEMA_REQUEST = "/topic/:topicName/request-schema",

--- a/coral/src/domain/connector/connector-api.ts
+++ b/coral/src/domain/connector/connector-api.ts
@@ -243,6 +243,21 @@ const requestConnectorClaim = (params: ConnectorClaimPayload) => {
   >(API_PATHS.createClaimConnectorRequest, payload);
 };
 
+const requestConnectorPromotion = (
+  connectorPayload: Omit<
+    KlawApiRequest<"createConnectorRequest">,
+    "requestOperationType"
+  >
+) => {
+  return api.post<
+    KlawApiResponse<"createConnectorRequest">,
+    KlawApiRequest<"createConnectorRequest">
+  >(API_PATHS.createConnectorRequest, {
+    ...connectorPayload,
+    requestOperationType: "PROMOTE",
+  });
+};
+
 export {
   approveConnectorRequest,
   requestConnectorCreation,
@@ -257,4 +272,5 @@ export {
   getConnectors,
   updateConnectorDocumentation,
   requestConnectorClaim,
+  requestConnectorPromotion,
 };

--- a/coral/src/domain/connector/index.ts
+++ b/coral/src/domain/connector/index.ts
@@ -12,6 +12,7 @@ import {
   getConnectors,
   updateConnectorDocumentation,
   requestConnectorClaim,
+  requestConnectorPromotion,
 } from "src/domain/connector/connector-api";
 import {
   Connector,
@@ -37,6 +38,7 @@ export {
   getConnectors,
   updateConnectorDocumentation,
   requestConnectorClaim,
+  requestConnectorPromotion,
 };
 
 export type {

--- a/coral/src/domain/promotion/index.ts
+++ b/coral/src/domain/promotion/index.ts
@@ -1,0 +1,3 @@
+import { PromotionStatus } from "src/domain/promotion/promotion-types";
+
+export type { PromotionStatus };

--- a/coral/src/domain/promotion/promotion-types.ts
+++ b/coral/src/domain/promotion/promotion-types.ts
@@ -1,5 +1,7 @@
 import { KlawApiModel } from "types/utils";
 
-type PromotionStatus = KlawApiModel<"PromotionStatus">;
+type PromotionStatus =
+  | KlawApiModel<"PromotionStatus">
+  | KlawApiModel<"ConnectorPromotionStatus">;
 
 export type { PromotionStatus };

--- a/coral/src/domain/topic/index.ts
+++ b/coral/src/domain/topic/index.ts
@@ -23,7 +23,7 @@ import {
   TopicSchemaOverview,
   TopicTeam,
 } from "src/domain/topic/topic-types";
-import { PromotionStatus } from "src/domain/promotion/promotion-types";
+
 export {
   requestTopicClaim,
   requestTopicDeletion,
@@ -48,5 +48,4 @@ export type {
   TopicRequestStatus,
   TopicSchemaOverview,
   TopicTeam,
-  PromotionStatus,
 };


### PR DESCRIPTION
# About this change - What it does

Is part of #1639


Testing on staging: e.g. https://localhost:5173/connector/Aindriu45/request-promotion?sourceEnv=4&targetEnv=6


## This PR

- adds routing and page for promotion request
- adds api endpoint 
- adds form to promote connector


