### PR TITLE
refactor(coral): Use new property `hasOpenRequestOnEnyEnv` for Claim Banners

### DIFF
--- a/coral/src/app/features/components/ClaimBanner.test.tsx
+++ b/coral/src/app/features/components/ClaimBanner.test.tsx
@@ -12,7 +12,7 @@ const testProps = {
   claimEntity: mockClaimEntity,
   isError: false,
   hasOpenClaimRequest: false,
-  hasOpenRequest: false,
+  hasOpenRequestOnAnyEnv: false,
   entityOwner: "teamname",
 };
 
@@ -70,7 +70,7 @@ describe("ClaimBanner", () => {
           <ClaimBanner
             {...testProps}
             entityType={"topic"}
-            hasOpenRequest={true}
+            hasOpenRequestOnAnyEnv={true}
           />
         );
       });
@@ -92,7 +92,7 @@ describe("ClaimBanner", () => {
           <ClaimBanner
             {...testProps}
             entityType={"connector"}
-            hasOpenRequest={true}
+            hasOpenRequestOnAnyEnv={true}
           />
         );
       });
@@ -115,7 +115,7 @@ describe("ClaimBanner", () => {
             {...testProps}
             entityType={"topic"}
             hasOpenClaimRequest={true}
-            hasOpenRequest={true}
+            hasOpenRequestOnAnyEnv={true}
           />,
           {
             memoryRouter: true,
@@ -151,7 +151,7 @@ describe("ClaimBanner", () => {
             {...testProps}
             entityType={"connector"}
             hasOpenClaimRequest={true}
-            hasOpenRequest={true}
+            hasOpenRequestOnAnyEnv={true}
           />,
           {
             memoryRouter: true,

--- a/coral/src/app/features/components/ClaimBanner.tsx
+++ b/coral/src/app/features/components/ClaimBanner.tsx
@@ -5,7 +5,7 @@ import illustration from "src/app/images/topic-details-banner-Illustration.svg";
 interface ClaimBannerProps {
   entityType: "topic" | "connector";
   entityName: string;
-  hasOpenRequest: boolean;
+  hasOpenRequestOnAnyEnv: boolean;
   hasOpenClaimRequest: boolean;
   claimEntity: () => void;
   isError: boolean;
@@ -17,14 +17,14 @@ const ClaimBanner = ({
   entityType,
   entityName,
   hasOpenClaimRequest,
-  hasOpenRequest,
+  hasOpenRequestOnAnyEnv,
   claimEntity,
   isError,
   errorMessage,
   entityOwner,
 }: ClaimBannerProps) => {
-  // if there is an open claim request, hasOpenRequest is true, too
-  if (hasOpenRequest && !hasOpenClaimRequest) {
+  // if there is an open claim request, hasOpenRequestOnAnyEnv is true, too
+  if (hasOpenRequestOnAnyEnv && !hasOpenClaimRequest) {
     // We do not render an InternalLinkButton to the Requests page for this state...
     // .. because a user cannot see the requests opened by members of other teams
     return (

--- a/coral/src/app/features/connectors/details/ConnectorDetails.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.tsx
@@ -187,7 +187,9 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
                 connectorData?.connectorInfo.hasOpenClaimRequest
               }
               entityOwner={connectorData.connectorInfo.teamName}
-              hasOpenRequest={connectorData?.connectorInfo.hasOpenRequest}
+              hasOpenRequestOnAnyEnv={
+                connectorData?.connectorInfo.hasOpenRequestOnAnyEnv
+              }
               claimEntity={() => setShowClaimModal(true)}
               isError={isErrorCreateClaimConnectorRequest}
               errorMessage={claimErrorMessage}

--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -178,7 +178,9 @@ function TopicDetails(props: TopicOverviewProps) {
               entityName={topicName}
               hasOpenClaimRequest={topicData?.topicInfo.hasOpenClaimRequest}
               entityOwner={topicData.topicInfo.teamname}
-              hasOpenRequest={topicData?.topicInfo.hasOpenRequest}
+              hasOpenRequestOnAnyEnv={
+                topicData?.topicInfo.hasOpenRequestOnAnyEnv
+              }
               claimEntity={() => setShowClaimModal(true)}
               isError={createClaimTopicRequestIsError}
               errorMessage={claimErrorMessage}


### PR DESCRIPTION
# Linked issue

Resolves: #1756 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

If a topic/connector has an open promotion request, users from different team will see the "you can claim this" banner and be able to do a claim request. This can cause all kind of messes, e.g. a topic on different environments belonging to different teams etc.  Reason was that the property `hasOpenRequest`, that we used to check that, only checks request on the current environment, but a promotion request belongs to the target env. 

# What is the new behavior?

We have a new property in the backend, `hasOpenRequestOnAnyEnv` that, well, shows if there is any request open on any env. We now use this to decide how the claim banner looks and if user can claim. 

- [x] The commit message follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (for bug fixes / features)
