### PR TITLE
feat(coral): Show links to topic/connector in My teams requests 

### DIFF
--- a/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.test.tsx
@@ -87,7 +87,7 @@ describe("ConnectorRequestsTable", () => {
     screen.getByText("No Connector request matched your criteria.");
   });
 
-  it("has column with connector name as string when request type is CREATE", () => {
+  it("has column with connector name as string when connector does not exist", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[0]
@@ -97,7 +97,7 @@ describe("ConnectorRequestsTable", () => {
     );
   });
 
-  it("has column with connector name as link when request type is not CREATE", () => {
+  it("has column with connector name as link when connector does exist", () => {
     renderFromProps();
 
     const nameSecondTopicInResponse = mockedRequests[1].connectorName;

--- a/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.tsx
+++ b/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.tsx
@@ -17,6 +17,7 @@ import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import { Link } from "react-router-dom";
 import link from "@aivenio/aquarium/icons/link";
+import { doesEntityRelatedToRequestExists } from "src/services/entity-exists/entity-related-to-request-exists";
 
 type ConnectorRequestTableRow = {
   id: ConnectorRequest["connectorId"];
@@ -49,9 +50,15 @@ function ConnectorRequestsTable({
       headerName: "Name",
       UNSAFE_render: ({
         connectorName,
+        requestStatus,
         requestOperationType,
       }: ConnectorRequestTableRow) => {
-        if (requestOperationType !== "CREATE") {
+        if (
+          doesEntityRelatedToRequestExists({
+            requestStatus,
+            requestOperationType,
+          })
+        ) {
           return (
             <Link to={`/connector/${connectorName}/overview`}>
               {connectorName} <InlineIcon icon={link} />

--- a/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.tsx
+++ b/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.tsx
@@ -1,4 +1,9 @@
-import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import {
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  InlineIcon,
+} from "@aivenio/aquarium";
 import {
   requestOperationTypeChipStatusMap,
   requestOperationTypeNameMap,
@@ -10,6 +15,8 @@ import {
 import type { ConnectorRequest } from "src/domain/connector";
 import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
+import { Link } from "react-router-dom";
+import link from "@aivenio/aquarium/icons/link";
 
 type ConnectorRequestTableRow = {
   id: ConnectorRequest["connectorId"];
@@ -37,7 +44,25 @@ function ConnectorRequestsTable({
   onDelete,
 }: Props) {
   const columns: Array<DataTableColumn<ConnectorRequestTableRow>> = [
-    { type: "text", field: "connectorName", headerName: "Name" },
+    {
+      type: "custom",
+      headerName: "Name",
+      UNSAFE_render: ({
+        connectorName,
+        requestOperationType,
+      }: ConnectorRequestTableRow) => {
+        if (requestOperationType !== "CREATE") {
+          return (
+            <Link to={`/connector/${connectorName}/overview`}>
+              {connectorName} <InlineIcon icon={link} />
+            </Link>
+          );
+        } else {
+          return <>{connectorName}</>;
+        }
+      },
+    },
+
     {
       type: "status",
       headerName: "Environment",

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
@@ -103,7 +103,7 @@ describe("TopicRequestsTable", () => {
     screen.getByText("No Topic request matched your criteria.");
   });
 
-  it("has column with topic name as text when request type is CREATE", () => {
+  it("has column with topic name as text when topic does not exists", () => {
     renderFromProps();
     expect(
       within(getNthRow(0)).getAllByRole("columnheader")[0]
@@ -113,7 +113,7 @@ describe("TopicRequestsTable", () => {
     );
   });
 
-  it("has column with topic name as link when request type is not CREATE", () => {
+  it("has column with topic name as link when topic does exists", () => {
     renderFromProps();
 
     const nameSecondTopicInResponse = mockedRequests[1].topicname;

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
@@ -1,4 +1,9 @@
-import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import {
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  InlineIcon,
+} from "@aivenio/aquarium";
 import infoIcon from "@aivenio/aquarium/dist/src/icons/infoSign";
 import deleteIcon from "@aivenio/aquarium/dist/src/icons/delete";
 import { TopicRequest } from "src/domain/topic/topic-types";
@@ -10,6 +15,8 @@ import {
   requestOperationTypeChipStatusMap,
   requestOperationTypeNameMap,
 } from "src/app/features/approvals/utils/request-operation-type-helper";
+import { Link } from "react-router-dom";
+import link from "@aivenio/aquarium/icons/link";
 
 interface TopicRequestTableRow {
   id: TopicRequest["topicid"];
@@ -37,7 +44,24 @@ function TopicRequestsTable({
   ariaLabel,
 }: TopicRequestsTableProps) {
   const columns: Array<DataTableColumn<TopicRequestTableRow>> = [
-    { type: "text", field: "topicname", headerName: "Topic" },
+    {
+      type: "custom",
+      headerName: "Topic",
+      UNSAFE_render: ({
+        topicname,
+        requestOperationType,
+      }: TopicRequestTableRow) => {
+        if (requestOperationType !== "CREATE") {
+          return (
+            <Link to={`/topic/${topicname}/overview`}>
+              {topicname} <InlineIcon icon={link} />
+            </Link>
+          );
+        } else {
+          return <>{topicname}</>;
+        }
+      },
+    },
     {
       type: "status",
       headerName: "Environment",

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.tsx
@@ -17,6 +17,7 @@ import {
 } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { Link } from "react-router-dom";
 import link from "@aivenio/aquarium/icons/link";
+import { doesEntityRelatedToRequestExists } from "src/services/entity-exists/entity-related-to-request-exists";
 
 interface TopicRequestTableRow {
   id: TopicRequest["topicid"];
@@ -50,8 +51,14 @@ function TopicRequestsTable({
       UNSAFE_render: ({
         topicname,
         requestOperationType,
+        requestStatus,
       }: TopicRequestTableRow) => {
-        if (requestOperationType !== "CREATE") {
+        if (
+          doesEntityRelatedToRequestExists({
+            requestStatus,
+            requestOperationType,
+          })
+        ) {
           return (
             <Link to={`/topic/${topicname}/overview`}>
               {topicname} <InlineIcon icon={link} />

--- a/coral/src/services/entity-exists/entity-related-to-request-exists.test.ts
+++ b/coral/src/services/entity-exists/entity-related-to-request-exists.test.ts
@@ -1,0 +1,39 @@
+import { doesEntityRelatedToRequestExists } from "src/services/entity-exists/entity-related-to-request-exists";
+
+describe("doesEntityRelatedToRequestExists", () => {
+  describe.each`
+    type         | status        | exists
+    ${"CLAIM"}   | ${"APPROVED"} | ${true}
+    ${"CREATE"}  | ${"APPROVED"} | ${true}
+    ${"DELETE"}  | ${"APPROVED"} | ${false}
+    ${"PROMOTE"} | ${"APPROVED"} | ${true}
+    ${"UPDATE"}  | ${"APPROVED"} | ${true}
+    ${"CLAIM"}   | ${"CREATED"}  | ${true}
+    ${"CREATE"}  | ${"CREATED"}  | ${false}
+    ${"DELETE"}  | ${"CREATED"}  | ${true}
+    ${"PROMOTE"} | ${"CREATED"}  | ${true}
+    ${"UPDATE"}  | ${"CREATED"}  | ${true}
+    ${"CLAIM"}   | ${"DECLINED"} | ${true}
+    ${"CREATE"}  | ${"DECLINED"} | ${false}
+    ${"DELETE"}  | ${"DECLINED"} | ${true}
+    ${"PROMOTE"} | ${"DECLINED"} | ${true}
+    ${"UPDATE"}  | ${"DECLINED"} | ${true}
+    ${"CLAIM"}   | ${"DELETED"}  | ${true}
+    ${"CREATE"}  | ${"DELETED"}  | ${false}
+    ${"DELETE"}  | ${"DELETED"}  | ${true}
+    ${"PROMOTE"} | ${"DELETED"}  | ${true}
+    ${"UPDATE"}  | ${"DELETED"}  | ${true}
+  `(
+    "type: $type, status: $status, exists: $exists",
+    ({ type, status, exists }) => {
+      it(`returns ${exists} when type is ${type}, status is ${status}`, () => {
+        const result = doesEntityRelatedToRequestExists({
+          requestStatus: status,
+          requestOperationType: type,
+        });
+
+        expect(result).toBe(exists);
+      });
+    }
+  );
+});

--- a/coral/src/services/entity-exists/entity-related-to-request-exists.ts
+++ b/coral/src/services/entity-exists/entity-related-to-request-exists.ts
@@ -1,0 +1,26 @@
+import {
+  RequestOperationType,
+  RequestStatus,
+} from "src/domain/requests/requests-types";
+
+type DoesEntityExist = {
+  requestStatus: RequestStatus;
+  requestOperationType: RequestOperationType;
+};
+function doesEntityRelatedToRequestExists({
+  requestStatus,
+  requestOperationType,
+}: DoesEntityExist): boolean {
+  // a e.g. topic where a CREATE request has NOT been approved, does not exist as entity
+  if (requestOperationType === "CREATE" && requestStatus !== "APPROVED") {
+    return false;
+  }
+
+  // a e.g. topic where a DELETE request has been approved, does not exist as entity
+  if (requestOperationType === "DELETE" && requestStatus === "APPROVED") {
+    return false;
+  }
+  return true;
+}
+
+export { doesEntityRelatedToRequestExists };


### PR DESCRIPTION
# About this change - What it does

Adds a link to topic / connector page instead of only showing the name as text in the tables in "My teams requests". 
The link is only added for topic/connectors requests that don't have the `requestOperationType` `CREATE`, because for them there is no entity yet to link to. 

Relates to: #1659 

