### PR TITLE
Add timestamps to status check, remove reloading of cache on the hour.

### DIFF
--- a/core/src/test/java/io/aiven/klaw/service/EnvControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/EnvControllerServiceTest.java
@@ -73,8 +73,6 @@ class EnvControllerServiceTest {
     envControllerService.loadEnvsWithStatus();
 
     Mockito.verify(handleDbRequestsJdbc, Mockito.times(3)).addNewEnv(env);
-    Mockito.verify(manageDatabase, Mockito.times(3))
-        .loadEnvMapForOneTenant(TestConstants.TENANT_ID);
     Assertions.assertEquals(env.getEnvStatus(), ClusterStatus.ONLINE);
   }
 }


### PR DESCRIPTION
# Linked issue

Resolves: #1773 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

It was noted that the auto environment check was not adding the time stamp to when the environment was checked.

# What is the new behavior?

The envStatus timestamp is now added to the env object, and the also the reload cache function was removed as it was not required to keep the cache in sync.

# Other information:

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Please check if the PR fulfills these requirements

- [x] The commit message follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (for bug fixes / features)
