### PR TITLE
Use getCountRegisterUsersInfoForTenant instead of getAllRegisterUsersInfoForTenant if possible

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -263,6 +263,8 @@ public interface HandleDbRequests {
 
   List<RegisterUserInfo> getAllRegisterUsersInfoForTenant(int tenantId);
 
+  int getCountRegisterUsersInfoForTenant(int tenantId);
+
   List<RegisterUserInfo> getAllRegisterUsersInformation();
 
   RegisterUserInfo getFirstStagingRegisterUsersInfo(String userName);

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -598,6 +598,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public int getCountRegisterUsersInfoForTenant(int tenantId) {
+    return jdbcSelectHelper.countRegisterUsersInfoForTenant(tenantId);
+  }
+
+  @Override
   public List<RegisterUserInfo> getAllRegisterUsersInformation() {
     return jdbcSelectHelper.selectAllRegisterUsersInfo();
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1059,6 +1059,10 @@ public class SelectDataJdbc {
     return registerInfoRepo.findAllByStatusAndTenantId("PENDING", tenantId);
   }
 
+  public int countRegisterUsersInfoForTenant(int tenantId) {
+    return registerInfoRepo.countByStatusAndTenantId("PENDING", tenantId);
+  }
+
   public List<RegisterUserInfo> selectAllRegisterUsersInfo() {
     return registerInfoRepo.findAllByStatus("PENDING");
   }

--- a/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
@@ -10,6 +10,8 @@ public interface RegisterInfoRepo extends CrudRepository<RegisterUserInfo, Strin
 
   List<RegisterUserInfo> findAllByStatusAndTenantId(String status, int tenantId);
 
+  int countByStatusAndTenantId(String status, int tenantId);
+
   List<RegisterUserInfo> findAllByStatus(String status);
 
   List<RegisterUserInfo> findAllByTenantId(int tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.AclRequests;
 import io.aiven.klaw.dao.KafkaConnectorRequest;
-import io.aiven.klaw.dao.RegisterUserInfo;
 import io.aiven.klaw.dao.SchemaRequest;
 import io.aiven.klaw.dao.TopicRequest;
 import io.aiven.klaw.dao.UserInfo;
@@ -242,8 +241,6 @@ public class UtilControllerService implements InitializingBean {
       allConnectorReqs = new ArrayList<>();
     }
 
-    List<RegisterUserInfo> allUserReqs = reqsHandle.getAllRegisterUsersInfoForTenant(tenantId);
-
     countList.put("topics", allTopicReqs.size() + "");
     countList.put("acls", allAclReqs.size() + "");
     countList.put("schemas", allSchemaReqs.size() + "");
@@ -253,7 +250,7 @@ public class UtilControllerService implements InitializingBean {
         getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
       countList.put("users", "0");
     } else {
-      countList.put("users", allUserReqs.size() + "");
+      countList.put("users", reqsHandle.getCountRegisterUsersInfoForTenant(tenantId) + "");
     }
 
     return countList;


### PR DESCRIPTION
The PR makes use  of `getCountRegisterUsersInfoForTenant` rather than getAllRegisterUsersInfoForTenant 
also it does it in lazy mode instead of invoking it always

# Linked issue

Resolves: #xxxxx

# What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update


