### PR TITLE
fix(coral): Fix proper loading state for `SubmitButton` in `Form`

### DIFF
--- a/coral/src/app/components/Form.test.tsx
+++ b/coral/src/app/components/Form.test.tsx
@@ -14,7 +14,10 @@ import {
   Textarea,
   TextInput,
 } from "src/app/components/Form";
-import { renderForm } from "src/services/test-utils/render-form";
+import {
+  renderForm,
+  renderFormWithState,
+} from "src/services/test-utils/render-form";
 import { z } from "zod";
 
 describe("Form", () => {
@@ -94,6 +97,76 @@ describe("Form", () => {
       const submitButton = screen.getByRole("button", { name: "Submit" });
 
       expect(submitButton).toBeEnabled();
+    });
+  });
+
+  describe("<Form>, loading state", () => {
+    const schema = z.object({
+      formFieldsCustomName: z.string().min(3, "error"),
+    });
+    type Schema = z.infer<typeof schema>;
+
+    afterEach(cleanup);
+
+    it("shows disabled Submit button with loading animation while form is submitting", async () => {
+      renderFormWithState(
+        <TextInput<Schema> name="formFieldsCustomName" labelText="TextInput" />,
+        { schema, onSubmit, onError, isLoading: false }
+      );
+
+      const button = screen.getByRole("button", { name: "Submit" });
+
+      //not awaited on purpose so we're able to catch the in-between state
+      user.click(button);
+
+      await waitFor(() => expect(button).toBeDisabled());
+    });
+
+    it("shows enabled Submit button if isLoading is false", () => {
+      renderFormWithState(
+        <TextInput<Schema> name="formFieldsCustomName" labelText="TextInput" />,
+        { schema, onSubmit, onError, isLoading: false }
+      );
+
+      const button = screen.getByRole("button", { name: "Submit" });
+      expect(button).toBeEnabled();
+    });
+
+    it("calls onSubmit() after submit if isLoading is false", async () => {
+      renderFormWithState(
+        <TextInput<Schema> name="formFieldsCustomName" labelText="TextInput" />,
+        { schema, onSubmit, onError, isLoading: false }
+      );
+
+      await user.type(screen.getByLabelText("TextInput"), "abc");
+      await submit();
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { formFieldsCustomName: "abc" },
+          expect.anything()
+        )
+      );
+    });
+
+    it("shows disabled Submit button with loading animation if form is submitting", async () => {
+      renderFormWithState(
+        <TextInput<Schema> name="formFieldsCustomName" labelText="TextInput" />,
+        { schema, onSubmit, onError, isLoading: true }
+      );
+
+      const button = screen.getByRole("button", { name: "Submit" });
+      expect(button).toBeDisabled();
+    });
+
+    it("does not call onSubmit() after submit if isLoading is true", async () => {
+      renderFormWithState(
+        <TextInput<Schema> name="formFieldsCustomName" labelText="TextInput" />,
+        { schema, onSubmit, onError, isLoading: true }
+      );
+
+      await user.type(screen.getByLabelText("TextInput"), "abc");
+      await submit();
+      await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
     });
   });
 

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -448,12 +448,11 @@ NativeSelect.Skeleton = BaseNativeSelect.Skeleton;
 
 type ButtonProps = React.ComponentProps<typeof Button.Primary>;
 function _SubmitButton<T extends FieldValues>({
-  formContext: {
-    formState: { isSubmitting },
-  },
+  formContext: { formState },
   ...props
 }: ButtonProps & FormRegisterProps<T>) {
-  return <Button.Primary {...props} loading={isSubmitting} type="submit" />;
+  const loadingProp = props.loading || formState.isSubmitting;
+  return <Button.Primary {...props} loading={loadingProp} type="submit" />;
 }
 
 const SubmitButtonMemo = memo(
@@ -464,6 +463,11 @@ const SubmitButtonMemo = memo(
   }
 ) as typeof _SubmitButton;
 
+/*** Pass `loading` property to button when
+ * onSubmitHandler does not
+ * pass a Promise, e.g. when using
+ * `mutate` from react-query
+ */
 // eslint-disable-next-line import/exports-last,import/group-exports
 export const SubmitButton = <T extends FieldValues>(
   props: ButtonProps

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -463,10 +463,12 @@ const SubmitButtonMemo = memo(
   }
 ) as typeof _SubmitButton;
 
