### PR TITLE
fix(coral): Add keepPreviousData to getPaginatedEnvironments

### DIFF
--- a/coral/src/app/features/configuration/environments/hooks/getPaginatedEnvironments.tsx
+++ b/coral/src/app/features/configuration/environments/hooks/getPaginatedEnvironments.tsx
@@ -53,6 +53,7 @@ const getPaginatedEnvironments = ({
           pageNo: String(currentPage),
           searchEnvParam: search.length === 0 ? undefined : search,
         }),
+      keepPreviousData: true,
     }
   );
   return {


### PR DESCRIPTION
# Linked issue

Resolves: #1894

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The Environments tables flash the loading state when filtering.

# What is the new behavior?

The Environments tables *do not* flash loading state when filtering


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
