### PR TITLE
Fix cluster connect url resttemplate, extend schema env length

### DIFF
--- a/core/src/main/java/io/aiven/klaw/model/requests/EnvModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/EnvModel.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 public class EnvModel implements Serializable {
 
   @NotNull
-  @Size(min = 2, max = 10, message = "Please fill in a valid name")
+  @Size(min = 2, max = 25, message = "Please fill in a valid name")
   @Pattern(message = "Invalid environment name !!", regexp = "^[a-zA-Z0-9_.-]{3,}$")
   private String name;
 

--- a/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ClusterApiService.java
@@ -3,7 +3,6 @@ package io.aiven.klaw.service;
 import static io.aiven.klaw.error.KlawErrorMessages.*;
 import static io.aiven.klaw.helpers.KwConstants.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.AclRequests;
 import io.aiven.klaw.dao.Env;
@@ -63,6 +62,7 @@ import java.util.UUID;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -126,7 +126,7 @@ public class ClusterApiService {
   }
 
   private RestTemplate getRestTemplate(String clusterConnectivityUrl) {
-    if (clusterConnectivityUrl == null) {
+    if (StringUtils.isEmpty(clusterConnectivityUrl)) {
       clusterConnectivityUrl = clusterConnUrl;
     }
     if (clusterConnectivityUrl.toLowerCase().startsWith("https")) {

--- a/core/src/main/resources/db/changelog/changelog.yaml
+++ b/core/src/main/resources/db/changelog/changelog.yaml
@@ -1199,3 +1199,11 @@ databaseChangeLog:
                     name: otherparams
                     type: VARCHAR(150)
               tableName: kwoperationalrequests
+    - changeSet:
+        id: 21-09-2023 Modify column envname extend length in kwenv table
+        author: muralibasani
+        changes:
+          - modifyDataType:
+              columnName: envname
+              newDataType: VARCHAR(25)
+              tableName: kwenv

--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -953,9 +953,9 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                     return;
                 }
 
-                if($scope.addNewSchemaEnv.envname.length > 10)
+                if($scope.addNewSchemaEnv.envname.length > 25)
                 {
-                    $scope.alertnote = "Environment name cannot be more than 10 characters.";
+                    $scope.alertnote = "Environment name cannot be more than 25 characters.";
                     $scope.showAlertToast();
                     return;
                 }

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -644,9 +644,9 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                         return;
                     }
 
-                    if($scope.envDetails.name.length > 10)
+                    if($scope.envDetails.name.length > 25)
                     {
-                        $scope.alertnote = "Environment name cannot be more than 10 characters.";
+                        $scope.alertnote = "Environment name cannot be more than 25 characters.";
                         $scope.showAlertToast();
                         return;
                     }

--- a/core/src/main/resources/templates/addSchemaEnv.html
+++ b/core/src/main/resources/templates/addSchemaEnv.html
@@ -489,7 +489,7 @@
 										<div class="col-md-6">
 											<div class="form-group">
 												<label class="control-label">Environment Name</label>
-												<input type="text" class="form-control" maxlength="7" required ng-model="addNewSchemaEnv.envname" placeholder="DEV_SCH"/>
+												<input type="text" class="form-control" maxlength="25" required ng-model="addNewSchemaEnv.envname" placeholder="DEV_SCH"/>
 												<small class="form-control-feedback">(No spaces)</small>
 											</div>
 										</div>

--- a/core/src/main/resources/templates/modifyEnv.html
+++ b/core/src/main/resources/templates/modifyEnv.html
@@ -655,7 +655,7 @@
 										<div class="col-md-6">
 											<div class="form-group">
 												<label class="control-label">Environment Name</label>
-												<input type="text" class="form-control" maxlength="10" minlength="2" required ng-model="envDetails.name" placeholder="DEV_SCH"/>
+												<input type="text" class="form-control" maxlength="25" minlength="2" required ng-model="envDetails.name" placeholder="DEV_SCH"/>
 
 											</div>
 										</div>

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -1213,7 +1213,7 @@ public class TopicAclControllerIT {
     envModelSch.setClusterId(3);
     envModelSch.setType(KafkaClustersType.SCHEMA_REGISTRY.value);
     EnvTag envTag = new EnvTag();
-    envTag.setName("SCHD");
+    envTag.setName("SCHEMA_ENVIRONMENT_DEV");
     envTag.setId("1");
     envModelSch.setAssociatedEnv(envTag);
     String jsonReqSch = OBJECT_MAPPER.writer().writeValueAsString(envModelSch);

--- a/core/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
@@ -202,7 +202,7 @@ public class UiConfigControllerTest {
   @Order(9)
   public void addNewEnvMoreThan10CharsFailure() throws Exception {
     EnvModel env = utilMethods.getEnvListToAdd().get(0);
-    env.setName("ABCDEFGHIJKL"); // > 10 chars, not allowed
+    env.setName("ABCDEFGHIJKLfkjdshfkjhasdkjfhaskjfhkshdfkjhasdk"); // > 25 chars, not allowed
     String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(env);
     ApiResponse apiResponse = ApiResponse.FAILURE;
     when(envsClustersTenantsControllerService.addNewEnv(any())).thenReturn(apiResponse);


### PR DESCRIPTION
About this change - What it does

- cluster api url - connectivity bug fix for resttemplate
- extend length of environments table (schema env)

Resolves: #1787 
Why this way