-/*** Pass `loading` property to button when
- * onSubmitHandler does not
- * pass a Promise, e.g. when using
- * `mutate` from react-query
+/*** Loading state can rely on `isSubmitting` from
+ * form state, but only when `onSubmit` returns a Promise
+ * and that promise has a catch which calls Promise.reject().
+ * see https://github.com/Aiven-Open/klaw/issues/1439#issuecomment-1699202614
+ * If this is not the case (e.g. when using `mutate` from react-query)
+ * we can pass a `loading` prop to get the loading state
  */
 // eslint-disable-next-line import/exports-last,import/group-exports
 export const SubmitButton = <T extends FieldValues>(

--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -448,10 +448,12 @@ NativeSelect.Skeleton = BaseNativeSelect.Skeleton;
 
 type ButtonProps = React.ComponentProps<typeof Button.Primary>;
 function _SubmitButton<T extends FieldValues>({
-  formContext: { formState },
+  formContext: {
+    formState: { isSubmitting },
+  },
   ...props
 }: ButtonProps & FormRegisterProps<T>) {
-  const loadingProp = props.loading || formState.isSubmitting;
+  const loadingProp = props.loading || isSubmitting;
   return <Button.Primary {...props} loading={loadingProp} type="submit" />;
 }
 

--- a/coral/src/app/components/__snapshots__/Form.test.tsx.snap
+++ b/coral/src/app/components/__snapshots__/Form.test.tsx.snap
@@ -9,8 +9,8 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
     >
       <label
         class="w-full"
-        for="input-1198"
-        id="input-1198-label"
+        for="input-1226"
+        id="input-1226-label"
       >
         <span
           class="block mb-2"
@@ -26,7 +26,7 @@ exports[`Form <PasswordInput> should render <PasswordInput> 1`] = `
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
-            id="input-1198"
+            id="input-1226"
             name="password"
             type="password"
           />
@@ -56,8 +56,8 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
     >
       <label
         class="w-full"
-        for="input-27"
-        id="input-27-label"
+        for="input-55"
+        id="input-55-label"
       >
         <span
           class="block mb-2"
@@ -73,7 +73,7 @@ exports[`Form <TextInput> should render <TextInput> 1`] = `
         >
           <input
             class="block w-full rounded-sm disabled:cursor-not-allowed disabled:border-grey-20 disabled:bg-grey-5 typography-small text-grey-70 disabled:text-grey-40 placeholder:text-grey-40 focus:outline-none px-3 py-3 border border-grey-20 hover:border-grey-50 focus:border-info-70"
-            id="input-27"
+            id="input-55"
             name="formFieldsCustomName"
             type="text"
           />

--- a/coral/src/services/test-utils/render-form.tsx
+++ b/coral/src/services/test-utils/render-form.tsx
@@ -3,12 +3,14 @@ import React from "react";
 import type { DeepPartial, FieldValues } from "react-hook-form";
 import {
   Form,
+  SubmitButton,
   SubmitErrorHandler,
   SubmitHandler,
   useForm,
 } from "src/app/components/Form";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { ZodSchema } from "zod";
+import { render } from "@testing-library/react";
 
 type WrapperProps<T extends FieldValues> = {
   schema: ZodSchema;
@@ -32,6 +34,7 @@ const Wrapper = <T extends FieldValues>({
   );
 };
 
+// eslint-disable-next-line import/group-exports
 export const renderForm = <T extends FieldValues>(
   children: React.ReactNode,
   {
@@ -57,5 +60,37 @@ export const renderForm = <T extends FieldValues>(
       <Button type="submit" title="Submit" />
     </Wrapper>,
     { queryClient: true }
+  );
+};
+
+// eslint-disable-next-line import/group-exports
+export const renderFormWithState = <T extends FieldValues>(
+  children: React.ReactNode,
+  {
+    isLoading,
+    schema,
+    defaultValues,
+    onSubmit,
+    onError,
+  }: {
+    isLoading: boolean;
+    schema: ZodSchema;
+    defaultValues?: DeepPartial<T>;
+    onSubmit: SubmitHandler<T>;
+    onError: SubmitErrorHandler<T>;
+  }
+) => {
+  return render(
+    <Wrapper<T>
+      schema={schema}
+      defaultValues={defaultValues}
+      onSubmit={onSubmit}
+      onError={onError}
+    >
+      {children}
+      <SubmitButton title="Submit" loading={isLoading}>
+        Submit
+      </SubmitButton>
+    </Wrapper>
   );
 };


### PR DESCRIPTION
# About this change - What it does

react-hook-forms expects the `onSubmitHandler` to return a Promise to be able to show `formState.isSubmitting` properly. We're using `mutate` from react-query, so this does not work. 

This PR updates the `SubmitButton` in `Form` to:

- if a property `loading` is passed, this property will be used to get a loading state on the button, otherwise it will take the state from `isSubmitting`. 

This way, we can pass `isLoading` from `mutate` to `SubmitButton` if needed but are still able to rely on `isSubmitting` in cases we don't use react-query.

## Recording

This shows the `TopicRequest` form with passing `loading` in `SubmitButton`. 

https://github.com/Aiven-Open/klaw/assets/943800/0cac5159-e553-4d20-8010-9359fcea0ab1






Resolves: #1439

