### PR TITLE
feat(coral): Topic and Connector overview: keep Environment context while navigating and linking

### DIFF
--- a/coral/src/app/features/components/EntityDetailsHeader.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.tsx
@@ -6,10 +6,9 @@ import {
   Typography,
 } from "@aivenio/aquarium";
 import database from "@aivenio/aquarium/dist/src/icons/database";
-import { Dispatch, SetStateAction } from "react";
-import { EnvironmentInfo } from "src/domain/environment";
-import { InternalLinkButton } from "src/app/components/InternalLinkButton";
 import { DisabledButtonTooltip } from "src/app/components/DisabledButtonTooltip";
+import { InternalLinkButton } from "src/app/components/InternalLinkButton";
+import { EnvironmentInfo } from "src/domain/environment";
 
 type TopicOverviewHeaderProps = {
   entity: { name: string; type: "connector" | "topic" };
@@ -20,7 +19,7 @@ type TopicOverviewHeaderProps = {
   entityUpdating: boolean;
   environments?: EnvironmentInfo[];
   environmentId?: string;
-  setEnvironmentId: Dispatch<SetStateAction<string | undefined>>;
+  setEnvironmentId: (id: string) => void;
 };
 
 function EntityDetailsHeader(props: TopicOverviewHeaderProps) {

--- a/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
@@ -65,14 +65,22 @@ describe("EnvironmentStatus", () => {
       expect(button).toBeEnabled();
     });
   });
