### PR TITLE
refactor(coral): Update monaco editor mock

### DIFF
--- a/coral/test-setup/mock-monaco-editor.tsx
+++ b/coral/test-setup/mock-monaco-editor.tsx
@@ -1,14 +1,12 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import React from "react"; // eslint-disable-line @typescript-eslint/no-unused-vars
-
 // GitHub issue to investigate a more versatile testing approach:
 // 🐙 https://github.com/aiven/klaw/issues/475
 jest.mock("@monaco-editor/react", () => {
   return {
     __esModule: true,
     ...jest.requireActual("@monaco-editor/react"),
-    default: jest.fn((props) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    default: (props) => {
       return (
         <textarea
           data-testid={props["data-testid"] ?? "mocked-monaco-editor"}
@@ -16,6 +14,6 @@ jest.mock("@monaco-editor/react", () => {
           onChange={(event) => props.onChange(event.target.value)}
         ></textarea>
       );
-    }),
+    },
   };
 });


### PR DESCRIPTION
# About this change - What it does

- update mock for monaco editor to not use `jest.fn()`
Background: There's no need for using jest.fn() as a mock. Also, when using `jest.resetAllMocks` or `jest.restoreAllMocks` in a test, this will effect this mock and lead to unexpected behaviour, since the mock is not explicitly added in the test suite. 

Resolves: #475
(it does not really resolve this issue, but relate to it, and we won't investigate a more sophisticated way to mock the editor for now)


