### PR TITLE
Use int for count query instead of list of array of objects

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1566,7 +1566,7 @@ public class SelectDataJdbc {
   }
 
   public int getAllTopicsCountInAllTenants() {
-    return ((Long) topicRepo.findAllTopicsCount().get(0)[0]).intValue();
+    return topicRepo.findAllTopicsCount();
   }
 
   // teamId is requestedBy. For 'topics' all the requests are assigned to the same team, except

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
@@ -39,7 +39,7 @@ public interface TopicRepo extends CrudRepository<Topic, TopicID> {
   List<Object[]> findAllTopicsGroupByTeamId(@Param("tenantId") Integer tenantId);
 
   @Query(value = "select count(*) from kwtopics", nativeQuery = true)
-  List<Object[]> findAllTopicsCount();
+  int findAllTopicsCount();
 
   @Query(
       value = "select count(*) from kwtopics where teamid = :teamIdVar and tenantid = :tenantId",


### PR DESCRIPTION
count query always returns a number even if there is no data at all it will return zero
so no need for usage of arrays, lists or optionals