### PR TITLE
fix(coral): Show environments:  Fix unable to refresh status after first two clicks

### DIFF
--- a/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
@@ -99,6 +99,7 @@ describe("EnvironmentStatus", () => {
 
       await userEvent.click(refreshButton);
 
+      expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
       expect(console.error).not.toHaveBeenCalled();
       expect(screen.getByText("Working")).toBeVisible();
     });
@@ -117,6 +118,7 @@ describe("EnvironmentStatus", () => {
 
       await userEvent.click(refreshButton);
 
+      expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
       expect(console.error).not.toHaveBeenCalled();
       expect(screen.getByText("Not working")).toBeVisible();
     });
@@ -132,6 +134,7 @@ describe("EnvironmentStatus", () => {
 
       await userEvent.click(refreshButton);
 
+      expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
       expect(screen.getByText("Working")).toBeVisible();
 
       await waitFor(() =>
@@ -143,6 +146,37 @@ describe("EnvironmentStatus", () => {
       );
 
       expect(console.error).toHaveBeenCalledWith(errorMessage);
+    });
+
+    it("allows to refetch status several times in a row", async () => {
+      mockGetUpdateEnvStatus.mockResolvedValue({
+        result: "success",
+        envStatus: "OFFLINE",
+      });
+
+      expect(screen.getByText("Working")).toBeVisible();
+
+      const refreshButton = screen.getByRole("button", {
+        name: "Refresh Environment status",
+      });
+
+      await userEvent.click(refreshButton);
+
+      expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
+      expect(console.error).not.toHaveBeenCalled();
+      expect(screen.getByText("Not working")).toBeVisible();
+
+      await userEvent.click(refreshButton);
+
+      expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
+      expect(console.error).not.toHaveBeenCalled();
+      expect(screen.getByText("Not working")).toBeVisible();
+
+      await userEvent.click(refreshButton);
+
+      expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
+      expect(console.error).not.toHaveBeenCalled();
+      expect(screen.getByText("Not working")).toBeVisible();
     });
   });
 });

--- a/coral/src/app/features/configuration/environments/components/EnvironmentStatus.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentStatus.tsx
@@ -31,11 +31,11 @@ const EnvironmentStatus = ({
   });
 
   useEffect(() => {
-    if (isSuccess) {
+    if (!isFetching && isSuccess) {
       setShouldUpdateStatus(false);
       setEnvStatus(updatedEnvStatus.envStatus);
     }
-    if (isError) {
+    if (!isFetching && isError) {
       setShouldUpdateStatus(false);
       toast({
         message: `Could not refresh Environment status: ${parseErrorMsg(
@@ -45,7 +45,7 @@ const EnvironmentStatus = ({
         variant: "danger",
       });
     }
-  }, [isSuccess, isError]);
+  }, [isSuccess, isError, isFetching]);
 
   if (isFetching || isRefetching) {
     return (

--- a/coral/src/app/features/configuration/environments/components/EnvironmentStatus.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentStatus.tsx
@@ -21,7 +21,6 @@ const EnvironmentStatus = ({
   const {
     data: updatedEnvStatus,
     isFetching,
-    isRefetching,
     isSuccess,
     isError,
     error,
@@ -47,7 +46,7 @@ const EnvironmentStatus = ({
     }
   }, [isSuccess, isError, isFetching]);
 
-  if (isFetching || isRefetching) {
+  if (isFetching) {
     return (
       <Box.Flex justifyContent="space-between">
         <StatusChip dense status="neutral" text="Refreshing..." />


### PR DESCRIPTION
# The problem
I discovered that in the Environments tables, the "update status" button would not work after the first two clicks (no API call dispatched, no loading state). This was because of the caching mechanism of react-query, which would keep the `isSuccess` value to `true` throughout the refetching. 


https://github.com/Aiven-Open/klaw/assets/20607294/da1fbc56-bc34-4c82-90c5-c429a7aff7d4



# The fix

- make the `useEffect` also dependent on `isFetching`
- remove `isRefecthing` use, as it is superfluous in this case
- improve tests


https://github.com/Aiven-Open/klaw/assets/20607294/dc36e0a6-9198-48c4-bd5b-b28f54ca8056


