### PR TITLE
fix(coral): Use correct path for paginated envs endpoints

### DIFF
--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -69,7 +69,7 @@ const getPaginatedEnvironmentsForSchema = async (
 
   const apiResponse = await api.get<
     KlawApiResponse<"getSchemaRegEnvsPaginated">
-  >(API_PATHS.getKafkaEnvsPaginated, new URLSearchParams(queryParams));
+  >(API_PATHS.getSchemaRegEnvsPaginated, new URLSearchParams(queryParams));
 
   return transformPaginatedEnvironmentApiResponse(apiResponse);
 };
@@ -100,7 +100,7 @@ const getPaginatedEnvironmentsForConnector = async (
 
   const apiResponse = await api.get<
     KlawApiResponse<"getKafkaConnectEnvsPaginated">
-  >(API_PATHS.getKafkaEnvsPaginated, new URLSearchParams(queryParams));
+  >(API_PATHS.getKafkaConnectEnvsPaginated, new URLSearchParams(queryParams));
 
   return transformPaginatedEnvironmentApiResponse(apiResponse);
 };


### PR DESCRIPTION
# About this change - What it does

Don't return Kafka envs for all three endpoints 🤦 