### PR TITLE
feat(coral) - View Environments: Add tab navigation for environments page

### DIFF
--- a/coral/src/app/features/configuration/environments/components/EnvironmentsTabs.test.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentsTabs.test.tsx
@@ -1,0 +1,213 @@
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EnvironmentsTabs from "src/app/features/configuration/environments/components/EnvironmentsTabs";
+import {
+  ENVIRONMENT_TAB_ID_INTO_PATH,
+  EnvironmentsTabEnum,
+  Routes,
+} from "src/app/router_utils";
+import * as environmentsApi from "src/domain/environment/environment-api";
+import { EnvironmentPaginatedApiResponse } from "src/domain/environment/environment-types";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+
+class Deferred<T> {
+  public promise: Promise<T>;
+  public resolve!: (value: T | PromiseLike<T>) => void;
+  public reject!: (value: T | PromiseLike<T>) => void;
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+const mockedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+const mockedKafkaTotalEnvs: EnvironmentPaginatedApiResponse = {
+  totalPages: 1,
+  currentPage: 1,
+  totalEnvs: 1,
+  entries: [
+    {
+      type: "kafka",
+      name: "DEV",
+      id: "1001",
+      params: {},
+    },
+  ],
+};
+
+const mockedSchemaTotalEnvs: EnvironmentPaginatedApiResponse = {
+  totalPages: 1,
+  currentPage: 1,
+  totalEnvs: 2,
+  entries: [
+    {
+      type: "schemaregistry",
+      name: "DEV",
+      id: "1001",
+      params: {},
+    },
+    {
+      type: "schemaregistry",
+      name: "TST",
+      id: "1002",
+      params: {},
+    },
+  ],
+};
+
+const mockedConnectorTotalEnvs: EnvironmentPaginatedApiResponse = {
+  totalPages: 0,
+  currentPage: 0,
+  totalEnvs: 0,
+  entries: [],
+};
+
+describe("EnvironmentsTabs", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+  const getPaginatedEnvironmentsForTopicAndAclSpy = jest
+    .spyOn(environmentsApi, "getPaginatedEnvironmentsForTopicAndAcl")
+    .mockImplementation(() => {
+      throw Error(
+        "getPaginatedEnvironmentsForTopicAndAcl return must be mocked"
+      );
+    });
+  const getPaginatedEnvironmentsForSchemaSpy = jest
+    .spyOn(environmentsApi, "getPaginatedEnvironmentsForSchema")
+    .mockImplementation(() => {
+      throw Error("getPaginatedEnvironmentsForSchema return must be mocked");
+    });
+  const getPaginatedEnvironmentsForConnectorSpy = jest
+    .spyOn(environmentsApi, "getPaginatedEnvironmentsForConnector")
+    .mockImplementation(() => {
+      throw Error("getPaginatedEnvironmentsForConnector return must be mocked");
+    });
+
+  afterEach(() => {
+    getPaginatedEnvironmentsForTopicAndAclSpy.mockReset();
+    getPaginatedEnvironmentsForSchemaSpy.mockReset();
+    getPaginatedEnvironmentsForConnectorSpy.mockReset();
+  });
+
+  describe("Tab badges", () => {
+    let manualKafka: Deferred<EnvironmentPaginatedApiResponse>;
+    let manualSchema: Deferred<EnvironmentPaginatedApiResponse>;
+    let manualConnector: Deferred<EnvironmentPaginatedApiResponse>;
+
+    beforeAll(() => {
+      manualKafka = new Deferred();
+      manualSchema = new Deferred();
+      manualConnector = new Deferred();
+      getPaginatedEnvironmentsForTopicAndAclSpy.mockReturnValue(
+        manualKafka.promise
+      );
+      getPaginatedEnvironmentsForSchemaSpy.mockReturnValue(
+        manualSchema.promise
+      );
+      getPaginatedEnvironmentsForConnectorSpy.mockReturnValue(
+        manualConnector.promise
+      );
+      customRender(
+        <EnvironmentsTabs currentTab={EnvironmentsTabEnum.KAFKA} />,
+        {
+          queryClient: true,
+          memoryRouter: true,
+        }
+      );
+    });
+
+    afterAll(() => {
+      cleanup();
+    });
+    describe("while environment count requests are in flight", () => {
+      it("renders a tab for Kafka", () => {
+        screen.getByRole("tab", { name: "Kafka" });
+      });
+
+      it("renders a tab for Schema registry", () => {
+        screen.getByRole("tab", { name: "Schema Registry" });
+      });
+
+      it("renders a tab for Kafka Connect", () => {
+        screen.getByRole("tab", { name: "Kafka Connect" });
+      });
+
+      describe("when environment count requests resolve", () => {
+        beforeAll(() => {
+          manualKafka.resolve(mockedKafkaTotalEnvs);
+          manualSchema.resolve(mockedSchemaTotalEnvs);
+          manualConnector.resolve(mockedConnectorTotalEnvs);
+        });
+
+        it("renders correctenvironments count for Kafka", async () => {
+          await screen.findByRole("tab", {
+            name: "Kafka, 1 environment",
+          });
+        });
+
+        it("renders correctenvironments count for Schema Registry", async () => {
+          await screen.findByRole("tab", {
+            name: "Schema Registry, 2 environments",
+          });
+        });
+
+        it("renders correctenvironments count for Kafka Connect", async () => {
+          await screen.findByRole("tab", {
+            name: "Kafka Connect, no environments",
+          });
+        });
+      });
+    });
+  });
+
+  describe("Tab navigation", () => {
+    beforeEach(() => {
+      user = userEvent.setup();
+      customRender(
+        <EnvironmentsTabs currentTab={EnvironmentsTabEnum.KAFKA} />,
+        {
+          queryClient: true,
+          memoryRouter: true,
+        }
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      mockedNavigate.mockReset();
+    });
+
+    it('navigates to correct URL when "Kafka" tab is clicked', async () => {
+      await user.click(screen.getByRole("tab", { name: "Kafka" }));
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        `${Routes.ENVIRONMENTS}/${
+          ENVIRONMENT_TAB_ID_INTO_PATH[EnvironmentsTabEnum.KAFKA]
+        }`
+      );
+    });
+
+    it('navigates to correct URL when "Schema Registry" tab is clicked', async () => {
+      await user.click(screen.getByRole("tab", { name: "Schema Registry" }));
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        `${Routes.ENVIRONMENTS}/${
+          ENVIRONMENT_TAB_ID_INTO_PATH[EnvironmentsTabEnum.SCHEMA_REGISTRY]
+        }`
+      );
+    });
+
+    it('navigates to correct URL when "Kafka Connect" tab is clicked', async () => {
+      await user.click(screen.getByRole("tab", { name: "Kafka Connect" }));
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        `${Routes.ENVIRONMENTS}/${
+          ENVIRONMENT_TAB_ID_INTO_PATH[EnvironmentsTabEnum.KAFKA_CONNECT]
+        }`
+      );
+    });
+  });
+});