+
   describe("Refresh status", () => {
+    const originalConsoleError = console.error;
+
     beforeEach(() => {
+      console.error = jest.fn();
+
       customRender(<EnvironmentStatus envId="1" initialEnvStatus="ONLINE" />, {
         queryClient: true,
       });
     });
 
     afterEach(() => {
+      console.error = originalConsoleError;
+      jest.clearAllMocks();
+
       cleanup();
     });
 

--- a/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
@@ -97,10 +97,6 @@ describe("ConnectorDetails", () => {
           id: "CONNECTOR_OVERVIEW_TAB_ENUM_overview",
         },
       ]);
-      customRender(<ConnectorDetails connectorName={testConnectorName} />, {
-        memoryRouter: true,
-        queryClient: true,
-      });
     });
 
     afterEach(() => {
@@ -109,6 +105,10 @@ describe("ConnectorDetails", () => {
     });
 
     it("fetches connector overview and schema data on first load of page", async () => {
+      customRender(<ConnectorDetails connectorName={testConnectorName} />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
       expect(mockGetConnectorOverview).toHaveBeenNthCalledWith(1, {
         connectornamesearch: testConnectorName,
         environmentId: undefined,
@@ -116,6 +116,10 @@ describe("ConnectorDetails", () => {
     });
 
     it("updates the environment based on lowest environment of the connector", async () => {
+      customRender(<ConnectorDetails connectorName={testConnectorName} />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
       await waitFor(() => {
         expect(mockGetConnectorOverview).toHaveBeenNthCalledWith(2, {
           connectornamesearch: testConnectorName,
@@ -125,6 +129,10 @@ describe("ConnectorDetails", () => {
     });
 
     it("fetches the data anew when user changes environment", async () => {
+      customRender(<ConnectorDetails connectorName={testConnectorName} />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
       await waitForElementToBeRemoved(screen.getByPlaceholderText("Loading"));
 
       const select = await screen.findByRole("combobox", {
@@ -138,6 +146,21 @@ describe("ConnectorDetails", () => {
 
       await waitFor(() =>
         expect(mockGetConnectorOverview).toHaveBeenNthCalledWith(3, {
+          connectornamesearch: testConnectorName,
+          environmentId: testConnectorOverview.availableEnvironments[1].id,
+        })
+      );
+    });
+
+    it("fetches the correct data when URL has env search param", async () => {
+      customRender(<ConnectorDetails connectorName={testConnectorName} />, {
+        memoryRouter: true,
+        queryClient: true,
+        customRoutePath: "/?env=10",
+      });
+
+      await waitFor(() =>
+        expect(mockGetConnectorOverview).toHaveBeenCalledWith({
           connectornamesearch: testConnectorName,
           environmentId: testConnectorOverview.availableEnvironments[1].id,
         })

--- a/coral/src/app/features/connectors/details/ConnectorDetails.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.tsx
@@ -1,3 +1,4 @@
+import { Box, useToast } from "@aivenio/aquarium";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import {
@@ -5,7 +6,10 @@ import {
   useLocation,
   useMatches,
   useOutletContext,
+  useSearchParams,
 } from "react-router-dom";
+import { ClaimBanner } from "src/app/features/components/ClaimBanner";
+import { ClaimConfirmationModal } from "src/app/features/components/ClaimConfirmationModal";
 import { EntityDetailsHeader } from "src/app/features/components/EntityDetailsHeader";
 import { ConnectorOverviewResourcesTabs } from "src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs";
 import {
@@ -15,9 +19,6 @@ import {
 } from "src/app/router_utils";
 import { ConnectorOverview, requestConnectorClaim } from "src/domain/connector";
 import { getConnectorOverview } from "src/domain/connector/connector-api";
-import { Box, useToast } from "@aivenio/aquarium";
-import { ClaimBanner } from "src/app/features/components/ClaimBanner";
-import { ClaimConfirmationModal } from "src/app/features/components/ClaimConfirmationModal";
 import { HTTPError } from "src/services/api";
 import { parseErrorMsg } from "src/services/mutation-utils";
 
@@ -44,16 +45,19 @@ function findMatchingTab(
 
 function ConnectorDetails(props: ConnectorOverviewProps) {
   const { connectorName } = props;
+  // This state comes from the topic Link components in ConnectorTable
   const { state: initialEnvironment }: { state: string | null } = useLocation();
 
   const [showClaimModal, setShowClaimModal] = useState(false);
-  const [environmentId, setEnvironmentId] = useState<string | undefined>(
-    initialEnvironment ?? undefined
-  );
 
   const [claimErrorMessage, setClaimErrorMessage] = useState<
     string | undefined
   >();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState(
+    searchParams.get("env") ?? initialEnvironment ?? undefined
+  );
 
   const toast = useToast();
 
@@ -69,11 +73,11 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
     isRefetching: connectorIsRefetching,
     refetch: refetchConnectors,
   } = useQuery({
-    queryKey: ["connector-overview", connectorName, environmentId],
+    queryKey: ["connector-overview", connectorName, selectedEnvironmentId],
     queryFn: () =>
       getConnectorOverview({
         connectornamesearch: connectorName,
-        environmentId,
+        environmentId: selectedEnvironmentId,
       }),
   });
 
@@ -118,11 +122,15 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
   useEffect(() => {
     if (
       connectorData?.availableEnvironments !== undefined &&
-      environmentId === undefined
+      selectedEnvironmentId === undefined
     ) {
-      setEnvironmentId(connectorData?.availableEnvironments[0].id);
+      setSelectedEnvironmentId(connectorData?.availableEnvironments[0].id);
     }
-  }, [connectorData?.availableEnvironments, environmentId, setEnvironmentId]);
+  }, [
+    connectorData?.availableEnvironments,
+    selectedEnvironmentId,
+    setSelectedEnvironmentId,
+  ]);
 
   if (currentTab === undefined) {
     return (
@@ -158,10 +166,13 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
         entity={{ name: connectorName, type: "connector" }}
         entityExists={Boolean(connectorData?.connectorExists)}
         entityUpdating={connectorIsRefetching}
-        entityEditLink={`/connector/${connectorName}/request-update?env=${connectorData?.connectorInfo.environmentId}`}
+        entityEditLink={`/connector/${connectorName}/request-update?env=${selectedEnvironmentId}`}
         environments={connectorData?.availableEnvironments}
-        environmentId={environmentId}
-        setEnvironmentId={setEnvironmentId}
+        environmentId={selectedEnvironmentId}
+        setEnvironmentId={(id: string) => {
+          setSelectedEnvironmentId(id);
+          setSearchParams({ env: id });
+        }}
         showEditButton={Boolean(connectorData?.connectorInfo.showEditConnector)}
         hasPendingRequest={Boolean(connectorData?.connectorInfo.hasOpenRequest)}
       />
@@ -190,7 +201,7 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
         error={connectorError}
         isLoading={connectorIsLoading}
         currentTab={currentTab}
-        environmentId={environmentId}
+        environmentId={selectedEnvironmentId}
         connectorOverview={connectorData}
         connectorIsRefetching={connectorIsRefetching}
       />

--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -10,9 +10,9 @@ import userEvent from "@testing-library/user-event";
 import { TopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { TopicOverview, TopicSchemaOverview } from "src/domain/topic";
 import {
-  requestTopicClaim,
   getSchemaOfTopic,
   getTopicOverview,
+  requestTopicClaim,
 } from "src/domain/topic/topic-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
@@ -248,6 +248,34 @@ describe("TopicDetails", () => {
       await user.selectOptions(
         select,
         testTopicOverview.availableEnvironments[1].name
+      );
+
+      await waitFor(() =>
+        expect(mockGetTopicOverview).toHaveBeenCalledWith({
+          topicName: testTopicName,
+          environmentId: testTopicOverview.availableEnvironments[1].id,
+        })
+      );
+      // This is a dependent query relying on mockGetTopicOverview to have finished fetching
+      // So we need to await
+      await waitFor(() => {
+        expect(mockGetSchemaOfTopic).toHaveBeenCalledWith({
+          topicName: testTopicName,
+          kafkaEnvId: testTopicOverview.availableEnvironments[1].id,
+        });
+      });
+    });
+
+    it("fetches the correct data when URL has env search param", async () => {
+      customRender(
+        <AquariumContext>
+          <TopicDetails topicName={testTopicName} />
+        </AquariumContext>,
+        {
+          memoryRouter: true,
+          queryClient: true,
+          customRoutePath: "/?env=2",
+        }
       );
 
       await waitFor(() =>


### PR DESCRIPTION
# About this change - What it does

- add `env` search param when selecting different environments
- this allows to go back to previously selected environment when exiting `Edit` page or other navigation
- also allows direct linking to an entity in a specific env, instead of always linking to the lowest env by default


https://github.com/Aiven-Open/klaw/assets/20607294/05832f97-3199-4d73-8990-a269ad2589f1



Resolves: #1526
