### PR TITLE
Remove  useless guava version

### DIFF
--- a/cluster-api/pom.xml
+++ b/cluster-api/pom.xml
@@ -22,7 +22,6 @@
         <java.version>17</java.version>
         <!-- the list is sorted-->
         <apache.commons.lang.version>3.13.0</apache.commons.lang.version>
-        <guava.version>31.1-jre</guava.version>
         <kafka.version>3.5.1</kafka.version>
         <kafka.client.version>3.5.1</kafka.client.version>
         <mockserver.version>5.15.0</mockserver.version>


### PR DESCRIPTION
There is a guava version configured in parent pom and there is not need to have another one
Moreover this one isn't used and not updated (from parent it is alredey referenced to guava 32.x while this only to 31.x)