### PR TITLE
feat(coral): Add profile dropdown

### DIFF
--- a/coral/src/app/layout/Layout.test.tsx
+++ b/coral/src/app/layout/Layout.test.tsx
@@ -9,6 +9,10 @@ jest.mock("src/services/feature-flags/utils", () => ({
   isFeatureFlagActive: () => isFeatureFlagActiveMock(),
 }));
 
+jest.mock("@aivenio/aquarium", () => ({
+  ...jest.requireActual("@aivenio/aquarium"),
+  useToast: () => jest.fn(),
+}));
 describe("Layout.tsx", () => {
   isFeatureFlagActiveMock.mockReturnValue(true);
 

--- a/coral/src/app/layout/LayoutWithoutNav.test.tsx
+++ b/coral/src/app/layout/LayoutWithoutNav.test.tsx
@@ -9,6 +9,11 @@ jest.mock("src/services/feature-flags/utils", () => ({
   isFeatureFlagActive: () => isFeatureFlagActiveMock(),
 }));
 
+jest.mock("@aivenio/aquarium", () => ({
+  ...jest.requireActual("@aivenio/aquarium"),
+  useToast: () => jest.fn(),
+}));
+
 describe("LayoutWithoutNav.tsx", () => {
   isFeatureFlagActiveMock.mockReturnValue(true);
 

--- a/coral/src/app/layout/header/HeaderMenuLink.test.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import HeaderMenuLink from "src/app/layout/header/HeaderMenuLink";
 import { tabNavigateTo } from "src/services/test-utils/tabbing";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const linkText = "Go to your profile page";
 
@@ -10,25 +11,28 @@ describe("HeaderMenuLink.tsx", () => {
   // (icon is not needed for the test, Icon component mocked out)
   const mockIcon = "" as unknown as typeof data;
 
-  describe("renders a default link with required props", () => {
+  describe("renders by default an internal link with required props", () => {
     beforeEach(() => {
-      render(
+      customRender(
         <HeaderMenuLink
           icon={mockIcon}
           href={"/myProfile"}
           linkText={linkText}
-        />
+        />,
+        { memoryRouter: true }
       );
     });
 
     afterEach(cleanup);
 
     it(`renders a link with text dependent on a given property`, () => {
+      const controlLink = screen.getByTestId("internal-link");
       const navLink = screen.getByRole("link", {
         name: linkText,
       });
 
       expect(navLink).toBeVisible();
+      expect(navLink).toEqual(controlLink);
     });
 
     it(`renders a href for that link dependent on a given property`, () => {
@@ -91,7 +95,91 @@ describe("HeaderMenuLink.tsx", () => {
     });
   });
 
-  describe("renders additional attributes dependent on props", () => {
+  describe("renders an external link with required props", () => {
+    beforeEach(() => {
+      render(
+        <HeaderMenuLink
+          icon={mockIcon}
+          href={"/myProfile"}
+          linkText={linkText}
+          externalLink={true}
+        />
+      );
+    });
+
+    afterEach(cleanup);
+
+    it(`renders a link with text dependent on a given property`, () => {
+      const controlLink = screen.getByTestId("external-link");
+      const navLink = screen.getByRole("link", {
+        name: linkText,
+      });
+
+      expect(navLink).toBeVisible();
+      expect(navLink).toEqual(controlLink);
+    });
+
+    it(`renders a href for that link dependent on a given property`, () => {
+      const navLink = screen.getByRole("link", {
+        name: linkText,
+      });
+      expect(navLink).toHaveAttribute("href", "/myProfile");
+    });
+
+    it(`renders an Icon`, async () => {
+      const icon = screen.getByTestId("ds-icon");
+
+      expect(icon).toBeVisible();
+    });
+
+    it(`triggers the rendering of a Tooltip on mouse hover`, async () => {
+      const navLink = screen.getByRole("link", {
+        name: linkText,
+      });
+      const tooltipBeforeHover = screen.queryByRole("tooltip");
+
+      expect(tooltipBeforeHover).toBeNull();
+
+      await userEvent.hover(navLink);
+
+      const tooltipAfterHover = screen.getByRole("tooltip");
+
+      expect(tooltipAfterHover).toBeVisible();
+      expect(tooltipAfterHover).toHaveTextContent(linkText);
+
+      // Assert the tooltip disappears after hover event stops
+      await userEvent.unhover(navLink);
+      expect(tooltipBeforeHover).toBeNull();
+    });
+
+    it(`triggers the rendering of a Tooltip on tab navigation`, async () => {
+      const navLink = screen.getByRole("link", {
+        name: linkText,
+      });
+      const tooltipBeforeFocus = screen.queryByRole("tooltip");
+
+      expect(tooltipBeforeFocus).toBeNull();
+
+      await tabNavigateTo({ targetElement: navLink });
+
+      const tooltipAfterFocus = screen.getByRole("tooltip");
+
+      expect(tooltipAfterFocus).toBeVisible();
+      expect(tooltipAfterFocus).toHaveTextContent(linkText);
+
+      // Assert the tooltip disappears after losing focus
+      await userEvent.tab();
+      expect(tooltipBeforeFocus).toBeNull();
+    });
+
+    it(`renders a hidden child with the tooltip text for assistive technology`, async () => {
+      const hiddenText = screen.getByText(linkText);
+
+      expect(hiddenText).toHaveClass("visually-hidden");
+    });
+  });
+
+  describe("renders an external link with additional attributes dependent on props", () => {
     afterEach(cleanup);
 
     it(`does not add a rel attribute by default`, () => {
@@ -100,6 +188,7 @@ describe("HeaderMenuLink.tsx", () => {
           icon={mockIcon}
           href={"/myProfile"}
           linkText={linkText}
+          externalLink={true}
         />
       );
 
@@ -117,6 +206,7 @@ describe("HeaderMenuLink.tsx", () => {
           href={"/myProfile"}
           linkText={linkText}
           rel={"noreferrer"}
+          externalLink={true}
         />
       );
 

--- a/coral/src/app/layout/header/HeaderMenuLink.test.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.test.tsx
@@ -1,5 +1,5 @@
 import data from "@aivenio/aquarium/dist/src/icons/console";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import HeaderMenuLink from "src/app/layout/header/HeaderMenuLink";
 import { tabNavigateTo } from "src/services/test-utils/tabbing";
@@ -11,7 +11,7 @@ describe("HeaderMenuLink.tsx", () => {
   // (icon is not needed for the test, Icon component mocked out)
   const mockIcon = "" as unknown as typeof data;
 
-  describe("renders by default an internal link with required props", () => {
+  describe("renders by default link with required props", () => {
     beforeEach(() => {
       customRender(
         <HeaderMenuLink
@@ -26,13 +26,11 @@ describe("HeaderMenuLink.tsx", () => {
     afterEach(cleanup);
 
     it(`renders a link with text dependent on a given property`, () => {
-      const controlLink = screen.getByTestId("internal-link");
       const navLink = screen.getByRole("link", {
         name: linkText,
       });
 
       expect(navLink).toBeVisible();
-      expect(navLink).toEqual(controlLink);
     });
 
     it(`renders a href for that link dependent on a given property`, () => {
@@ -95,101 +93,17 @@ describe("HeaderMenuLink.tsx", () => {
     });
   });
 
-  describe("renders an external link with required props", () => {
-    beforeEach(() => {
-      render(
-        <HeaderMenuLink
-          icon={mockIcon}
-          href={"/myProfile"}
-          linkText={linkText}
-          externalLink={true}
-        />
-      );
-    });
-
-    afterEach(cleanup);
-
-    it(`renders a link with text dependent on a given property`, () => {
-      const controlLink = screen.getByTestId("external-link");
-      const navLink = screen.getByRole("link", {
-        name: linkText,
-      });
-
-      expect(navLink).toBeVisible();
-      expect(navLink).toEqual(controlLink);
-    });
-
-    it(`renders a href for that link dependent on a given property`, () => {
-      const navLink = screen.getByRole("link", {
-        name: linkText,
-      });
-      expect(navLink).toHaveAttribute("href", "/myProfile");
-    });
-
-    it(`renders an Icon`, async () => {
-      const icon = screen.getByTestId("ds-icon");
-
-      expect(icon).toBeVisible();
-    });
-
-    it(`triggers the rendering of a Tooltip on mouse hover`, async () => {
-      const navLink = screen.getByRole("link", {
-        name: linkText,
-      });
-      const tooltipBeforeHover = screen.queryByRole("tooltip");
-
-      expect(tooltipBeforeHover).toBeNull();
-
-      await userEvent.hover(navLink);
-
-      const tooltipAfterHover = screen.getByRole("tooltip");
-
-      expect(tooltipAfterHover).toBeVisible();
-      expect(tooltipAfterHover).toHaveTextContent(linkText);
-
-      // Assert the tooltip disappears after hover event stops
-      await userEvent.unhover(navLink);
-      expect(tooltipBeforeHover).toBeNull();
-    });
-
-    it(`triggers the rendering of a Tooltip on tab navigation`, async () => {
-      const navLink = screen.getByRole("link", {
-        name: linkText,
-      });
-      const tooltipBeforeFocus = screen.queryByRole("tooltip");
-
-      expect(tooltipBeforeFocus).toBeNull();
-
-      await tabNavigateTo({ targetElement: navLink });
-
-      const tooltipAfterFocus = screen.getByRole("tooltip");
-
-      expect(tooltipAfterFocus).toBeVisible();
-      expect(tooltipAfterFocus).toHaveTextContent(linkText);
-
-      // Assert the tooltip disappears after losing focus
-      await userEvent.tab();
-      expect(tooltipBeforeFocus).toBeNull();
-    });
-
-    it(`renders a hidden child with the tooltip text for assistive technology`, async () => {
-      const hiddenText = screen.getByText(linkText);
-
-      expect(hiddenText).toHaveClass("visually-hidden");
-    });
-  });
-
-  describe("renders an external link with additional attributes dependent on props", () => {
+  describe("renders an link with additional attributes dependent on props", () => {
     afterEach(cleanup);
 
     it(`does not add a rel attribute by default`, () => {
-      render(
+      customRender(
         <HeaderMenuLink
           icon={mockIcon}
           href={"/myProfile"}
           linkText={linkText}
-          externalLink={true}
-        />
+        />,
+        { memoryRouter: true }
       );
 
       const navLink = screen.getByRole("link", {
@@ -200,14 +114,14 @@ describe("HeaderMenuLink.tsx", () => {
     });
 
     it(`adds a rel attribute with a given value`, () => {
-      render(
+      customRender(
         <HeaderMenuLink
           icon={mockIcon}
           href={"/myProfile"}
           linkText={linkText}
           rel={"noreferrer"}
-          externalLink={true}
-        />
+        />,
+        { memoryRouter: true }
       );
 
       const navLink = screen.getByRole("link", {

--- a/coral/src/app/layout/header/HeaderMenuLink.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.tsx
@@ -8,16 +8,27 @@ type HeaderMenuLinkProps = {
   linkText: string;
   href: string;
   rel?: string;
-  externalLink?: boolean;
 };
 function HeaderMenuLink(props: HeaderMenuLinkProps) {
-  const { icon, linkText, href, rel, externalLink } = props;
+  const { icon, linkText, href, rel } = props;
 
   const [isOpen, setIsOpen] = useState(false);
   const toggleOpen = () => setIsOpen(!isOpen);
 
-  const children = (
-    <>
+  return (
+    <Link
+      to={href}
+      rel={rel}
+      // These mouse events are necessary because the Tooltip component does not show the popover on hover with React version >= 18
+      // @TODO: remove when aquarium is compatible with React version >= 18
+      onMouseEnter={toggleOpen}
+      onMouseLeave={toggleOpen}
+      // Allow displaying the tooltip when navigating with keyboard
+      // Because the Tooltip is rendered outside the main DOM hierarchy, it is ignored by screen readers
+      // So we can display it with keyboard navigation for users who use keyboard navigation, but not a screen reader
+      onFocus={toggleOpen}
+      onBlur={toggleOpen}
+    >
       <span className={"visually-hidden"}>{linkText}</span>
       {/*Aquarium does not fully support React 18 now, where children */}
       {/*is not a default prop for FC*/}
@@ -33,48 +44,6 @@ function HeaderMenuLink(props: HeaderMenuLinkProps) {
         {/* aria-hidden="true" is added natively to the Icon component */}
         <Icon icon={icon} fontSize={"20px"} color={"grey-0"} />
       </Tooltip>
-    </>
-  );
-
-  if (externalLink) {
-    return (
-      <a
-        // in tests there's no way to confirm
-        // the right link is rendered as Link
-        // is rendered as an A tag
-        data-testid={"external-link"}
-        href={href}
-        rel={rel}
-        // These mouse events are necessary because the Tooltip component does not show the popover on hover with React version >= 18
-        // @TODO: remove when aquarium is compatible with React version >= 18
-        onMouseEnter={toggleOpen}
-        onMouseLeave={toggleOpen}
-        // Allow displaying the tooltip when navigating with keyboard
-        // Because the Tooltip is rendered outside the main DOM hierarchy, it is ignored by screen readers
-        // So we can display it with keyboard navigation for users who use keyboard navigation, but not a screen reader
-        onFocus={toggleOpen}
-        onBlur={toggleOpen}
-      >
-        {children}
-      </a>
-    );
-  }
-
-  return (
-    <Link
-      data-testid={"internal-link"}
-      to={href}
-      // These mouse events are necessary because the Tooltip component does not show the popover on hover with React version >= 18
-      // @TODO: remove when aquarium is compatible with React version >= 18
-      onMouseEnter={toggleOpen}
-      onMouseLeave={toggleOpen}
-      // Allow displaying the tooltip when navigating with keyboard
-      // Because the Tooltip is rendered outside the main DOM hierarchy, it is ignored by screen readers
-      // So we can display it with keyboard navigation for users who use keyboard navigation, but not a screen reader
-      onFocus={toggleOpen}
-      onBlur={toggleOpen}
-    >
-      {children}
     </Link>
   );
 }

--- a/coral/src/app/layout/header/HeaderMenuLink.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.tsx
@@ -1,33 +1,23 @@
 import { Icon, Tooltip } from "@aivenio/aquarium";
 import data from "@aivenio/aquarium/dist/src/icons/console";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 type HeaderMenuLinkProps = {
   icon: typeof data;
   linkText: string;
   href: string;
   rel?: string;
+  externalLink?: boolean;
 };
 function HeaderMenuLink(props: HeaderMenuLinkProps) {
-  const { icon, linkText, href, rel } = props;
+  const { icon, linkText, href, rel, externalLink } = props;
 
   const [isOpen, setIsOpen] = useState(false);
   const toggleOpen = () => setIsOpen(!isOpen);
 
-  return (
-    <a
-      href={href}
-      rel={rel}
-      // These mouse events are necessary because the Tooltip component does not show the popover on hover with React version >= 18
-      // @TODO: remove when aquarium is compatible with React version >= 18
-      onMouseEnter={toggleOpen}
-      onMouseLeave={toggleOpen}
-      // Allow displaying the tooltip when navigating with keyboard
-      // Because the Tooltip is rendered outside the main DOM hierarchy, it is ignored by screen readers
-      // So we can display it with keyboard navigation for users who use keyboard navigation, but not a screen reader
-      onFocus={toggleOpen}
-      onBlur={toggleOpen}
-    >
+  const children = (
+    <>
       <span className={"visually-hidden"}>{linkText}</span>
       {/*Aquarium does not fully support React 18 now, where children */}
       {/*is not a default prop for FC*/}
@@ -43,7 +33,49 @@ function HeaderMenuLink(props: HeaderMenuLinkProps) {
         {/* aria-hidden="true" is added natively to the Icon component */}
         <Icon icon={icon} fontSize={"20px"} color={"grey-0"} />
       </Tooltip>
-    </a>
+    </>
+  );
+
+  if (externalLink) {
+    return (
+      <a
+        // in tests there's no way to confirm
+        // the right link is rendered as Link
+        // is rendered as an A tag
+        data-testid={"external-link"}
+        href={href}
+        rel={rel}
+        // These mouse events are necessary because the Tooltip component does not show the popover on hover with React version >= 18
+        // @TODO: remove when aquarium is compatible with React version >= 18
+        onMouseEnter={toggleOpen}
+        onMouseLeave={toggleOpen}
+        // Allow displaying the tooltip when navigating with keyboard
+        // Because the Tooltip is rendered outside the main DOM hierarchy, it is ignored by screen readers
+        // So we can display it with keyboard navigation for users who use keyboard navigation, but not a screen reader
+        onFocus={toggleOpen}
+        onBlur={toggleOpen}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      data-testid={"internal-link"}
+      to={href}
+      // These mouse events are necessary because the Tooltip component does not show the popover on hover with React version >= 18
+      // @TODO: remove when aquarium is compatible with React version >= 18
+      onMouseEnter={toggleOpen}
+      onMouseLeave={toggleOpen}
+      // Allow displaying the tooltip when navigating with keyboard
+      // Because the Tooltip is rendered outside the main DOM hierarchy, it is ignored by screen readers
+      // So we can display it with keyboard navigation for users who use keyboard navigation, but not a screen reader
+      onFocus={toggleOpen}
+      onBlur={toggleOpen}
+    >
+      {children}
+    </Link>
   );
 }
 

--- a/coral/src/app/layout/header/HeaderNavigation.test.tsx
+++ b/coral/src/app/layout/header/HeaderNavigation.test.tsx
@@ -13,6 +13,11 @@ jest.mock("src/services/feature-flags/utils", () => ({
   isFeatureFlagActive: () => isFeatureFlagActiveMock(),
 }));
 
+jest.mock("@aivenio/aquarium", () => ({
+  ...jest.requireActual("@aivenio/aquarium"),
+  useToast: () => jest.fn(),
+}));
+
 const quickLinksNavItems = [
   { name: "Go to approve requests", linkTo: Routes.APPROVALS },
   {

--- a/coral/src/app/layout/header/HeaderNavigation.test.tsx
+++ b/coral/src/app/layout/header/HeaderNavigation.test.tsx
@@ -19,7 +19,6 @@ const quickLinksNavItems = [
     name: "Go to Klaw documentation page",
     linkTo: "https://www.klaw-project.io/docs",
   },
-  { name: "Go to your profile", linkTo: "/myProfile" },
 ];
 
 describe("HeaderNavigation.tsx", () => {
@@ -48,6 +47,16 @@ describe("HeaderNavigation.tsx", () => {
       });
     });
 
+    it(`renders a button for the profile dropdown`, () => {
+      const nav = screen.getByRole("navigation", { name: "Quick links" });
+      const button = within(nav).getByRole("button", {
+        name: "Open profile menu",
+      });
+
+      expect(button).toBeEnabled();
+      expect(button).toHaveAttribute("aria-haspopup", "true");
+    });
+
     it("renders all links in the header menu", () => {
       const nav = screen.getByRole("navigation", { name: "Quick links" });
       const links = within(nav).getAllByRole("link");
@@ -60,6 +69,7 @@ describe("HeaderNavigation.tsx", () => {
     const allHeaderElements = [
       "Request a new",
       ...quickLinksNavItems.map((link) => link.name),
+      "Open profile menu",
     ];
 
     describe("user can navigate through elements", () => {
@@ -75,7 +85,8 @@ describe("HeaderNavigation.tsx", () => {
         const numbersOfTabs = index + 1;
         it(`sets focus on ${headerElement} when user tabs ${numbersOfTabs} times`, async () => {
           const element =
-            headerElement !== "Request a new"
+            headerElement !== "Request a new" &&
+            headerElement !== "Open profile menu"
               ? screen.getByRole("link", { name: headerElement })
               : screen.getByRole("button", { name: headerElement });
 
@@ -92,7 +103,7 @@ describe("HeaderNavigation.tsx", () => {
       beforeEach(() => {
         customRender(<HeaderNavigation />, { memoryRouter: true });
         const lastElement = allHeaderElements[allHeaderElements.length - 1];
-        const lastNavItem = screen.getByRole("link", {
+        const lastNavItem = screen.getByRole("button", {
           name: lastElement,
         });
         lastNavItem.focus();
@@ -106,7 +117,8 @@ describe("HeaderNavigation.tsx", () => {
 
         it(`sets focus on ${headerElement} when user shift+tabs ${numbersOfTabs} times`, async () => {
           const element =
-            headerElement !== "Request a new"
+            headerElement !== "Request a new" &&
+            headerElement !== "Open profile menu"
               ? screen.getByRole("link", { name: headerElement })
               : screen.getByRole("button", { name: headerElement });
           index > 0 && expect(element).not.toHaveFocus();

--- a/coral/src/app/layout/header/HeaderNavigation.tsx
+++ b/coral/src/app/layout/header/HeaderNavigation.tsx
@@ -1,7 +1,6 @@
 import { Box, DropdownMenu, Button } from "@aivenio/aquarium";
 import notifications from "@aivenio/aquarium/dist/module/icons/notifications";
 import questionMark from "@aivenio/aquarium/dist/module/icons/questionMark";
-import user from "@aivenio/aquarium/dist/module/icons/user";
 import code from "@aivenio/aquarium/icons/code";
 import codeBlock from "@aivenio/aquarium/icons/codeBlock";
 import dataflow02 from "@aivenio/aquarium/icons/dataflow02";
@@ -9,6 +8,7 @@ import people from "@aivenio/aquarium/icons/people";
 import { useNavigate } from "react-router-dom";
 import HeaderMenuLink from "src/app/layout/header/HeaderMenuLink";
 import { Routes } from "src/app/router_utils";
+import { ProfileDropdown } from "src/app/layout/header/ProfileDropdown";
 
 const requestNewEntityPaths: { [key: string]: string } = {
   topic: Routes.TOPIC_REQUEST,
@@ -68,11 +68,7 @@ function HeaderNavigation() {
             />
           </li>
           <li>
-            <HeaderMenuLink
-              icon={user}
-              linkText={"Go to your profile"}
-              href={`/myProfile`}
-            />
+            <ProfileDropdown />
           </li>
         </Box>
       </nav>

--- a/coral/src/app/layout/header/ProfileDropdown.module.css
+++ b/coral/src/app/layout/header/ProfileDropdown.module.css
@@ -1,4 +1,4 @@
-.profileDropdownDeaderIcon {
+.profileDropdownHeaderIcon {
   position: relative;
   right: -10px;
 }

--- a/coral/src/app/layout/header/ProfileDropdown.module.css
+++ b/coral/src/app/layout/header/ProfileDropdown.module.css
@@ -1,0 +1,4 @@
+.profileDropdownDeaderIcon {
+  position: relative;
+  right: -10px;
+}

--- a/coral/src/app/layout/header/ProfileDropdown.module.css
+++ b/coral/src/app/layout/header/ProfileDropdown.module.css
@@ -1,3 +1,4 @@
+/*Position matches the style in similar dropdown in Aiven console*/
 .profileDropdownHeaderIcon {
   position: relative;
   right: -10px;

--- a/coral/src/app/layout/header/ProfileDropdown.test.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProfileDropdown } from "src/app/layout/header/ProfileDropdown";
+
+const menuItems = [
+  { path: "/myProfile", name: "My profile" },
+  { path: "/tenantInfo", name: "My tenant info" },
+  { path: "/changePwd", name: "Change password" },
+];
+
+describe("ProfileDropdown", () => {
+  const user = userEvent.setup();
+
+  describe("renders all necessary elements when dropdown is closed", () => {
+    beforeAll(() => {
+      render(<ProfileDropdown />);
+    });
+    afterAll(cleanup);
+
+    it("shows a button to open menu", () => {
+      const button = screen.getByRole("button", { name: "Open profile menu" });
+      expect(button).toBeEnabled();
+    });
+
+    it("shows popup information on the button to support assistive technology", () => {
+      const button = screen.getByRole("button", { name: "Open profile menu" });
+
+      expect(button).toHaveAttribute("aria-haspopup", "true");
+    });
+
+    it("shows that menu is not expanded on the button to support assistive technology", () => {
+      const button = screen.getByRole("button", { name: "Open profile menu" });
+
+      expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+
+  describe("renders all necessary elements when dropdown is open", () => {
+    beforeAll(async () => {
+      render(<ProfileDropdown />);
+      const button = screen.getByRole("button", { name: "Open profile menu" });
+      await user.click(button);
+    });
+
+    afterAll(cleanup);
+
+    it("shows all necessary menu items", () => {
+      const menuItems = screen.getAllByRole("menuitem");
+
+      expect(menuItems).toHaveLength(menuItems.length);
+    });
+
+    menuItems.forEach((item) => {
+      it(`shows a menu item for ${item.name}`, () => {
+        const menuItem = screen.getByRole("menuitem", { name: item.name });
+
+        expect(menuItem).toBeVisible();
+      });
+    });
+  });
+
+  describe("handles user choosing items from the menu", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "location", {
+        value: {
+          assign: jest.fn(),
+        },
+        writable: true,
+      });
+      render(<ProfileDropdown />);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      cleanup();
+    });
+
+    menuItems.forEach((item) => {
+      const name = item.name;
+      const path = item.path;
+
+      it(`navigates to "${path}" when user clicks "${name}"`, async () => {
+        const button = screen.getByRole("button", {
+          name: "Open profile menu",
+        });
+        await user.click(button);
+
+        const menuItem = screen.getByRole("menuitem", { name: name });
+        await user.click(menuItem);
+
+        // in tests it will start with http://localhost/ since that is the window.origin
+        expect(window.location.assign).toHaveBeenCalledWith(
+          `http://localhost${path}`
+        );
+      });
+    });
+  });
+});

--- a/coral/src/app/layout/header/ProfileDropdown.test.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.test.tsx
@@ -137,6 +137,22 @@ describe("ProfileDropdown", () => {
       expect(mockLogoutUser).toHaveBeenCalled();
     });
 
+    it("shows a progress notification to user while logout is in progress", async () => {
+      const button = screen.getByRole("button", {
+        name: "Open profile menu",
+      });
+      await user.click(button);
+
+      const logout = screen.getByRole("menuitem", { name: "Log out" });
+      await user.click(logout);
+
+      expect(mockedUseToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "You are being logged out of Klaw...",
+        })
+      );
+    });
+
     it("redirects user to /login when they have logged out", async () => {
       const button = screen.getByRole("button", {
         name: "Open profile menu",

--- a/coral/src/app/layout/header/ProfileDropdown.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.tsx
@@ -1,4 +1,10 @@
-import { Box, DropdownMenu, Typography, Icon } from "@aivenio/aquarium";
+import {
+  Box,
+  DropdownMenu,
+  Typography,
+  Icon,
+  useToast,
+} from "@aivenio/aquarium";
 import user from "@aivenio/aquarium/dist/src/icons/user";
 import logOut from "@aivenio/aquarium/dist/src/icons/logOut";
 import classes from "src/app/layout/header/ProfileDropdown.module.css";
@@ -26,25 +32,31 @@ const menuItems: MenuItem[] = [
 
 const LOGOUT_KEY = "logout";
 function ProfileDropdown() {
+  const toast = useToast();
   function navigateToAngular(path: string) {
     window.location.assign(`${window.origin}${path}`);
   }
+
   function onDropdownClick(actionKey: string | number) {
     if (actionKey === LOGOUT_KEY) {
-      logoutUser()
-        .catch((error) => {
+      logoutUser().catch((error) => {
+        if (error.status !== 401) {
+          toast({
+            message:
+              "Something went wrong in the log out process. Please try again or contact your administrator.",
+            position: "bottom-left",
+            variant: "danger",
+          });
+          console.error(error);
+        } else {
           // after calling /logout, we will receive a 401 error
           // based on transformHTTPRedirectToLoginTo401 in `api.ts`
           // which confirms the user is not authorized anymore
           // only in case the status is different we need to
           // surface the error.
-          if (error.status !== 401) {
-            throw error;
-          }
-        })
-        .finally(() => {
           window.location.assign(`${window.origin}/login`);
-        });
+        }
+      });
 
       return;
     } else {

--- a/coral/src/app/layout/header/ProfileDropdown.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.tsx
@@ -2,6 +2,7 @@ import { Box, DropdownMenu, Typography, Icon } from "@aivenio/aquarium";
 import user from "@aivenio/aquarium/dist/src/icons/user";
 import logOut from "@aivenio/aquarium/dist/src/icons/logOut";
 import classes from "src/app/layout/header/ProfileDropdown.module.css";
+import { logoutUser } from "src/domain/auth-user";
 
 type MenuItem = {
   path: string;
@@ -30,7 +31,21 @@ function ProfileDropdown() {
   }
   function onDropdownClick(actionKey: string | number) {
     if (actionKey === LOGOUT_KEY) {
-      console.log("LOGOUT");
+      logoutUser()
+        .catch((error) => {
+          // after calling /logout, we will receive a 401 error
+          // based on transformHTTPRedirectToLoginTo401 in `api.ts`
+          // which confirms the user is not authorized anymore
+          // only in case the status is different we need to
+          // surface the error.
+          if (error.status !== 401) {
+            throw error;
+          }
+        })
+        .finally(() => {
+          window.location.assign(`${window.origin}/login`);
+        });
+
       return;
     } else {
       const selectedItem = menuItems[actionKey as number];

--- a/coral/src/app/layout/header/ProfileDropdown.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.tsx
@@ -39,6 +39,12 @@ function ProfileDropdown() {
 
   function onDropdownClick(actionKey: string | number) {
     if (actionKey === LOGOUT_KEY) {
+      toast({
+        message: "You are being logged out of Klaw...",
+        position: "bottom-left",
+        variant: "default",
+        duration: 30 * 1000,
+      });
       logoutUser().catch((error) => {
         if (error.status !== 401) {
           toast({
@@ -49,11 +55,6 @@ function ProfileDropdown() {
           });
           console.error(error);
         } else {
-          // after calling /logout, we will receive a 401 error
-          // based on transformHTTPRedirectToLoginTo401 in `api.ts`
-          // which confirms the user is not authorized anymore
-          // only in case the status is different we need to
-          // surface the error.
           window.location.assign(`${window.origin}/login`);
         }
       });

--- a/coral/src/app/layout/header/ProfileDropdown.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.tsx
@@ -1,0 +1,93 @@
+import { Box, DropdownMenu, Typography, Icon } from "@aivenio/aquarium";
+import user from "@aivenio/aquarium/dist/src/icons/user";
+import logOut from "@aivenio/aquarium/dist/src/icons/logOut";
+import classes from "src/app/layout/header/ProfileDropdown.module.css";
+
+type MenuItem = {
+  path: string;
+  name: string;
+};
+
+const menuItems: MenuItem[] = [
+  {
+    path: "/myProfile",
+    name: "My profile",
+  },
+  {
+    path: "/tenantInfo",
+    name: "My tenant info",
+  },
+  {
+    path: "/changePwd",
+    name: "Change password",
+  },
+];
+
+const LOGOUT_KEY = "logout";
+function ProfileDropdown() {
+  function navigateToAngular(path: string) {
+    window.location.assign(`${window.origin}${path}`);
+  }
+  function onDropdownClick(actionKey: string | number) {
+    if (actionKey === LOGOUT_KEY) {
+      console.log("LOGOUT");
+      return;
+    } else {
+      const selectedItem = menuItems[actionKey as number];
+      // selectedItem should never be undefined, this is to support
+      // developers and make sure we can not make a mistake here
+      if (selectedItem === undefined) {
+        console.error(`No item with index ${actionKey} found.`);
+      } else {
+        navigateToAngular(selectedItem.path);
+      }
+    }
+  }
+
+  return (
+    <DropdownMenu
+      onAction={onDropdownClick}
+      maxWidth={300}
+      placement="bottom-right"
+      header={
+        <Box.Flex backgroundColor={"primary-10"} paddingLeft={"l1"}>
+          <Box paddingTop={"l1"} className={"profile-dropdown-header"}>
+            <Typography.Large color="grey-90" className="panel-header-title">
+              User name
+            </Typography.Large>
+            <Typography.Caption color="grey-50">Team</Typography.Caption>
+          </Box>
+          <Icon
+            color={"primary-30"}
+            icon={user}
+            height={80}
+            width={80}
+            className={classes.profileDropdownDeaderIcon}
+          />
+        </Box.Flex>
+      }
+    >
+      <DropdownMenu.Trigger>
+        <button aria-label={"Open profile menu"}>
+          <Icon icon={user} fontSize={"20px"} color={"grey-0"} />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Items>
+        <DropdownMenu.Section>
+          {menuItems.map((item, index) => {
+            return (
+              <DropdownMenu.Item key={index}>{item.name}</DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Section>
+        <DropdownMenu.Section>
+          <DropdownMenu.Item key={LOGOUT_KEY} icon={logOut}>
+            Log out
+          </DropdownMenu.Item>
+        </DropdownMenu.Section>
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}
+
+export { ProfileDropdown };

--- a/coral/src/app/layout/header/ProfileDropdown.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.tsx
@@ -90,7 +90,7 @@ function ProfileDropdown() {
             icon={user}
             height={80}
             width={80}
-            className={classes.profileDropdownDeaderIcon}
+            className={classes.profileDropdownHeaderIcon}
           />
         </Box.Flex>
       }

--- a/coral/src/domain/auth-user/auth-user-api.ts
+++ b/coral/src/domain/auth-user/auth-user-api.ts
@@ -56,4 +56,8 @@ function getAuth(): Promise<AuthUser> {
     .then((response) => transformAuthResponse(response));
 }
 
-export { getAuthUserMockForLogin, getAuth };
+function logoutUser() {
+  return api.post<KlawApiResponse<"logout">, never>(API_PATHS.logout);
+}
+
+export { getAuthUserMockForLogin, getAuth, logoutUser };

--- a/coral/src/domain/auth-user/index.ts
+++ b/coral/src/domain/auth-user/index.ts
@@ -1,8 +1,9 @@
 import {
   getAuthUserMockForLogin,
   getAuth,
+  logoutUser,
 } from "src/domain/auth-user/auth-user-api";
 import { AuthUser } from "src/domain/auth-user/auth-user-types";
 
-export { getAuthUserMockForLogin, getAuth };
+export { getAuthUserMockForLogin, getAuth, logoutUser };
 export type { AuthUser };


### PR DESCRIPTION
# About this change - What it does

- adds the profile dropdown menu in header
- adds logout functionality

- 🐛 additionally it updated the `HeaderLink` component to show internal and external links, because the link to `/approvals` did lead user to the Angular start page

Note: I tested all links in the build and they work

## recording logut


https://github.com/Aiven-Open/klaw/assets/943800/beafc901-0ab9-4cee-b149-8ffc42ef92e2


Resolves: #1758 