--- a/coral/src/app/features/configuration/environments/components/EnvironmentsTabs.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentsTabs.tsx
@@ -1,0 +1,118 @@
+import { Tabs } from "@aivenio/aquarium";
+import { useQuery } from "@tanstack/react-query";
+import { NavigateFunction, Outlet, useNavigate } from "react-router-dom";
+import {
+  ENVIRONMENT_TAB_ID_INTO_PATH,
+  EnvironmentsTabEnum,
+  Routes,
+  isEnvironmentsTabEnum,
+} from "src/app/router_utils";
+import {
+  getPaginatedEnvironmentsForConnector,
+  getPaginatedEnvironmentsForSchema,
+  getPaginatedEnvironmentsForTopicAndAcl,
+} from "src/domain/environment";
+
+type Props = {
+  currentTab: EnvironmentsTabEnum;
+};
+
+function getTabAriaLabel(
+  title: string,
+  amountOfEnvs: number | undefined
+): string {
+  if (typeof amountOfEnvs === "number") {
+    if (amountOfEnvs === 0) {
+      return `${title}, no environments`;
+    } else if (amountOfEnvs === 1) {
+      return `${title}, ${amountOfEnvs} environment`;
+    } else {
+      return `${title}, ${amountOfEnvs} environments`;
+    }
+  }
+  return title;
+}
+
+function getBadgeValue(amountOfEnvs: number | undefined): number | undefined {
+  if (typeof amountOfEnvs === "number" && amountOfEnvs > 0) {
+    return amountOfEnvs;
+  }
+  return undefined;
+}
+
+function EnvironmentsTabs({ currentTab }: Props) {
+  const navigate = useNavigate();
+
+  const { data: kafkaEnvs } = useQuery(
+    ["getPaginatedEnvironmentsForTopicAndAcl"],
+    {
+      queryFn: () => getPaginatedEnvironmentsForTopicAndAcl({ pageNo: "1" }),
+      refetchOnMount: false,
+    }
+  );
+  const { data: schemaRegistryEnvs } = useQuery(
+    ["getPaginatedEnvironmentsForSchema"],
+    {
+      queryFn: () => getPaginatedEnvironmentsForSchema({ pageNo: "1" }),
+      refetchOnMount: false,
+    }
+  );
+  const { data: kafkaConnectEnvs } = useQuery(
+    ["getPaginatedEnvironmentsForConnector"],
+    {
+      queryFn: () => getPaginatedEnvironmentsForConnector({ pageNo: "1" }),
+      refetchOnMount: false,
+    }
+  );
+
+  return (
+    <Tabs
+      value={currentTab}
+      onChange={(resourceTypeId) => navigateToTab(navigate, resourceTypeId)}
+    >
+      <Tabs.Tab
+        title="Kafka"
+        value={EnvironmentsTabEnum.KAFKA}
+        badge={getBadgeValue(kafkaEnvs?.totalEnvs)}
+        aria-label={getTabAriaLabel("Kafka", kafkaEnvs?.totalEnvs)}
+      >
+        {currentTab === EnvironmentsTabEnum.KAFKA && <Outlet />}
+      </Tabs.Tab>
+      <Tabs.Tab
+        title="Schema Registry"
+        value={EnvironmentsTabEnum.SCHEMA_REGISTRY}
+        badge={getBadgeValue(schemaRegistryEnvs?.totalEnvs)}
+        aria-label={getTabAriaLabel(
+          "Schema Registry",
+          schemaRegistryEnvs?.totalEnvs
+        )}
+      >
+        {currentTab === EnvironmentsTabEnum.SCHEMA_REGISTRY && <Outlet />}
+      </Tabs.Tab>
+      <Tabs.Tab
+        title="Kafka Connect"
+        value={EnvironmentsTabEnum.KAFKA_CONNECT}
+        badge={getBadgeValue(kafkaConnectEnvs?.totalEnvs)}
+        aria-label={getTabAriaLabel(
+          "Kafka Connect",
+          kafkaConnectEnvs?.totalEnvs
+        )}
+      >
+        {currentTab === EnvironmentsTabEnum.KAFKA_CONNECT && <Outlet />}
+      </Tabs.Tab>
+    </Tabs>
+  );
+
+  function navigateToTab(
+    navigate: NavigateFunction,
+    resourceTypeId: unknown
+  ): void {
+    if (isEnvironmentsTabEnum(resourceTypeId)) {
+      navigate(
+        `${Routes.ENVIRONMENTS}/${ENVIRONMENT_TAB_ID_INTO_PATH[resourceTypeId]}`
+      );
+    }
+  }
+}
+
+export default EnvironmentsTabs;

