### PR TITLE
fix(coral): Add `server` for all test suites

### DIFF
--- a/coral/src/services/test-utils/api-mocks/server.ts
+++ b/coral/src/services/test-utils/api-mocks/server.ts
@@ -3,8 +3,13 @@ import { rest } from "msw";
 
 export const server = setupServer(
   rest.all("*", (req, res, ctx) => {
-    console.error("Please mock all api calls in your tests.");
-    console.error("Request params: ", req.params);
+    console.error(
+      `
+A test has made an API call which was not caught by a mock (endpoint: ${req.url}). 
+Please make sure that every test file is mocking the appropriate API endpoints. 
+Some page components may render child components sending those call.
+`
+    );
 
     return res(ctx.status(404), ctx.json({}));
   })

--- a/coral/test-setup/setup-files-after-env.ts
+++ b/coral/test-setup/setup-files-after-env.ts
@@ -6,6 +6,9 @@ import "src/services/test-utils/mock-documenation-helper";
 // This is needed to be able to use crypto.randomUUID in testing components which use it
 // ie: components using useToast
 import { Crypto } from "@peculiar/webcrypto";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { server } from "src/services/test-utils/api-mocks/server";
 
 window.crypto.randomUUID = new Crypto().randomUUID;
 
@@ -13,3 +16,11 @@ window.crypto.randomUUID = new Crypto().randomUUID;
 
 process.env.API_BASE_URL = "http://localhost:8080";
 process.env.FEATURE_FLAG_TOPIC_REQUEST = "true";
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterAll(() => {
+  server.close();
+});


### PR DESCRIPTION
# About this change - What it does

Initialises the msw server beforeAll test suites for jest, hopefully this will surface missing mocks sooner for us. 
