### PR TITLE
fix(coral): Exclude api.d.ts from lint-staged, add md linting

### DIFF
--- a/coral/package.json
+++ b/coral/package.json
@@ -30,11 +30,11 @@
     "add-precommit": "git config --local core.hooksPath .githooks/"
   },
   "lint-staged": {
-    "**/*.{ts,tsx,js}": [
+    "**/!(*api.d).{ts,tsx,js}": [
       "prettier --check",
       "eslint"
     ],
-    "**/*.css": [
+    "**/*.{md, css}": [
       "prettier --check"
     ],
     "../openapi.yaml": [

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -17,11 +17,11 @@
     "tsc": "tsc -p tsconfig.json"
   },
   "lint-staged": {
-    "**/*.{ts,tsx,js}": [
+    "**/!(*api.d).{ts,tsx,js}": [
       "prettier --check",
       "eslint"
     ],
-    "**/*.css": [
+    "**/*.{md, css}": [
       "prettier --check"
     ]
   },


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

If the generated `api.d.ts` breaks one of our linting rules, it will be prevented from being committed by the pre-commit `lint-staged` rules. This is undesirable, as it is an automatically generated file that no human should edit.

<img width="749" alt="Screenshot 2023-10-05 at 16 21 11" src="https://github.com/Aiven-Open/klaw/assets/20607294/eb06a1b1-bcf4-42e4-82b6-35485a0f4058">

# What is the new behavior?

- Exclude `api.d.ts` from being formetted and linted
- Adds a rule to check Prettier formatting of md files


# Please check if the PR fulfills these requirements

- [x] The commit message follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (for bug fixes / features)
