### PR TITLE
fix(coral): 🐛  handle not existent topic/connector correctly

### DIFF
--- a/coral/src/app/features/connectors/details/ConnectorDetails.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.tsx
@@ -185,6 +185,7 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
         )}
 
       <ConnectorOverviewResourcesTabs
+        connectorName={connectorName}
         isError={connectorIsError}
         error={connectorError}
         isLoading={connectorIsLoading}

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
@@ -77,7 +77,7 @@ const defaultProps = {
   environmentId: "1",
   isError: false,
   isLoading: false,
-  topicName: testConnectorName,
+  connectorName: testConnectorName,
   connectorOverview: testConnectorOverview,
   connectorIsRefetching: false,
 };

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
@@ -18,6 +18,7 @@ type Props = {
   isLoading: boolean;
   connectorIsRefetching: boolean;
   connectorOverview?: ConnectorOverview;
+  connectorName: string;
 };
 
 function ConnectorOverviewResourcesTabs({
@@ -28,10 +29,9 @@ function ConnectorOverviewResourcesTabs({
   isLoading,
   connectorOverview,
   connectorIsRefetching,
+  connectorName,
 }: Props) {
   const navigate = useNavigate();
-  const connectorName = connectorOverview?.connectorInfo.connectorName;
-
   function navigateToTab(
     navigate: NavigateFunction,
     resourceTypeId: unknown

--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -183,6 +183,7 @@ function TopicDetails(props: TopicOverviewProps) {
         topicOverviewIsRefetching={topicIsRefetching}
         topicSchemas={schemaData}
         topicSchemasIsRefetching={schemaIsRefetching}
+        topicName={topicName}
       />
     </>
   );

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -22,6 +22,7 @@ type Props = {
   topicOverviewIsRefetching: boolean;
   topicSchemas?: TopicSchemaOverview;
   topicSchemasIsRefetching?: boolean;
+  topicName: string;
 };
 
 function TopicOverviewResourcesTabs({
@@ -35,9 +36,9 @@ function TopicOverviewResourcesTabs({
   topicOverviewIsRefetching,
   topicSchemas,
   topicSchemasIsRefetching,
+  topicName,
 }: Props) {
   const navigate = useNavigate();
-  const topicName = topicOverview?.topicInfo.topicName;
 
   function navigateToTab(
     navigate: NavigateFunction,
@@ -117,6 +118,7 @@ function TopicOverviewResourcesTabs({
         </Box>
       );
     }
+
     return (
       <div data-testid={"tabpanel-content"}>
         <Outlet
@@ -126,7 +128,7 @@ function TopicOverviewResourcesTabs({
             setSchemaVersion,
             topicOverview,
             topicOverviewIsRefetching,
-            topicName: topicOverview.topicInfo.topicName,
+            topicName: topicName,
             topicSchemas,
             topicSchemasIsRefetching,
             userCanDeleteTopic: topicOverview.topicInfo.topicDeletable,

--- a/coral/src/domain/topic/topic-api.ts
+++ b/coral/src/domain/topic/topic-api.ts
@@ -27,7 +27,7 @@ import {
   TopicOverview,
   TopicRequestApiResponse,
 } from "src/domain/topic/topic-types";
-import api, { API_PATHS } from "src/services/api";
+import api, { API_PATHS, KlawApiError } from "src/services/api";
 import { convertQueryValuesToString } from "src/services/api-helper";
 import {
   KlawApiModel,
@@ -312,7 +312,19 @@ const getTopicOverview = ({
       API_PATHS.getTopicOverview,
       new URLSearchParams(queryParams)
     )
-    .then(transformTopicOverviewResponse);
+    .then((topicOverview) => {
+      if (!topicOverview.topicExists) {
+        // Currently the API returns a reduced TopicOverview when
+        // a topic does not exist. In the future, it should return
+        // a 404. Until then, we're doing that ourself.
+        const topicDoesNotExistError: KlawApiError = {
+          message: "Topic does not exist",
+          success: false,
+        };
+        throw topicDoesNotExistError;
+      }
+      return transformTopicOverviewResponse(topicOverview);
+    });
 };
 
 const getSchemaOfTopic = (


### PR DESCRIPTION
# About this change - What it does


## Bug one
**(this all goes for connectors, too)**

`TopicOverview` has a property `topicInfoList` that, based on openapi, is required and always there (https://github.com/Aiven-Open/klaw/blob/main/openapi.yaml#L7691). But if a topic does not exist anymore, the endpoint `/getTopicOverview` will return a `TopicOverview` with _no_ `topicInfoList`. 

Since coral assumes based on typing a specific behaviour, this causes an error in our code, which leads to this error message for user:

<img width="432" alt="error-before" src="https://github.com/Aiven-Open/klaw/assets/943800/ebfda4bf-115c-42c1-817d-81a9a85d50d4">

We never get to the information that a topic does not exist, because the not-existent `topicInfoList` will throw an error before. 

This also means in the rest of the API the topic and topic-info will be treaded as existent.

There were two way to solve this:
1) (not done): mark `topicInfo` in our api types as optional. 
not done, because: 
- openapi def should be source of truth
- requires a lot of updates in code, because `topicInfo` will have to be handled as potential `undefined` everywhere 
- there should only be two case: 
    - Topic exists -> this is the TopicOverview with topic info
    - Topic does not exist -> no data for topic 

2) (done) when fetching the data from `getTopicOverview`, check if topic exists. If not, throw an error (that matches an api error from Klaw). This will show the correct error to user and UI rendering will be correct (based on: There is no topic)

Possible future improvement would be to return a `404` with a good error message from the backend (possible that Angular relies on the current response in case of a non existent topic though)

(adding @muralibasani  and @aindriu-aiven  to this issue in case you want to create a follow up issue)


## Bug two

If we have topic that is not existent, clicking another tab in the navigation will change topic name in URL to `undefined`, and then it really get's weird :D

<img width="870" alt="undefined" src="https://github.com/Aiven-Open/klaw/assets/943800/d6e0fe9b-9352-4cc2-9649-115cabb62f92">

This is because we assumes that the `topicName` will always be available on the topic info. In case there no info, the name will be `undefined`. 

To resolve this, we're passing the topicName from routing in `TopicDetails`. 
