### PR TITLE
feat(coral): Add promotion banner to connector promotion

### DIFF
--- a/coral/src/app/features/connectors/details/components/ConnectorPromotionBanner.test.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorPromotionBanner.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, screen } from "@testing-library/react";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import {
+  ConnectorPromotionBanner,
+  TemporaryConnectorPromotionDetails,
+} from "src/app/features/connectors/details/components/ConnectorPromotionBanner";
+
+const promotionDetailForPromote: TemporaryConnectorPromotionDetails = {
+  status: "SUCCESS",
+  targetEnv: "TST",
+  sourceEnv: "DEV",
+  targetEnvId: "2",
+};
+
+const promoteProps = {
+  connectorPromotionDetails: promotionDetailForPromote,
+  hasOpenConnectorRequest: false,
+  hasOpenClaimRequest: false,
+  connectorName: "my-nice-connector-name",
+};
+
+const promotionDetailForSeeOpenRequest: TemporaryConnectorPromotionDetails = {
+  status: "SUCCESS",
+  targetEnv: "TST",
+  sourceEnv: "DEV",
+  targetEnvId: "2",
+};
+
+const seeOpenRequestProps = {
+  connectorPromotionDetails: promotionDetailForSeeOpenRequest,
+  hasOpenConnectorRequest: true,
+  hasOpenClaimRequest: false,
+  connectorName: "my-nice-connector-name",
+};
+
+const seeOpenClaimRequestProps = {
+  connectorPromotionDetails: promotionDetailForSeeOpenRequest,
+  hasOpenConnectorRequest: false,
+  hasOpenClaimRequest: true,
+  connectorName: "my-nice-connector-name",
+};
+
+const promotionDetailForSeeOpenPromotionRequest: TemporaryConnectorPromotionDetails =
+  {
+    status: "REQUEST_OPEN",
+    targetEnv: "TST",
+    sourceEnv: "DEV",
+    targetEnvId: "2",
+  };
+
+const seeOpenPromotionRequestProps = {
+  connectorPromotionDetails: promotionDetailForSeeOpenPromotionRequest,
+  hasOpenConnectorRequest: false,
+  hasOpenClaimRequest: false,
+  connectorName: "my-nice-connector-name",
+};
+
+const promotionDetailForNoPromotion: TemporaryConnectorPromotionDetails = {
+  status: "NO_PROMOTION",
+};
+
+const nullProps = {
+  connectorPromotionDetails: promotionDetailForNoPromotion,
+  hasOpenConnectorRequest: false,
+  hasOpenClaimRequest: false,
+  connectorName: "my-nice-connector-name",
+};
+
+describe("ConnectorPromotionBanner", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    cleanup();
+  });
+
+  it("renders correct banner (promote connector)", () => {
+    customRender(<ConnectorPromotionBanner {...promoteProps} />, {
+      browserRouter: true,
+    });
+
+    const link = screen.getByRole("link", {
+      name: "Promote",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      `/connector/${promoteProps.connectorName}/request-promotion?sourceEnv=${promoteProps.connectorPromotionDetails.sourceEnv}&targetEnv=${promoteProps.connectorPromotionDetails.targetEnvId}`
+    );
+  });
+
+  it("renders correct banner (see open request)", () => {
+    customRender(<ConnectorPromotionBanner {...seeOpenRequestProps} />, {
+      browserRouter: true,
+    });
+
+    const link = screen.getByRole("link", {
+      name: "View request",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      `/requests/connectors?search=${promoteProps.connectorName}&requestType=ALL&status=CREATED&page=1`
+    );
+  });
+
+  it("renders correct banner (see open claim request)", () => {
+    customRender(<ConnectorPromotionBanner {...seeOpenClaimRequestProps} />, {
+      browserRouter: true,
+    });
+
+    const link = screen.getByRole("link", {
+      name: "View request",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      `/approvals/connectors?search=${promoteProps.connectorName}&requestType=CLAIM&status=CREATED&page=1`
+    );
+  });
+
+  it("renders correct banner (see open promotion request)", () => {
+    customRender(
+      <ConnectorPromotionBanner {...seeOpenPromotionRequestProps} />,
+      {
+        browserRouter: true,
+      }
+    );
+
+    const link = screen.getByRole("link", {
+      name: "View request",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      `/requests/connectors?search=${promoteProps.connectorName}&requestType=PROMOTE&status=CREATED&page=1`
+    );
+  });
+
+  it("renders nothing if status === 'NO_PROMOTION'", () => {
+    customRender(<ConnectorPromotionBanner {...nullProps} />, {
+      browserRouter: true,
+    });
+
+    const wrapper = screen.getByTestId("connector-promotion-banner");
+
+    expect(wrapper).toBeEmptyDOMElement();
+  });
+});

--- a/coral/src/app/features/connectors/details/components/ConnectorPromotionBanner.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorPromotionBanner.tsx
@@ -1,0 +1,59 @@
+import { PromotionBanner } from "src/app/features/topics/details/components/PromotionBanner";
+import { InternalLinkButton } from "src/app/components/InternalLinkButton";
+
+//@TODO replace when api is ready
+// eslint-disable-next-line import/exports-last
+export type TemporaryConnectorPromotionDetails = {
+  status:
+    | "SUCCESS"
+    | "NOT_AUTHORIZED"
+    | "REQUEST_OPEN"
+    | "NO_PROMOTION"
+    | "FAILURE";
+  sourceEnv?: string;
+  targetEnv?: string;
+  targetEnvId?: string;
+  error?: string;
+  connectorName?: string;
+  sourceConnectorConfig?: string;
+};
+interface ConnectorPromotionBannerProps {
+  connectorPromotionDetails: TemporaryConnectorPromotionDetails;
+  /** In case there is an open request for this connector
+   * it can't be promoted, and we want to show that
+   * information to the user.
+   */
+  hasOpenConnectorRequest: boolean;
+  hasOpenClaimRequest: boolean;
+  connectorName: string;
+}
+
+const ConnectorPromotionBanner = ({
+  connectorPromotionDetails,
+  hasOpenClaimRequest,
+  hasOpenConnectorRequest,
+  connectorName,
+}: ConnectorPromotionBannerProps) => {
+  return (
+    <div data-testid={"connector-promotion-banner"}>
+      <PromotionBanner
+        entityName={connectorName}
+        promotionDetails={connectorPromotionDetails}
+        hasOpenRequest={hasOpenConnectorRequest}
+        hasOpenClaimRequest={hasOpenClaimRequest}
+        type={"connector"}
+        promoteElement={
+          <InternalLinkButton
+            to={`/connector/${connectorName}/request-promotion?sourceEnv=${connectorPromotionDetails.sourceEnv}&targetEnv=${connectorPromotionDetails.targetEnvId}`}
+          >
+            Promote
+          </InternalLinkButton>
+        }
+        hasError={false}
+        errorMessage={""}
+      />
+    </div>
+  );
+};
+
+export { ConnectorPromotionBanner };

--- a/coral/src/app/features/connectors/details/overview/ConnectorOverview.test.tsx
+++ b/coral/src/app/features/connectors/details/overview/ConnectorOverview.test.tsx
@@ -1,68 +1,209 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { ConnectorOverview } from "src/app/features/connectors/details/overview/ConnectorOverview";
+import { ConnectorOverview as ConnectorOverviewType } from "src/domain/connector";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { within } from "@testing-library/react/pure";
 
 const mockedUseConnectorDetails = jest.fn();
 jest.mock("src/app/features/connectors/details/ConnectorDetails", () => ({
   useConnectorDetails: () => mockedUseConnectorDetails(),
 }));
 
-const testConnectorDetails = {
+const connectorInfoPromotion: ConnectorOverviewType["connectorInfo"] = {
+  connectorStatus: "",
+  hasOpenClaimRequest: false,
+  hasOpenRequest: false,
+  highestEnv: false,
+  connectorOwner: true,
+  connectorId: 1003,
+  connectorName: "release240",
+  runningTasks: 0,
+  failedTasks: 0,
   environmentId: "4",
-  connectorOverview: {
-    topicHistoryList: [],
-    promotionDetails: {
-      sourceEnv: "4",
-      connectorName: "release240",
-      targetEnvId: "10",
-      sourceConnectorConfig:
-        '{\n  "connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector",\n  "tasks.max" : "1",\n  "name" : "release240",\n  "topic" : "testtopic",\n  "topics.regex" : "*"\n}',
-      targetEnv: "TST",
-      status: "success",
-    },
-    connectorExists: true,
-    availableEnvironments: [
-      {
-        id: "4",
-        name: "DEV",
-      },
-    ],
-    topicIdForDocumentation: 1003,
-    connectorInfo: {
-      connectorId: 1003,
-      connectorName: "release240",
-      runningTasks: 0,
-      failedTasks: 0,
-      environmentId: "4",
-      teamName: "Ospo",
-      teamId: 0,
-      showEditConnector: true,
-      showDeleteConnector: true,
-      connectorDeletable: true,
-      connectorConfig:
-        '{\n  "connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector",\n  "tasks.max" : "1",\n  "name" : "release240",\n  "topic" : "testtopic",\n  "topics.regex" : "*"\n}',
-      environmentName: "DEV",
-    },
+  teamName: "Ospo",
+  teamId: 0,
+  showEditConnector: true,
+  showDeleteConnector: true,
+  connectorDeletable: true,
+  connectorConfig:
+    '{\n  "connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector",\n  "tasks.max" : "1",\n  "name" : "release240",\n  "topic" : "testtopic",\n  "topics.regex" : "*"\n}',
+  environmentName: "DEV",
+};
+
+const connectorInfoNoPromotionOpenRequest: ConnectorOverviewType["connectorInfo"] =
+  {
+    ...connectorInfoPromotion,
+    hasOpenRequest: true,
+  };
+
+const connectorInfoNotConnectorOwner: ConnectorOverviewType["connectorInfo"] = {
+  ...connectorInfoPromotion,
+  connectorOwner: false,
+};
+
+const testConnectorOverview: ConnectorOverviewType = {
+  connectorHistoryList: [],
+  promotionDetails: {
+    sourceEnv: "4",
+    connectorName: "release240",
+    targetEnvId: "10",
+    sourceConnectorConfig:
+      '{\n  "connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector",\n  "tasks.max" : "1",\n  "name" : "release240",\n  "topic" : "testtopic",\n  "topics.regex" : "*"\n}',
+    targetEnv: "TST",
+    status: "SUCCESS",
   },
+  connectorExists: true,
+  availableEnvironments: [
+    {
+      id: "4",
+      name: "DEV",
+    },
+  ],
+  connectorIdForDocumentation: 1003,
+  connectorInfo: connectorInfoNotConnectorOwner,
 };
 
 describe("ConnectorOverview", () => {
-  beforeAll(() => {
-    mockedUseConnectorDetails.mockReturnValue(testConnectorDetails);
-    render(<ConnectorOverview />);
+  describe("renders right view for user that is not connector owner", () => {
+    beforeAll(() => {
+      mockedUseConnectorDetails.mockReturnValue({
+        environmentId: "4",
+        connectorOverview: {
+          ...testConnectorOverview,
+          connectorInfo: connectorInfoNotConnectorOwner,
+        },
+      });
+      customRender(<ConnectorOverview />, { memoryRouter: true });
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("shows the correct header", () => {
+      const header = screen.getByText("Connector configuration");
+
+      expect(header).toBeVisible();
+    });
+
+    it("shows an editor with preview of the connector info", () => {
+      const previewEditor = screen.getByTestId("connector-editor");
+
+      expect(previewEditor).toBeVisible();
+      expect(previewEditor).toHaveTextContent(
+        `"connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector"`
+      );
+    });
   });
 
-  it("shows the correct header", () => {
-    const header = screen.getByText("Connector configuration");
+  describe("renders right view for connector owner", () => {
+    describe("shows all necessary elements", () => {
+      beforeAll(() => {
+        mockedUseConnectorDetails.mockReturnValue({
+          environmentId: "4",
+          connectorOverview: {
+            ...testConnectorOverview,
+          },
+        });
+        customRender(<ConnectorOverview />, { memoryRouter: true });
+      });
 
-    expect(header).toBeVisible();
-  });
+      afterAll(() => {
+        cleanup();
+        jest.clearAllMocks();
+      });
 
-  it("shows an editor with preview of the connector info", () => {
-    const previewEditor = screen.getByTestId("topic-connector");
+      it("shows the correct header", () => {
+        const header = screen.getByText("Connector configuration");
 
-    expect(previewEditor).toBeVisible();
-    expect(previewEditor).toHaveTextContent(
-      `"connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector"`
-    );
+        expect(header).toBeVisible();
+      });
+
+      it("shows an editor with preview of the connector info", () => {
+        const previewEditor = screen.getByTestId("connector-editor");
+
+        expect(previewEditor).toBeVisible();
+        expect(previewEditor).toHaveTextContent(
+          `"connector.class" : "io.confluent.connect.storage.tools.SchemaSourceConnector"`
+        );
+      });
+    });
+
+    describe("shows when promotion is possible", () => {
+      beforeAll(() => {
+        mockedUseConnectorDetails.mockReturnValue({
+          environmentId: "4",
+          connectorOverview: {
+            ...testConnectorOverview,
+            connectorInfo: connectorInfoPromotion,
+          },
+        });
+        customRender(<ConnectorOverview />, { memoryRouter: true });
+      });
+
+      afterAll(() => {
+        cleanup();
+        jest.clearAllMocks();
+      });
+
+      it("shows a banner with information that promotion is possible", () => {
+        const banner = screen.getByTestId("connector-promotion-banner");
+
+        expect(banner).toBeVisible();
+        expect(banner).toHaveTextContent(
+          `This connector has not yet been promoted to the ${testConnectorOverview.promotionDetails.targetEnv} environment`
+        );
+      });
+
+      it("shows a link to the promotion form", () => {
+        const banner = screen.getByTestId("connector-promotion-banner");
+        const link = within(banner).getByRole("link", { name: "Promote" });
+
+        expect(link).toBeVisible();
+        expect(link).toHaveAttribute(
+          "href",
+          `/connector/${connectorInfoPromotion.connectorName}/request-promotion?sourceEnv=${testConnectorOverview.promotionDetails.sourceEnv}&targetEnv=${testConnectorOverview.promotionDetails.targetEnvId}`
+        );
+      });
+    });
+
+    describe("shows when promotion is not possible due to a pending request", () => {
+      beforeAll(() => {
+        mockedUseConnectorDetails.mockReturnValue({
+          environmentId: "4",
+          connectorOverview: {
+            ...testConnectorOverview,
+            connectorInfo: connectorInfoNoPromotionOpenRequest,
+          },
+        });
+        customRender(<ConnectorOverview />, { memoryRouter: true });
+      });
+
+      afterAll(() => {
+        cleanup();
+        jest.clearAllMocks();
+      });
+
+      it("shows a banner with information that promotion is possible", () => {
+        const banner = screen.getByTestId("connector-promotion-banner");
+
+        expect(banner).toBeVisible();
+        expect(banner).toHaveTextContent(
+          `You cannot promote the connector at this time. ${connectorInfoNoPromotionOpenRequest.connectorName} has a pending request`
+        );
+      });
+
+      it("shows a link to the pending request", () => {
+        const banner = screen.getByTestId("connector-promotion-banner");
+        const link = within(banner).getByRole("link", { name: "View request" });
+
+        expect(link).toBeVisible();
+        expect(link).toHaveAttribute(
+          "href",
+          `/requests/connectors?search=${connectorInfoNoPromotionOpenRequest.connectorName}&requestType=ALL&status=CREATED&page=1`
+        );
+      });
+    });
   });
 });

--- a/coral/src/app/features/connectors/details/overview/ConnectorOverview.tsx
+++ b/coral/src/app/features/connectors/details/overview/ConnectorOverview.tsx
@@ -1,17 +1,32 @@
 import { Box, PageHeader } from "@aivenio/aquarium";
 import MonacoEditor from "@monaco-editor/react";
 import { useConnectorDetails } from "src/app/features/connectors/details/ConnectorDetails";
+import { ConnectorPromotionBanner } from "src/app/features/connectors/details/components/ConnectorPromotionBanner";
 
 const ConnectorOverview = () => {
   const { connectorOverview } = useConnectorDetails();
+  const { promotionDetails } = connectorOverview;
+  const { hasOpenClaimRequest, hasOpenRequest, connectorName, connectorOwner } =
+    connectorOverview.connectorInfo;
 
   return (
     <>
+      {connectorOwner && (
+        <Box paddingTop={"l1"} paddingBottom={"l2"}>
+          <ConnectorPromotionBanner
+            connectorPromotionDetails={promotionDetails}
+            hasOpenConnectorRequest={hasOpenRequest}
+            hasOpenClaimRequest={hasOpenClaimRequest}
+            connectorName={connectorName}
+          />
+        </Box>
+      )}
+
       <PageHeader title={"Connector configuration"} />
 
       <Box borderColor={"grey-20"} borderWidth={"1px"}>
         <MonacoEditor
-          data-testid="topic-connector"
+          data-testid="connector-editor"
           height="300px"
           language="json"
           theme={"light"}

--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -10,7 +10,7 @@ const promotionDetails: KlawApiModel<"PromotionStatus"> = {
   targetEnvId: "2",
 };
 const testTopicName = "my-test-topic";
-
+const testConnectorName = "my-connector";
 describe("PromotionBanner", () => {
   describe("does not show a promotion banner at all dependent on promotion details", () => {
     afterEach(cleanup);
@@ -200,6 +200,44 @@ describe("PromotionBanner", () => {
     });
   });
 
+  describe("handles banner for entity with an open request (type connector)", () => {
+    beforeAll(() => {
+      customRender(
+        <PromotionBanner
+          entityName={testConnectorName}
+          promotionDetails={promotionDetails}
+          type={"connector"}
+          promoteElement={<></>}
+          hasOpenClaimRequest={false}
+          hasOpenRequest={true}
+          hasError={false}
+          errorMessage={""}
+        />,
+        { browserRouter: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `You cannot promote the connector at this time. ${testConnectorName} has a pending request.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByRole("link", { name: "View request" });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/requests/connectors?search=my-connector&requestType=ALL&status=CREATED&page=1"
+      );
+    });
+  });
+
   describe("handles banner for entity with an open claim request (type schema)", () => {
     beforeAll(() => {
       customRender(
@@ -272,6 +310,44 @@ describe("PromotionBanner", () => {
       expect(link).toHaveAttribute(
         "href",
         "/approvals/topics?search=my-test-topic&requestType=CLAIM&status=CREATED&page=1"
+      );
+    });
+  });
+
+  describe("handles banner for entity with an open claim request (type connector)", () => {
+    beforeAll(() => {
+      customRender(
+        <PromotionBanner
+          entityName={testConnectorName}
+          promotionDetails={promotionDetails}
+          type={"connector"}
+          promoteElement={<></>}
+          hasOpenClaimRequest={true}
+          hasOpenRequest={false}
+          hasError={false}
+          errorMessage={""}
+        />,
+        { browserRouter: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `You cannot promote the connector at this time. A claim request for ${testConnectorName} is in progress.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByRole("link", { name: "View request" });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/approvals/connectors?search=my-connector&requestType=CLAIM&status=CREATED&page=1"
       );
     });
   });
@@ -354,6 +430,46 @@ describe("PromotionBanner", () => {
     });
   });
 
+  describe("handles banner for entity with an open promotion request (type topic)", () => {
+    beforeAll(() => {
+      customRender(
+        <PromotionBanner
+          entityName={testConnectorName}
+          promotionDetails={{ ...promotionDetails, status: "REQUEST_OPEN" }}
+          type={"connector"}
+          promoteElement={<></>}
+          hasOpenRequest={false}
+          hasOpenClaimRequest={false}
+          hasError={false}
+          errorMessage={""}
+        />,
+        { browserRouter: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about the open request", () => {
+      const information = screen.getByText(
+        `You cannot promote the connector at this time. An promotion request for ${testConnectorName} is already in progress.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("shows a link to open requests", () => {
+      const link = screen.getByRole("link", {
+        name: "View request",
+      });
+
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute(
+        "href",
+        "/requests/connectors?search=my-connector&requestType=PROMOTE&status=CREATED&page=1"
+      );
+    });
+  });
+
   describe("handles banner for entity that can be promoted (type schema)", () => {
     const promoteElement = <div data-testid={"another-test-promote-element"} />;
     beforeAll(() => {
@@ -426,7 +542,42 @@ describe("PromotionBanner", () => {
     });
   });
 
-  describe("handles error for promotion (type schema and topic)", () => {
+  describe("handles banner for entity that can be promoted (type connector)", () => {
+    const promoteElement = <div data-testid={"test-promote-element"} />;
+    beforeAll(() => {
+      customRender(
+        <PromotionBanner
+          entityName={testConnectorName}
+          promotionDetails={promotionDetails}
+          type={"connector"}
+          promoteElement={promoteElement}
+          hasOpenRequest={false}
+          hasOpenClaimRequest={false}
+          hasError={false}
+          errorMessage={""}
+        />,
+        { browserRouter: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows information about possible promotion", () => {
+      const information = screen.getByText(
+        `This connector has not yet been promoted to the ${promotionDetails.targetEnv} environment.`
+      );
+
+      expect(information).toBeVisible();
+    });
+
+    it("renders a given component as element handling the promotion", () => {
+      const promotionElement = screen.getByTestId("test-promote-element");
+
+      expect(promotionElement).toBeVisible();
+    });
+  });
+
+  describe("handles error for promotion (type schema, topic and connector)", () => {
     const originalConsoleError = console.error;
 
     beforeEach(() => {

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -5,7 +5,7 @@ import illustration from "src/app/images/topic-details-banner-Illustration.svg";
 import { PromotionStatus } from "src/domain/topic";
 
 type RequestTypeLocal = "CLAIM" | "ALL" | "PROMOTE";
-type EntityTypeLocal = "schema" | "topic";
+type EntityTypeLocal = "schema" | "topic" | "connector";
 
 interface PromotionBannerProps {
   // `entityName` is only optional on
@@ -57,7 +57,7 @@ function createText({
   entityName,
   requestType,
 }: {
-  type: "schema" | "topic";
+  type: EntityTypeLocal;
   entityName: string;
   requestType: RequestTypeLocal;
 }): string {


### PR DESCRIPTION
# About this change - What it does

Adds promotion banner to Connector overview. 

NOTE: There is an open PR for adding the actual form that the banner links to for promotion ( #1723 ) so following the link at the moment will show a 404. 

## Screenshots

#### View for user that is _not_ connector owner

<img width="1306" alt="NOT-owner-can-be-promoted" src="https://github.com/Aiven-Open/klaw/assets/943800/779d85a1-37cc-4ef7-9a6f-d267d9675148">

#### View for connector owner, promotion is possible
<img width="1303" alt="owner-can-be-promoted" src="https://github.com/Aiven-Open/klaw/assets/943800/e9ed2801-7045-4ce9-b087-4d9713ba2e2b">

#### View for connector owner, open claim request prevents promotion atm

<img width="1299" alt="owner-open-claim-request" src="https://github.com/Aiven-Open/klaw/assets/943800/bca289ba-e92a-494e-9d5e-c5f4ab96bf86">


#### View for connector owner, open request prevents promotion atm

<img width="1441" alt="owner-open-request" src="https://github.com/Aiven-Open/klaw/assets/943800/2d19ae3a-583e-4133-baaf-1ff01805a34f">



Relates to: #1639 

