### PR TITLE
feat(api): Add `totalRecs` to `EnvModelResponse`

### DIFF
--- a/coral/src/domain/environment/environment-test-helper.test.ts
+++ b/coral/src/domain/environment/environment-test-helper.test.ts
@@ -7,6 +7,7 @@ describe("environment-test-helper.ts", () => {
       const result = {
         allPageNos: ["1"],
         currentPage: "1",
+        totalRecs: 1,
         clusterId: 1,
         clusterName: "DEV",
         defaultPartitions: undefined,

--- a/coral/src/domain/environment/environment-test-helper.ts
+++ b/coral/src/domain/environment/environment-test-helper.ts
@@ -15,6 +15,7 @@ const defaultEnvironmentDTO: KlawApiModel<"EnvModelResponse"> = {
   showDeleteEnv: false,
   totalNoPages: "1",
   currentPage: "1",
+  totalRecs: 1,
   allPageNos: ["1"],
   associatedEnv: undefined,
   clusterType: "ALL",

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -53,6 +53,7 @@ function transformPaginatedEnvironmentApiResponse(
     return {
       totalPages: 0,
       currentPage: 0,
+      totalEnvs: 0,
       entries: [],
     };
   }
@@ -93,6 +94,7 @@ function transformPaginatedEnvironmentApiResponse(
   return {
     totalPages: Number(apiResponse[0].totalNoPages),
     currentPage: Number(apiResponse[0].currentPage),
+    totalEnvs: Number(apiResponse[0].totalRecs),
     entries: envData.flat(),
   };
 }

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -35,11 +35,12 @@ type Environment = {
 };
 
 type EnvironmentInfo = KlawApiModel<"EnvIdInfo">;
-interface Test extends Paginated<Environment[]> {
+interface PaginatedEnvironmentsWithTotalEnvs extends Paginated<Environment[]> {
   totalEnvs: number;
 }
 
-type EnvironmentPaginatedApiResponse = ResolveIntersectionTypes<Test>;
+type EnvironmentPaginatedApiResponse =
+  ResolveIntersectionTypes<PaginatedEnvironmentsWithTotalEnvs>;
 
 const ALL_ENVIRONMENTS_VALUE = "ALL";
 

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -35,10 +35,11 @@ type Environment = {
 };
 
 type EnvironmentInfo = KlawApiModel<"EnvIdInfo">;
+interface Test extends Paginated<Environment[]> {
+  totalEnvs: number;
+}
 
-type EnvironmentPaginatedApiResponse = ResolveIntersectionTypes<
-  Paginated<Environment[]>
->;
+type EnvironmentPaginatedApiResponse = ResolveIntersectionTypes<Test>;
 
 const ALL_ENVIRONMENTS_VALUE = "ALL";
 

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1377,6 +1377,8 @@ export type components = {
       totalNoPages: string;
       currentPage: string;
       allPageNos: (string)[];
+      /** Format: int32 */
+      totalRecs: number;
       associatedEnv?: components["schemas"]["EnvTag"];
       params: components["schemas"]["EnvParams"];
       /** @enum {string} */

--- a/core/src/main/java/io/aiven/klaw/helpers/Pager.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/Pager.java
@@ -64,7 +64,8 @@ public class Pager {
     List<String> numList = new ArrayList<>();
     getAllPagesList(requestPageNo, currentPage, totalPages, numList);
 
-    PageContext pageContext = PageContext.of(totalPages, numList, Integer.toString(requestPageNo));
+    PageContext pageContext =
+        PageContext.of(totalPages, numList, Integer.toString(requestPageNo), totalRecs);
     for (int i = startVar; i < lastVar; i++) {
       aclListMapUpdated.add(consumer.apply(pageContext, aclListMap.get(i)));
     }
@@ -75,15 +76,18 @@ public class Pager {
     private final String totalPages;
     private final List<String> allPageNos;
     private final String pageNo;
+    private final int totalRecs;
 
-    private PageContext(int totalPages, List<String> allPageNos, String pageNo) {
+    private PageContext(int totalPages, List<String> allPageNos, String pageNo, int totalRecs) {
       this.totalPages = totalPages + "";
       this.allPageNos = allPageNos;
       this.pageNo = pageNo;
+      this.totalRecs = totalRecs;
     }
 
-    public static PageContext of(int totalPages, List<String> allPageNos, String pageNo) {
-      return new PageContext(totalPages, allPageNos, pageNo);
+    public static PageContext of(
+        int totalPages, List<String> allPageNos, String pageNo, int totalRecs) {
+      return new PageContext(totalPages, allPageNos, pageNo, totalRecs);
     }
 
     public String getTotalPages() {
@@ -96,6 +100,10 @@ public class Pager {
 
     public String getPageNo() {
       return pageNo;
+    }
+
+    public int getTotalRecs() {
+      return totalRecs;
     }
   }
 }

--- a/core/src/main/java/io/aiven/klaw/model/response/EnvModelResponse.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/EnvModelResponse.java
@@ -41,6 +41,8 @@ public class EnvModelResponse implements Serializable {
 
   @NotNull private List<String> allPageNos;
 
+  @NotNull private int totalRecs;
+
   private EnvTag associatedEnv;
 
   @NotNull private EnvParams params;

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -433,6 +433,7 @@ public class EnvsClustersTenantsControllerService {
           }
           mp.setAllPageNos(numList);
           mp.setCurrentPage(pageContext.getPageNo());
+          mp.setTotalRecs(pageContext.getTotalRecs());
           return mp;
         });
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7667,10 +7667,10 @@
             "type" : "integer",
             "format" : "int32"
           },
-          "topicOwner" : {
+          "highestEnv" : {
             "type" : "boolean"
           },
-          "highestEnv" : {
+          "topicOwner" : {
             "type" : "boolean"
           }
         },
@@ -8152,6 +8152,10 @@
               "type" : "string"
             }
           },
+          "totalRecs" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
           "associatedEnv" : {
             "$ref" : "#/components/schemas/EnvTag"
           },
@@ -8164,7 +8168,7 @@
             "writeOnly" : true
           }
         },
-        "required" : [ "allPageNos", "clusterId", "clusterName", "currentPage", "envStatus", "id", "name", "otherParams", "params", "showDeleteEnv", "tenantId", "tenantName", "totalNoPages", "type" ]
+        "required" : [ "allPageNos", "clusterId", "clusterName", "currentPage", "envStatus", "id", "name", "otherParams", "params", "showDeleteEnv", "tenantId", "tenantName", "totalNoPages", "totalRecs", "type" ]
       },
       "AclInfo" : {
         "properties" : {


### PR DESCRIPTION
# About this change - What it does

The designs for the Environments configuration section shows badges in the tabs with the total count of environments for each tab.

![Screenshot 2023-09-07 at 15 35 33](https://github.com/Aiven-Open/klaw/assets/20607294/fc926cab-e9f9-4289-890a-901f4e24854f)

Because we want to use the paginated endpoints to fetch the data for these tabs, we do not have an eqasy way to compute this value on the front-end.

However, this value is available as `totalRecs` in `Pager.java`.

This PR adds this `totalRecs` value to the reponse payload `EnvModelResponse`.

This was discussed previously with @aindriu-aiven , but I am not sure if this implementation is the one we want. 

Additionally, unsure if this requires some testing in the backend.

Tested the endpoints locally in the context of this tabbed navitgation:

https://github.com/Aiven-Open/klaw/assets/20607294/c09dd94f-2a00-490e-91a0-a97aa433aa68