--- a/coral/src/app/pages/configuration/environments/index.test.tsx
+++ b/coral/src/app/pages/configuration/environments/index.test.tsx
@@ -2,10 +2,25 @@ import { cleanup, screen } from "@testing-library/react/pure";
 import EnvironmentsPage from "src/app/pages/configuration/environments";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
+const mockMatches = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useMatches: () => mockMatches(),
+}));
+
 describe("Environments page", () => {
   describe("renders Environments page with correct text", () => {
     beforeAll(() => {
-      customRender(<EnvironmentsPage />, { memoryRouter: true });
+      mockMatches.mockImplementation(() => [
+        {
+          id: "ENVIRONMENTS_TAB_ENUM_kafka",
+        },
+      ]);
+
+      customRender(<EnvironmentsPage />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
     });
 
     afterAll(cleanup);

--- a/coral/src/app/pages/configuration/environments/index.tsx
+++ b/coral/src/app/pages/configuration/environments/index.tsx
@@ -1,10 +1,37 @@
 import { PageHeader } from "@aivenio/aquarium";
+import { useMatches, Navigate } from "react-router-dom";
+import EnvironmentsTabs from "src/app/features/configuration/environments/components/EnvironmentsTabs";
+import {
+  ENVIRONMENT_TAB_ID_INTO_PATH,
+  EnvironmentsTabEnum,
+  isEnvironmentsTabEnum,
+} from "src/app/router_utils";
+
+function findMatchingTab(
+  matches: ReturnType<typeof useMatches>
+): EnvironmentsTabEnum | undefined {
+  const match = matches
+    .map((match) => match.id)
+    .find((id) =>
+      Object.prototype.hasOwnProperty.call(ENVIRONMENT_TAB_ID_INTO_PATH, id)
+    );
+  if (isEnvironmentsTabEnum(match)) {
+    return match;
+  }
+  return undefined;
+}
 
 const EnvironmentsPage = () => {
+  const matches = useMatches();
+  const currentTab = findMatchingTab(matches);
+
+  if (currentTab === undefined) {
+    return <Navigate to={`/configuration/environments/kafka`} replace={true} />;
+  }
   return (
     <>
       <PageHeader title={"Environments"} />
-      <div>Environment tabs</div>
+      <EnvironmentsTabs currentTab={currentTab} />
     </>
   );
 };


### PR DESCRIPTION
## About this change - What it does

- Adds tab navigation
- Adds data fetching to render environments count in badges

## Note

The new endpoints are currently not available as staging is a little behind on deployments. You may see the full implementation by building the API locally:


https://github.com/Aiven-Open/klaw/assets/20607294/3c845138-d475-4f93-bdf3-1d78bd61c650



Resolves: #1706
