### PR TITLE
fix(core): Allow `Pager` to return `pageNo` as `currentPage` when `pageNo` is a stringified int

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/Pager.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/Pager.java
@@ -14,9 +14,7 @@ public class Pager {
       case ">>" -> totalPages;
       case "<" -> Integer.parseInt(currentPage) - 1;
       case "<<" -> 1;
-      default -> currentPage.isBlank() || !NumberUtils.isCreatable(currentPage)
-          ? 1
-          : Integer.parseInt(currentPage);
+      default -> !NumberUtils.isCreatable(pageNo) ? 1 : Integer.parseInt(pageNo);
     };
   }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/Pager.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/Pager.java
@@ -14,8 +14,14 @@ public class Pager {
       case ">>" -> totalPages;
       case "<" -> Integer.parseInt(currentPage) - 1;
       case "<<" -> 1;
-      default -> !NumberUtils.isCreatable(pageNo) ? 1 : Integer.parseInt(pageNo);
+      default -> !NumberUtils.isCreatable(pageNo)
+          ? defaultToCurrentPage(currentPage)
+          : Integer.parseInt(pageNo);
     };
+  }
+
+  private static int defaultToCurrentPage(String currentPage) {
+    return !NumberUtils.isCreatable(currentPage) ? 1 : Integer.parseInt(currentPage);
   }
 
   private static void getAllPagesList(

--- a/core/src/test/java/io/aiven/klaw/helpers/PagerTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/PagerTest.java
@@ -14,7 +14,7 @@ public class PagerTest {
   @MethodSource("pagerInfoProvider")
   void testGetItemsList(PageInfoTestSpec pageInfoTestSpec) {
     int currentPage =
-        pageInfoTestSpec.currentPage.isEmpty() ? 1 : Integer.parseInt(pageInfoTestSpec.currentPage);
+        pageInfoTestSpec.currentPage.isEmpty() ? 1 : Integer.parseInt(pageInfoTestSpec.pageNo);
     int fromIndex = (currentPage - 1) * pageInfoTestSpec.itemsPerPage;
     List expected =
         pageInfoTestSpec.list.subList(

--- a/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
@@ -269,7 +269,7 @@ class EnvsClustersTenantsControllerServiceTest {
         Arguments.arguments(KafkaClustersType.KAFKA_CONNECT, "DEV", "1", 1),
         Arguments.arguments(KafkaClustersType.KAFKA, "3", "1", 1),
         Arguments.arguments(KafkaClustersType.SCHEMA_REGISTRY, "PREPROD", "1", 0),
-        Arguments.arguments(KafkaClustersType.SCHEMA_REGISTRY, "", "2", 0));
+        Arguments.arguments(KafkaClustersType.SCHEMA_REGISTRY, "", "2", 3));
   }
 
   private static Env generateKafkaEnv(String id, String Kafka) {

--- a/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
@@ -269,7 +269,7 @@ class EnvsClustersTenantsControllerServiceTest {
         Arguments.arguments(KafkaClustersType.KAFKA_CONNECT, "DEV", "1", 1),
         Arguments.arguments(KafkaClustersType.KAFKA, "3", "1", 1),
         Arguments.arguments(KafkaClustersType.SCHEMA_REGISTRY, "PREPROD", "1", 0),
-        Arguments.arguments(KafkaClustersType.SCHEMA_REGISTRY, "", "2", 3));
+        Arguments.arguments(KafkaClustersType.SCHEMA_REGISTRY, "", "2", 0));
   }
 
   private static Env generateKafkaEnv(String id, String Kafka) {


### PR DESCRIPTION
## About this change - What it does

`deriveCurrentPage` did not account for the cases when `pageNo` is passed as a stringified int, as coral does to handle pagination, breaking pagination on coral.

This PR changes the `default` case to not return the `currentPage` but the `pageNo` when `pageNo` is a stringified number.

https://github.com/Aiven-Open/klaw/assets/20607294/16e298e6-e4a7-40ea-9955-ef7e7fb4ac76


Resolves: #1770
