### PR TITLE
fix(coral): Replace `direction` by `flexDirection` on `Box.Flex`

### DIFF
--- a/coral/src/app/features/components/AclDetailsModalContent.tsx
+++ b/coral/src/app/features/components/AclDetailsModalContent.tsx
@@ -31,7 +31,7 @@ const TopicDetailsModalContent = ({ request }: DetailsModalContentProps) => {
 
   return (
     <Grid htmlTag={"dl"} cols={"2"} rows={"6"} rowGap={"6"}>
-      <Box.Flex direction={"column"} width={"min"}>
+      <Box.Flex flexDirection={"column"} width={"min"}>
         <Label>ACL type</Label>
         <dd>
           <StatusChip
@@ -40,26 +40,26 @@ const TopicDetailsModalContent = ({ request }: DetailsModalContentProps) => {
           />
         </dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requesting team</Label>
         <dd>{requestingTeamName}</dd>
       </Box.Flex>
 
-      <Box.Flex direction={"column"} width={"min"}>
+      <Box.Flex flexDirection={"column"} width={"min"}>
         <Label>Environment</Label>
         <dd>
           <StatusChip status={"neutral"} text={environmentName} />
         </dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Topic</Label>
         <dd>{topicname}</dd>
       </Box.Flex>
 
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Principals/Usernames</Label>
-          <Box.Flex direction={"row"} gap={"2"} component={"ul"}>
+          <Box.Flex flexDirection={"row"} gap={"2"} component={"ul"}>
             {acl_ssl.map((principal) => (
               <li key={principal}>
                 <dd>
@@ -73,9 +73,9 @@ const TopicDetailsModalContent = ({ request }: DetailsModalContentProps) => {
 
       {acl_ip.length > 0 && (
         <GridItem colSpan={"span-2"}>
-          <Box.Flex direction={"column"}>
+          <Box.Flex flexDirection={"column"}>
             <Label>IP addresses</Label>
-            <Box.Flex direction={"row"} gap={"2"} component={"ul"}>
+            <Box.Flex flexDirection={"row"} gap={"2"} component={"ul"}>
               {acl_ip.map((ip) => (
                 <li key={ip}>
                   <dd>
@@ -89,7 +89,7 @@ const TopicDetailsModalContent = ({ request }: DetailsModalContentProps) => {
       )}
 
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Consumer group</Label>
           <dd>
             {
@@ -107,17 +107,17 @@ const TopicDetailsModalContent = ({ request }: DetailsModalContentProps) => {
       </GridItem>
 
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Message for approval</Label>
           <dd>{remarks || <i>No message</i>}</dd>
         </Box.Flex>
       </GridItem>
 
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested by</Label>
         <dd>{requestor}</dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested on</Label>
         <dd>{requesttimestring} UTC</dd>
       </Box.Flex>

--- a/coral/src/app/features/components/ConnectorDetailsModalContent.tsx
+++ b/coral/src/app/features/components/ConnectorDetailsModalContent.tsx
@@ -17,13 +17,13 @@ function ConnectorRequestDetails(props: DetailsModalContentProps) {
   if (!request) return null;
   return (
     <Grid htmlTag={"dl"} cols={"2"} rowGap={"6"}>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Environment</Label>
         <dd>
           <StatusChip text={request.environmentName} />
         </dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Connector name</Label>
         <dd>{request.connectorName}</dd>
       </Box.Flex>
@@ -33,7 +33,7 @@ function ConnectorRequestDetails(props: DetailsModalContentProps) {
         <dd>{request.description}</dd>
       </GridItem>
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Connector configuration</Label>
           <dd>
             <MonacoEditor
@@ -59,17 +59,17 @@ function ConnectorRequestDetails(props: DetailsModalContentProps) {
       </GridItem>
 
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Message for approval</Label>
           <dd>{request.remarks || <i>No message</i>}</dd>
         </Box.Flex>
       </GridItem>
 
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested by</Label>
         <dd>{request.requestor}</dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested on</Label>
         <dd>{request.requesttimestring} UTC</dd>
       </Box.Flex>

--- a/coral/src/app/features/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.tsx
@@ -16,13 +16,13 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
   if (!request) return null;
   return (
     <Grid htmlTag={"dl"} cols={"2"} rowGap={"6"}>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Environment</Label>
         <dd>
           <StatusChip text={request.environmentName} />
         </dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Topic name</Label>
         <dd>{request.topicname}</dd>
       </Box.Flex>
@@ -32,7 +32,7 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
         <dd>{request.schemaversion}</dd>
       </GridItem>
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Schema preview</Label>
           <dd>
             <MonacoEditor
@@ -58,17 +58,17 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
       </GridItem>
 
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Message for approval</Label>
           <dd>{request.remarks || <i>No message</i>}</dd>
         </Box.Flex>
       </GridItem>
 
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested by</Label>
         <dd>{request.requestor}</dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested on</Label>
         <dd>{request.requesttimestring} UTC</dd>
       </Box.Flex>

--- a/coral/src/app/features/components/TopicDetailsModalContent.tsx
+++ b/coral/src/app/features/components/TopicDetailsModalContent.tsx
@@ -55,41 +55,41 @@ const TopicDetailsModalContent = ({
 
   return (
     <Grid htmlTag={"dl"} cols={"2"} rowGap={"6"}>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Environment</Label>
         <dd>
           <StatusChip status={"neutral"} text={environmentName} />
         </dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Request type</Label>
         <dd>
           <StatusChip status={"neutral"} text={requestOperationType} />
         </dd>
       </Box.Flex>
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Topic</Label>
           <dd>{topicname}</dd>
         </Box.Flex>
       </GridItem>
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Topic description</Label>
           <dd>{description}</dd>
         </Box.Flex>
       </GridItem>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Topic partition</Label>
         <dd>{topicpartitions}</dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Topic replication factor</Label>
         <dd>{replicationfactor}</dd>
       </Box.Flex>
       {hasAdvancedConfig && (
         <GridItem colSpan={"span-2"}>
-          <Box.Flex direction={"column"}>
+          <Box.Flex flexDirection={"column"}>
             <Label>Advanced configuration</Label>
             <BorderBox borderColor={"grey-20"}>
               <MonacoEditor
@@ -114,16 +114,16 @@ const TopicDetailsModalContent = ({
         </GridItem>
       )}
       <GridItem colSpan={"span-2"}>
-        <Box.Flex direction={"column"}>
+        <Box.Flex flexDirection={"column"}>
           <Label>Message for approval</Label>
           <dd>{remarks || <i>No message</i>}</dd>
         </Box.Flex>
       </GridItem>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested by</Label>
         <dd>{requestor}</dd>
       </Box.Flex>
-      <Box.Flex direction={"column"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Requested on</Label>
         <dd>{requesttimestring} UTC</dd>
       </Box.Flex>

--- a/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
+++ b/coral/src/app/features/topics/request/components/AdvancedConfiguration.tsx
@@ -67,7 +67,7 @@ function AdvancedConfiguration({ name }: Props) {
   }
 
   return (
-    <Box.Flex gap={"l1"} direction={"column"}>
+    <Box.Flex gap={"l1"} flexDirection={"column"}>
       <Typography.Subheading>
         Advanced Topic Configuration
       </Typography.Subheading>


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

We replaced the deprecated `Flexbox` by `Box.Flex`. However, the `direction` prop that was on `Flexbox` has been replaced by `flexDirection` on `Box.Flex`. This results in broken layouts, as the `direction` attribute is applied to the underlying `div` (which does nothing)

<img width="626" alt="Screenshot 2023-10-09 at 15 12 58" src="https://github.com/Aiven-Open/klaw/assets/20607294/0321eff4-1f04-42ea-be90-93e84f7d0df6">



<img width="1216" alt="Screenshot 2023-10-09 at 15 23 42" src="https://github.com/Aiven-Open/klaw/assets/20607294/fbe53553-a7cd-4478-a29a-7346ae4c778d">


# What is the new behavior?

Restore correct layout by using the correct prop.


# Please check if the PR fulfills these requirements

- [x] The commit message follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (for bug fixes / features)
