### PR TITLE
Use countByTeamIdAndTenantId for counting instead of select all

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -426,8 +426,7 @@ public class SelectDataJdbc {
     }
     dashboardStats.setConsumerCount(countConsumers);
 
-    List<UserInfo> allUsers = userInfoRepo.findAllByTeamIdAndTenantId(teamId, tenantId);
-    dashboardStats.setTeamMembersCount(allUsers.size());
+    dashboardStats.setTeamMembersCount(userInfoRepo.countByTeamIdAndTenantId(teamId, tenantId));
 
     return dashboardStats;
   }

--- a/core/src/main/java/io/aiven/klaw/repository/UserInfoRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/UserInfoRepo.java
@@ -16,6 +16,8 @@ public interface UserInfoRepo extends CrudRepository<UserInfo, String> {
 
   List<UserInfo> findAllByTeamIdAndTenantId(Integer teamId, int tenantId);
 
+  int countByTeamIdAndTenantId(Integer teamId, int tenantId);
+
   boolean existsByTeamIdAndTenantId(Integer teamId, int tenantId);
 
   void deleteByTenantId(int tenantId);


### PR DESCRIPTION
In `SelectDataJdbc#getDashboardStats` it's better to use count query instead of select all to get number of rows