### PR TITLE
Bump lombok version to allow build it with jdk21

### DIFF
--- a/.github/workflows/jobs-maven.yaml
+++ b/.github/workflows/jobs-maven.yaml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [17, 20]
+        java-version: [17, 21]
         runs-on: [ubuntu-latest]
     name: Jdk ${{ matrix.java-version }}, os ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <httpclient5.version>5.2.1</httpclient5.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <jjwt.version>0.11.5</jjwt.version>
+        <lombok.version>1.18.30</lombok.version>
         <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <snakeyaml.version>2.2</snakeyaml.version>
@@ -87,6 +88,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The problem with current lombok version is that build fails with an attempt to build it with jdk21
because of this issue https://github.com/projectlombok/lombok/issues/3393
which has been fixed in 1.8.30

so to have it working need to bump lombok a bit

PS: so far GH does not support jdk21 `temurin` that's why I didn't update GHA
however it supports jdk21 `corretto` (AWS jdk build) we could either wait for `temurin` or try it with `corretto`
