### PR TITLE
Quickstart mode from docker

### DIFF
--- a/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
+++ b/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
@@ -17,6 +17,9 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
   @Value("${server.servlet.context-path:}")
   private String contextPath;
 
+  @Value("${klaw.quickstart.enabled:false}")
+  private boolean quickStartEnabled;
+
   @Override
   public void onAuthenticationSuccess(
       HttpServletRequest request, HttpServletResponse response, Authentication authentication)
@@ -32,6 +35,11 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
     String indexPage = "index";
     String rootPath = "/";
     String providerRoute = "{{ provider }}";
+    String coralTopicsUri = "/coral/topics";
+
+    if (quickStartEnabled) {
+      return coralTopicsUri;
+    }
 
     if (defaultSavedRequest == null) {
       return indexPage;

--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -231,6 +231,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
                 superAdminDefaultUserName,
                 encryptorSecretKey));
       }
+      defaultDataService.handleQuickStartData(handleDbRequests, encryptorSecretKey, infraTeam);
     }
 
     // add props

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -81,6 +81,17 @@ public class KwConstants {
   public static final String GETSCHEMAS_ENABLE = "false";
   public static final String CLUSTERAPI_URL = "http://localhost:9343"; //
   public static final String TENANT_CONFIG = "{}";
+
+  public static final String TENANT_CONFIG_QUICK_START =
+      "{\n"
+          + "  \"tenantModel\" : {\n"
+          + "    \"tenantName\" : \"default\",\n"
+          + "    \"baseSyncEnvironment\" : \"1\",\n"
+          + "    \"orderOfTopicPromotionEnvsList\" : [ \"1\" ],\n"
+          + "    \"requestTopicsEnvironmentsList\" : [ \"1\" ],\n"
+          + "    \"requestSchemaEnvironmentsList\" : [ \"2\" ]\n"
+          + "  }\n"
+          + "}";
   public static final String ADDUSER_ROLES = "USER";
   public static final String ENVS_STANDARDNAMES =
       "DEV,TST,SIT,STG,QAE,ACC,E2E,IOE,DRE,PEE,PRD,PRE,UAT,TEST,PROD";

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -2,7 +2,12 @@ package io.aiven.klaw.service;
 
 import io.aiven.klaw.dao.*;
 import io.aiven.klaw.helpers.KwConstants;
+import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
+import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.KafkaFlavors;
+import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
 import io.aiven.klaw.model.enums.PermissionType;
+import io.aiven.klaw.model.response.EnvParams;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -10,10 +15,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.jasypt.util.text.BasicTextEncryptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class DefaultDataService {
+
+  @Value("${klaw.quickstart.enabled:false}")
+  private boolean quickStartEnabled;
+
+  @Value("${klaw.docker.clusterapi.host:host.docker.internal:9343}")
+  private String dockerClusterApiHost;
+
+  @Value("${klaw.docker.kafka.cluster:host.docker.internal:9092}")
+  private String dockerKafkaHost;
+
+  @Value("${klaw.docker.sr.cluster:host.docker.internal:8081}")
+  private String dockerSRHost;
+
+  @Value("${klaw.quickstart.default.user1:william}")
+  private String quickStartUser1;
+
+  @Value("${klaw.quickstart.default.user2:jennifer}")
+  private String quickStartUser2;
+
+  @Value("${klaw.quickstart.default.pwd:welcome}")
+  private String quickStartUserPwd;
 
   public UserInfo getUser(
       int tenantId,
@@ -214,9 +241,17 @@ public class DefaultDataService {
             "Enable View or retrieve schemas");
     kwPropertiesList.add(kwProperties20);
 
-    KwProperties kwProperties21 =
-        new KwProperties(
-            "klaw.clusterapi.url", tenantId, KwConstants.CLUSTERAPI_URL, "Cluster Api URL");
+    KwProperties kwProperties21;
+
+    if (quickStartEnabled) {
+      kwProperties21 =
+          new KwProperties(
+              "klaw.clusterapi.url", tenantId, dockerClusterApiHost, "Cluster Api URL");
+    } else {
+      kwProperties21 =
+          new KwProperties(
+              "klaw.clusterapi.url", tenantId, KwConstants.CLUSTERAPI_URL, "Cluster Api URL");
+    }
     kwPropertiesList.add(kwProperties21);
 
     KwProperties kwProperties22 =
@@ -430,5 +465,95 @@ public class DefaultDataService {
     productDetails.setVersion(version);
 
     return productDetails;
+  }
+
+  public void handleQuickStartData(
+      HandleDbRequestsJdbc handleDbRequests, String encryptorSecretKey, String infraTeam) {
+    if (quickStartEnabled) {
+      // verify if quick start data already exists tbd
+      List<KwClusters> kwClusters =
+          handleDbRequests.getAllClusters(KafkaClustersType.KAFKA, KwConstants.DEFAULT_TENANT_ID);
+      if (!kwClusters.isEmpty()) {
+        return;
+      }
+
+      handleDbRequests.addNewUser(
+          getUser(
+              KwConstants.DEFAULT_TENANT_ID,
+              quickStartUserPwd,
+              KwConstants.USER_ROLE,
+              handleDbRequests
+                  .getTeamDetailsFromName(infraTeam, KwConstants.DEFAULT_TENANT_ID)
+                  .getTeamId(),
+              "",
+              quickStartUser1,
+              encryptorSecretKey));
+      handleDbRequests.addNewUser(
+          getUser(
+              KwConstants.DEFAULT_TENANT_ID,
+              quickStartUserPwd,
+              KwConstants.USER_ROLE,
+              handleDbRequests
+                  .getTeamDetailsFromName(infraTeam, KwConstants.DEFAULT_TENANT_ID)
+                  .getTeamId(),
+              "",
+              quickStartUser2,
+              encryptorSecretKey));
+      // Add kafka cluster
+      KwClusters kwClusterKafka = new KwClusters();
+      kwClusterKafka.setClusterName("DEV");
+      kwClusterKafka.setKafkaFlavor(KafkaFlavors.APACHE_KAFKA.value);
+      kwClusterKafka.setBootstrapServers(dockerKafkaHost);
+      kwClusterKafka.setProtocol(KafkaSupportedProtocol.PLAINTEXT);
+      kwClusterKafka.setClusterType(KafkaClustersType.KAFKA.value);
+      kwClusterKafka.setTenantId(KwConstants.DEFAULT_TENANT_ID);
+      handleDbRequests.addNewCluster(kwClusterKafka);
+
+      // Add sr cluster
+      KwClusters kwClusterSchemaRegistry = new KwClusters();
+      kwClusterSchemaRegistry.setClusterName("DEV");
+      kwClusterSchemaRegistry.setKafkaFlavor(KafkaFlavors.APACHE_KAFKA.value);
+      kwClusterSchemaRegistry.setBootstrapServers(dockerSRHost);
+      kwClusterSchemaRegistry.setProtocol(KafkaSupportedProtocol.PLAINTEXT);
+      kwClusterSchemaRegistry.setClusterType(KafkaClustersType.SCHEMA_REGISTRY.value);
+      kwClusterSchemaRegistry.setTenantId(KwConstants.DEFAULT_TENANT_ID);
+      handleDbRequests.addNewCluster(kwClusterSchemaRegistry);
+
+      // Add kafka environment
+      kwClusters =
+          handleDbRequests.getAllClusters(KafkaClustersType.KAFKA, KwConstants.DEFAULT_TENANT_ID);
+      Env envKafka = new Env();
+      envKafka.setClusterId(kwClusters.get(0).getClusterId());
+      envKafka.setName("DEV");
+      envKafka.setType(KafkaClustersType.KAFKA.value);
+      EnvParams envParams = new EnvParams();
+      envParams.setDefaultPartitions("1");
+      envParams.setMaxPartitions("1");
+      envParams.setDefaultRepFactor("1");
+      envParams.setMaxRepFactor("1");
+      envParams.setTopicPrefix(null);
+      envParams.setTopicSuffix(null);
+      envKafka.setParams(envParams);
+      envKafka.setTenantId(KwConstants.DEFAULT_TENANT_ID);
+      envKafka.setEnvExists("true");
+      handleDbRequests.addNewEnv(envKafka);
+
+      // Add sr environment
+      List<KwClusters> kwClustersSR =
+          handleDbRequests.getAllClusters(
+              KafkaClustersType.SCHEMA_REGISTRY, KwConstants.DEFAULT_TENANT_ID);
+      Env envSR = new Env();
+      envSR.setClusterId(kwClustersSR.get(0).getClusterId());
+      envSR.setName("DEV");
+      envSR.setType(KafkaClustersType.SCHEMA_REGISTRY.value);
+      EnvParams envParamsSR = new EnvParams();
+      envSR.setParams(envParamsSR);
+      envSR.setTenantId(KwConstants.DEFAULT_TENANT_ID);
+      EnvTag envTag = new EnvTag();
+      envTag.setId(handleDbRequests.getAllEnvs(KwConstants.DEFAULT_TENANT_ID).get(0).getId());
+      envSR.setAssociatedEnv(envTag);
+      envSR.setEnvExists("true");
+      handleDbRequests.addNewEnv(envSR);
+    }
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -10,6 +10,7 @@ import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.EnvParams;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -254,12 +255,23 @@ public class DefaultDataService {
     }
     kwPropertiesList.add(kwProperties21);
 
-    KwProperties kwProperties22 =
-        new KwProperties(
-            "klaw.tenant.config",
-            tenantId,
-            KwConstants.TENANT_CONFIG,
-            "Base sync cluster, order of topic promotion environments, topic request envs");
+    KwProperties kwProperties22;
+    if (quickStartEnabled) {
+      kwProperties22 =
+          new KwProperties(
+              "klaw.tenant.config",
+              tenantId,
+              KwConstants.TENANT_CONFIG_QUICK_START,
+              "Base sync cluster, order of topic promotion environments, topic request envs");
+    } else {
+      kwProperties22 =
+          new KwProperties(
+              "klaw.tenant.config",
+              tenantId,
+              KwConstants.TENANT_CONFIG,
+              "Base sync cluster, order of topic promotion environments, topic request envs");
+    }
+
     kwPropertiesList.add(kwProperties22);
 
     KwProperties kwProperties23 =
@@ -531,8 +543,11 @@ public class DefaultDataService {
       envParams.setMaxPartitions("1");
       envParams.setDefaultRepFactor("1");
       envParams.setMaxRepFactor("1");
-      envParams.setTopicPrefix(null);
-      envParams.setTopicSuffix(null);
+      envParams.setReplicationFactorList(Collections.singletonList("1"));
+      envParams.setPartitionsList(List.of("1", "2"));
+      envParams.setTopicPrefix(Collections.emptyList());
+      envParams.setTopicSuffix(Collections.emptyList());
+      envParams.setTopicRegex(Collections.emptyList());
       envKafka.setParams(envParams);
       envKafka.setTenantId(KwConstants.DEFAULT_TENANT_ID);
       envKafka.setEnvExists("true");

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -513,7 +513,7 @@ public class DefaultDataService {
               encryptorSecretKey));
       // Add kafka cluster
       KwClusters kwClusterKafka = new KwClusters();
-      kwClusterKafka.setClusterName("DEV");
+      kwClusterKafka.setClusterName("STG");
       kwClusterKafka.setKafkaFlavor(KafkaFlavors.APACHE_KAFKA.value);
       kwClusterKafka.setBootstrapServers(dockerKafkaHost);
       kwClusterKafka.setProtocol(KafkaSupportedProtocol.PLAINTEXT);
@@ -523,7 +523,7 @@ public class DefaultDataService {
 
       // Add sr cluster
       KwClusters kwClusterSchemaRegistry = new KwClusters();
-      kwClusterSchemaRegistry.setClusterName("DEV");
+      kwClusterSchemaRegistry.setClusterName("STG");
       kwClusterSchemaRegistry.setKafkaFlavor(KafkaFlavors.APACHE_KAFKA.value);
       kwClusterSchemaRegistry.setBootstrapServers(dockerSRHost);
       kwClusterSchemaRegistry.setProtocol(KafkaSupportedProtocol.PLAINTEXT);
@@ -536,7 +536,7 @@ public class DefaultDataService {
           handleDbRequests.getAllClusters(KafkaClustersType.KAFKA, KwConstants.DEFAULT_TENANT_ID);
       Env envKafka = new Env();
       envKafka.setClusterId(kwClusters.get(0).getClusterId());
-      envKafka.setName("DEV");
+      envKafka.setName("STG");
       envKafka.setType(KafkaClustersType.KAFKA.value);
       EnvParams envParams = new EnvParams();
       envParams.setDefaultPartitions("1");
@@ -559,7 +559,7 @@ public class DefaultDataService {
               KafkaClustersType.SCHEMA_REGISTRY, KwConstants.DEFAULT_TENANT_ID);
       Env envSR = new Env();
       envSR.setClusterId(kwClustersSR.get(0).getClusterId());
-      envSR.setName("DEV");
+      envSR.setName("STG");
       envSR.setType(KafkaClustersType.SCHEMA_REGISTRY.value);
       EnvParams envParamsSR = new EnvParams();
       envSR.setParams(envParamsSR);

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -236,6 +236,16 @@ klaw.shedlock.lockAtLeastFor=PT30M
 klaw.shedlock.lockAtMostFor=PT60M
 klaw.shedlock.tablename=kwshedlock
 
+# Quick start from docker
+klaw.quickstart.enabled=false
+klaw.docker.internal.host=host.docker.internal
+klaw.docker.clusterapi.host=http://${klaw.docker.internal.host}:9343
+klaw.docker.kafka.cluster=${klaw.docker.internal.host}:9092
+klaw.docker.sr.cluster=${klaw.docker.internal.host}:8081
+klaw.quickstart.default.user1=william
+klaw.quickstart.default.user2=jennifer
+klaw.quickstart.default.pwd=welcome
+
 # log file settings
 logging.level.root=info
 logging.level.org.hibernate.SQL=off

--- a/core/src/test/resources/test-application-rdbms-ad-authorization.properties
+++ b/core/src/test/resources/test-application-rdbms-ad-authorization.properties
@@ -155,6 +155,8 @@ server.compression.min-response-size=1024
 #maximum tenants can be created
 klaw.max.tenants=200
 
+klaw.quickstart.enabled=false
+
 # log file settings
 #logging.level.root=debug
 logging.level.org.hibernate.SQL=off

--- a/core/src/test/resources/test-application-rdbms-sso-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-sso-ad.properties
@@ -155,6 +155,8 @@ server.compression.min-response-size=1024
 #maximum tenants can be created
 klaw.max.tenants=200
 
+klaw.quickstart.enabled=false
+
 # log file settings
 #logging.level.root=debug
 logging.level.org.hibernate.SQL=off

--- a/core/src/test/resources/test-application-rdbms-windows-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-windows-ad.properties
@@ -189,6 +189,8 @@ management.endpoints.web.exposure.exclude=
 management.health.ldap.enabled=false
 management.endpoint.shutdown.enabled=false
 
+klaw.quickstart.enabled=false
+
 # log file settings
 logging.level.root=info
 logging.level.org.hibernate.SQL=off

--- a/core/src/test/resources/test-application-rdbms.properties
+++ b/core/src/test/resources/test-application-rdbms.properties
@@ -146,6 +146,8 @@ server.compression.min-response-size=1024
 #maximum tenants can be created
 klaw.max.tenants=200
 
+klaw.quickstart.enabled=false
+
 # log file settings
 #logging.level.root=debug
 logging.level.org.hibernate.SQL=off

--- a/core/src/test/resources/test-application-rdbms1.properties
+++ b/core/src/test/resources/test-application-rdbms1.properties
@@ -146,6 +146,8 @@ server.compression.min-response-size=1024
 #maximum tenants can be created
 klaw.max.tenants=200
 
+klaw.quickstart.enabled=false
+
 # log file settings
 #logging.level.root=debug
 logging.level.org.hibernate.SQL=off


### PR DESCRIPTION
About this change - What it does

- Quick start mode in Klaw from docker
 - Few properties in core module for quick start 
 - Adds 1 kafka cluster
 - Adds 1 SR cluster
 - Adds 2 users
 - Redirects users to coral ui
 - This mode is applicable from docker for now and coral assets are built into it

Resolves: #xxxxx
Why this way
