### PR TITLE
feat(coral): Add force register to flow and tables

### DIFF
--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -61,7 +61,7 @@ const mockedRequests: SchemaRequest[] = [
     currentPage: "1",
     deletable: false,
     editable: false,
-    forceRegister: false,
+    forceRegister: true,
   },
 ];
 
@@ -79,6 +79,7 @@ describe("SchemaApprovalsTable", () => {
     { columnHeader: "Environment", relatedField: "environmentName" },
     { columnHeader: "Status", relatedField: "requestStatus" },
     { columnHeader: "Request type", relatedField: "requestOperationType" },
+    { columnHeader: "Force register", relatedField: "forceRegister" },
     { columnHeader: "Requested by", relatedField: "requestor" },
     { columnHeader: "Requested on", relatedField: "requesttimestring" },
     { columnHeader: "Details", relatedField: null },
@@ -277,6 +278,10 @@ describe("SchemaApprovalsTable", () => {
 
             if (column.columnHeader === "Request type") {
               text = requestOperationTypeNameMap[field as RequestOperationType];
+            }
+
+            if (column.columnHeader === "Force register") {
+              text = field ? "Yes" : "";
             }
 
             const cell = within(table).getByRole("cell", { name: text });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -79,7 +79,7 @@ describe("SchemaApprovalsTable", () => {
     { columnHeader: "Environment", relatedField: "environmentName" },
     { columnHeader: "Status", relatedField: "requestStatus" },
     { columnHeader: "Request type", relatedField: "requestOperationType" },
-    { columnHeader: "Force register", relatedField: "forceRegister" },
+    { columnHeader: "Additional notes", relatedField: "forceRegister" },
     { columnHeader: "Requested by", relatedField: "requestor" },
     { columnHeader: "Requested on", relatedField: "requesttimestring" },
     { columnHeader: "Details", relatedField: null },
@@ -280,8 +280,8 @@ describe("SchemaApprovalsTable", () => {
               text = requestOperationTypeNameMap[field as RequestOperationType];
             }
 
-            if (column.columnHeader === "Force register") {
-              text = field ? "Yes" : "";
+            if (column.columnHeader === "Additional notes") {
+              text = field ? "Force register applied" : "";
             }
 
             const cell = within(table).getByRole("cell", { name: text });

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -82,17 +82,6 @@ function SchemaApprovalsTable({
         };
       },
     },
-    {
-      type: "custom",
-      field: "forceRegister",
-      headerName: "Force register",
-      UNSAFE_render: ({ forceRegister }: { forceRegister: boolean }) => {
-        if (forceRegister) {
-          return <StatusChip text={"Yes"} status={"danger"} dense={true} />;
-        }
-      },
-    },
-
     { type: "text", field: "requestor", headerName: "Requested by" },
     {
       type: "text",
@@ -100,6 +89,22 @@ function SchemaApprovalsTable({
       headerName: "Requested on",
       formatter: (value) => {
         return `${value}${"\u00A0"}UTC`;
+      },
+    },
+    {
+      type: "custom",
+      field: "forceRegister",
+      headerName: "Additional notes",
+      UNSAFE_render: ({ forceRegister }: { forceRegister: boolean }) => {
+        if (forceRegister) {
+          return (
+            <StatusChip
+              text={"Force register applied"}
+              status={"danger"}
+              dense={true}
+            />
+          );
+        }
       },
     },
     {

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.tsx
@@ -1,4 +1,9 @@
-import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import {
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  StatusChip,
+} from "@aivenio/aquarium";
 import { SchemaRequest } from "src/domain/schema-request";
 import infoSign from "@aivenio/aquarium/icons/infoSign";
 import tickCircle from "@aivenio/aquarium/icons/tickCircle";
@@ -21,6 +26,7 @@ interface SchemaRequestTableData {
   requesttimestring: SchemaRequest["requesttimestring"];
   requestStatus: SchemaRequest["requestStatus"];
   requestOperationType: SchemaRequest["requestOperationType"];
+  forceRegister: SchemaRequest["forceRegister"];
 }
 
 type SchemaApprovalsTableProps = {
@@ -76,6 +82,17 @@ function SchemaApprovalsTable({
         };
       },
     },
+    {
+      type: "custom",
+      field: "forceRegister",
+      headerName: "Force register",
+      UNSAFE_render: ({ forceRegister }: { forceRegister: boolean }) => {
+        if (forceRegister) {
+          return <StatusChip text={"Yes"} status={"danger"} dense={true} />;
+        }
+      },
+    },
+
     { type: "text", field: "requestor", headerName: "Requested by" },
     {
       type: "text",
@@ -152,6 +169,7 @@ function SchemaApprovalsTable({
         requesttimestring: request.requesttimestring,
         requestStatus: request.requestStatus,
         requestOperationType: request.requestOperationType,
+        forceRegister: request.forceRegister,
       };
     }
   );

--- a/coral/src/app/features/components/SchemaRequestDetails.test.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.test.tsx
@@ -136,7 +136,8 @@ describe("SchemaRequestDetails", () => {
 
       expect(term).toBeVisible();
       expect(definition).toHaveTextContent(
-        "Warning: This schema is being force registered. This will override standard validation process of the schema registry."
+        "Warning: This schema is being force registered. This will override standard validation process of the" +
+        " schema registry. Learn more"
       );
     });
   });

--- a/coral/src/app/features/components/SchemaRequestDetails.test.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.test.tsx
@@ -112,4 +112,32 @@ describe("SchemaRequestDetails", () => {
       expect(definition).toHaveTextContent(testRequest.requesttimestring);
     });
   });
+
+  describe("renders an optional field when for force register", () => {
+    afterEach(cleanup);
+
+    it("shows no field when forceRegister is false", () => {
+      render(<SchemaRequestDetails request={testRequest} />);
+
+      const term = screen.queryByText("Force register");
+
+      expect(term).not.toBeInTheDocument();
+    });
+
+    it("shows a field when forceRegister is true", () => {
+      render(
+        <SchemaRequestDetails
+          request={{ ...testRequest, forceRegister: true }}
+        />
+      );
+
+      const term = findTerm("Force register");
+      const definition = findDefinition(term);
+
+      expect(term).toBeVisible();
+      expect(definition).toHaveTextContent(
+        "Warning: This schema is being force registered. This will override standard validation process of the schema registry."
+      );
+    });
+  });
 });

--- a/coral/src/app/features/components/SchemaRequestDetails.test.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.test.tsx
@@ -119,7 +119,7 @@ describe("SchemaRequestDetails", () => {
     it("shows no field when forceRegister is false", () => {
       render(<SchemaRequestDetails request={testRequest} />);
 
-      const term = screen.queryByText("Force register");
+      const term = screen.queryByText("Force register applied");
 
       expect(term).not.toBeInTheDocument();
     });
@@ -131,7 +131,7 @@ describe("SchemaRequestDetails", () => {
         />
       );
 
-      const term = findTerm("Force register");
+      const term = findTerm("Force register applied");
       const definition = findDefinition(term);
 
       expect(term).toBeVisible();

--- a/coral/src/app/features/components/SchemaRequestDetails.test.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.test.tsx
@@ -137,7 +137,7 @@ describe("SchemaRequestDetails", () => {
       expect(term).toBeVisible();
       expect(definition).toHaveTextContent(
         "Warning: This schema is being force registered. This will override standard validation process of the" +
-        " schema registry. Learn more"
+          " schema registry. Learn more"
       );
     });
   });

--- a/coral/src/app/features/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.tsx
@@ -41,7 +41,16 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
             {" "}
             <Typography.Small>
               Warning: This schema is being force registered. This will override
-              standard validation process of the schema registry.
+              standard validation process of the schema registry.{" "}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href={
+                  "https://www.klaw-project.io/docs/HowTo/schemas/Promote-a-schema/#how-does-force-register-work"
+                }
+              >
+                Learn more
+              </a>
             </Typography.Small>
           </dd>
         </Box.Flex>

--- a/coral/src/app/features/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.tsx
@@ -1,16 +1,19 @@
 import { SchemaRequest } from "src/domain/schema-request";
-import { Box, Grid, GridItem, StatusChip } from "@aivenio/aquarium";
+import { Box, Grid, GridItem, StatusChip, Typography } from "@aivenio/aquarium";
 import MonacoEditor from "@monaco-editor/react";
 
 type DetailsModalContentProps = {
   request?: SchemaRequest;
 };
 
-const Label = ({ children }: { children: React.ReactNode }) => (
-  <dt className="inline-block mb-2 typography-small-strong text-grey-60">
-    {children}
-  </dt>
-);
+const Label = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <dt className="inline-block mb-2 typography-small-strong text-grey-60">
+      {children}
+    </dt>
+  );
+};
+
 function SchemaRequestDetails(props: DetailsModalContentProps) {
   const { request } = props;
   if (!request) return null;
@@ -27,10 +30,23 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
         <dd>{request.topicname}</dd>
       </Box.Flex>
 
-      <GridItem colSpan={"span-2"}>
+      <Box.Flex flexDirection={"column"}>
         <Label>Schema version</Label>
         <dd>{request.schemaversion}</dd>
-      </GridItem>
+      </Box.Flex>
+      {request.forceRegister && (
+        <Box.Flex flexDirection={"column"}>
+          <Label>Force register</Label>
+          <dd>
+            {" "}
+            <Typography.Small>
+              Warning: This schema is being force registered. This will override
+              standard validation process of the schema registry.
+            </Typography.Small>
+          </dd>
+        </Box.Flex>
+      )}
+
       <GridItem colSpan={"span-2"}>
         <Box.Flex flexDirection={"column"}>
           <Label>Schema preview</Label>

--- a/coral/src/app/features/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.tsx
@@ -1,5 +1,11 @@
 import { SchemaRequest } from "src/domain/schema-request";
-import { Box, Grid, GridItem, StatusChip, Typography } from "@aivenio/aquarium";
+import {
+  Grid,
+  GridItem,
+  InlineIcon,
+  StatusChip,
+  Typography,
+} from "@aivenio/aquarium";
 import MonacoEditor from "@monaco-editor/react";
 
 type DetailsModalContentProps = {
@@ -19,23 +25,23 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
   if (!request) return null;
   return (
     <Grid htmlTag={"dl"} cols={"2"} rowGap={"6"}>
-      <Box.Flex flexDirection={"column"}>
+      <GridItem>
         <Label>Environment</Label>
         <dd>
           <StatusChip text={request.environmentName} />
         </dd>
-      </Box.Flex>
-      <Box.Flex flexDirection={"column"}>
+      </GridItem>
+      <GridItem>
         <Label>Topic name</Label>
         <dd>{request.topicname}</dd>
-      </Box.Flex>
+      </GridItem>
 
-      <Box.Flex flexDirection={"column"}>
+      <GridItem>
         <Label>Schema version</Label>
         <dd>{request.schemaversion}</dd>
-      </Box.Flex>
+      </GridItem>
       {request.forceRegister && (
-        <Box.Flex flexDirection={"column"}>
+        <GridItem>
           <Label>Force register</Label>
           <dd>
             {" "}
@@ -53,11 +59,11 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
               </a>
             </Typography.Small>
           </dd>
-        </Box.Flex>
+        </GridItem>
       )}
 
       <GridItem colSpan={"span-2"}>
-        <Box.Flex flexDirection={"column"}>
+        <GridItem>
           <Label>Schema preview</Label>
           <dd>
             <MonacoEditor
@@ -79,24 +85,24 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
               }}
             />
           </dd>
-        </Box.Flex>
+        </GridItem>
       </GridItem>
 
       <GridItem colSpan={"span-2"}>
-        <Box.Flex flexDirection={"column"}>
+        <GridItem>
           <Label>Message for approval</Label>
           <dd>{request.remarks || <i>No message</i>}</dd>
-        </Box.Flex>
+        </GridItem>
       </GridItem>
 
-      <Box.Flex flexDirection={"column"}>
+      <GridItem>
         <Label>Requested by</Label>
         <dd>{request.requestor}</dd>
-      </Box.Flex>
-      <Box.Flex flexDirection={"column"}>
+      </GridItem>
+      <GridItem>
         <Label>Requested on</Label>
         <dd>{request.requesttimestring} UTC</dd>
-      </Box.Flex>
+      </GridItem>
     </Grid>
   );
 }

--- a/coral/src/app/features/components/SchemaRequestDetails.tsx
+++ b/coral/src/app/features/components/SchemaRequestDetails.tsx
@@ -1,11 +1,5 @@
 import { SchemaRequest } from "src/domain/schema-request";
-import {
-  Grid,
-  GridItem,
-  InlineIcon,
-  StatusChip,
-  Typography,
-} from "@aivenio/aquarium";
+import { Grid, GridItem, StatusChip, Typography } from "@aivenio/aquarium";
 import MonacoEditor from "@monaco-editor/react";
 
 type DetailsModalContentProps = {
@@ -42,7 +36,7 @@ function SchemaRequestDetails(props: DetailsModalContentProps) {
       </GridItem>
       {request.forceRegister && (
         <GridItem>
-          <Label>Force register</Label>
+          <Label>Force register applied</Label>
           <dd>
             {" "}
             <Typography.Small>

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -1052,11 +1052,11 @@ describe("TopicDetailsSchema", () => {
           topicName: "topic-name",
         });
 
-        const checkboxToForceRegister = screen.getByRole("checkbox", {
-          name: "Force register Overrides standard validation processes of the schema registry.",
-        });
-
-        expect(checkboxToForceRegister).toBeVisible();
+        const checkboxToForceRegister = screen.getByRole("checkbox");
+        expect(checkboxToForceRegister).toHaveAccessibleName(
+          /Force register schema promotion Warning: This will override standard validation process of the schema registry. Learn more/
+        );
+        expect(checkboxToForceRegister).toBeEnabled();
 
         expect(console.error).toHaveBeenCalledWith({
           message: "failure: Schema is not compatible",
@@ -1088,9 +1088,7 @@ describe("TopicDetailsSchema", () => {
 
         await user.click(buttonRequest);
 
-        const checkboxToForceRegister = screen.getByRole("checkbox", {
-          name: "Force register Overrides standard validation processes of the schema registry.",
-        });
+        const checkboxToForceRegister = screen.getByRole("checkbox");
 
         await user.click(checkboxToForceRegister);
         await user.click(buttonRequest);
@@ -1134,9 +1132,7 @@ describe("TopicDetailsSchema", () => {
 
         await user.click(buttonRequest);
 
-        const checkboxToForceRegister = screen.getByRole("checkbox", {
-          name: "Force register Overrides standard validation processes of the schema registry.",
-        });
+        const checkboxToForceRegister = screen.getByRole("checkbox");
 
         await user.click(checkboxToForceRegister);
         await user.click(buttonRequest);

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionModal.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionModal.test.tsx
@@ -10,7 +10,7 @@ const testVersion = 1;
 describe("SchemaPromotionModal", () => {
   const user = userEvent.setup();
 
-  describe("renders all necessary elements (isLoading={false},  showForceRegister={false})", () => {
+  describe("renders all necessary elements for default promotion", () => {
     beforeAll(() => {
       render(
         <SchemaPromotionModal
@@ -91,7 +91,7 @@ describe("SchemaPromotionModal", () => {
     });
   });
 
-  describe("shows disabled UI (isLoading={true}, showForceRegister={true})", () => {
+  describe("shows disabled UI while loading is true for default promotion", () => {
     beforeAll(() => {
       render(
         <SchemaPromotionModal
@@ -100,7 +100,7 @@ describe("SchemaPromotionModal", () => {
           isLoading={true}
           version={testVersion}
           targetEnvironment={testTargetEnv}
-          showForceRegister={true}
+          showForceRegister={false}
         />
       );
     });
@@ -141,7 +141,7 @@ describe("SchemaPromotionModal", () => {
     });
   });
 
-  describe("enables user to cancel process ", () => {
+  describe("enables user to cancel process for default promotion", () => {
     beforeEach(() => {
       render(
         <SchemaPromotionModal
@@ -173,7 +173,64 @@ describe("SchemaPromotionModal", () => {
     });
   });
 
-  describe("enables user to start the promotion process (showForceRegister={true})", () => {
+  describe("enables user to start the promotion process", () => {
+    beforeEach(() => {
+      render(
+        <SchemaPromotionModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          isLoading={false}
+          version={testVersion}
+          targetEnvironment={testTargetEnv}
+          showForceRegister={false}
+        />
+      );
+    });
+
+    afterEach(() => {
+      cleanup();
+      jest.clearAllMocks();
+    });
+
+    it("triggers a given submit function with correct payload when user does not adds a reason", async () => {
+      const dialog = screen.getByRole("dialog");
+
+      const confirmationButton = within(dialog).getByRole("button", {
+        name: "Request schema promotion",
+      });
+
+      await user.click(confirmationButton);
+
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        forceRegister: false,
+        remarks: "",
+      });
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it("triggers a given submit function with correct date when adds a reason", async () => {
+      const dialog = screen.getByRole("dialog");
+
+      const textarea = within(dialog).getByRole("textbox", {
+        name: "You can add the reason to promote the schema (optional)",
+      });
+
+      const confirmationButton = within(dialog).getByRole("button", {
+        name: "Request schema promotion",
+      });
+
+      await user.type(textarea, "This is my reason");
+      await user.click(confirmationButton);
+
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        forceRegister: false,
+        remarks: "This is my reason",
+      });
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("optional enables user to start the promotion process (showForceRegister={true})", () => {
     beforeEach(() => {
       render(
         <SchemaPromotionModal
@@ -196,61 +253,45 @@ describe("SchemaPromotionModal", () => {
       const warning = screen.getByRole("alert");
 
       expect(warning).toBeVisible();
-      expect(warning).toHaveTextContent(
-        "Uploaded schema appears invalid. Are you sure you want to force register it?"
+      expect(warning).toHaveTextContent("Uploaded schema appears invalid.");
+    });
+
+    it("shows a checkbox to confirm force register", async () => {
+      const dialog = screen.getByRole("dialog");
+
+      const forceRegisterSwitch = within(dialog).getByRole("checkbox");
+      expect(forceRegisterSwitch).toHaveAccessibleName(
+        /Force register schema promotion Warning: This will override standard validation process of the schema registry. Learn more/
       );
+      expect(forceRegisterSwitch).toBeEnabled();
     });
 
-    it("triggers a given submit function with correct payload when user does not switch Force register or adds a reason", async () => {
+    it("changes the submit button text and disables button until checkbox is checked", async () => {
       const dialog = screen.getByRole("dialog");
 
       const confirmationButton = within(dialog).getByRole("button", {
-        name: "Request schema promotion",
+        name: "Force register",
       });
+      const forceRegisterSwitch = within(dialog).getByRole("checkbox");
 
-      await user.click(confirmationButton);
-
-      expect(mockOnSubmit).toHaveBeenCalledWith({
-        forceRegister: false,
-        remarks: "",
-      });
-      expect(mockOnClose).not.toHaveBeenCalled();
-    });
-
-    it("triggers a given submit function with correct date when user does switch Force register and not adds a reason", async () => {
-      const dialog = screen.getByRole("dialog");
-
-      const forceRegisterSwitch = screen.getByRole("checkbox", {
-        name: "Force register Overrides standard validation processes of the schema registry.",
-      });
-
-      const confirmationButton = within(dialog).getByRole("button", {
-        name: "Request schema promotion",
-      });
+      expect(confirmationButton).toBeDisabled();
 
       await user.click(forceRegisterSwitch);
-      await user.click(confirmationButton);
 
-      expect(mockOnSubmit).toHaveBeenCalledWith({
-        forceRegister: true,
-        remarks: "",
-      });
-      expect(mockOnClose).not.toHaveBeenCalled();
+      expect(confirmationButton).toBeEnabled();
     });
 
-    it("triggers a given submit function with correct date when user does check checkbox and adds a reason", async () => {
+    it("triggers a given submit function with correct data", async () => {
       const dialog = screen.getByRole("dialog");
 
-      const forceRegisterSwitch = screen.getByRole("checkbox", {
-        name: "Force register Overrides standard validation processes of the schema registry.",
-      });
+      const forceRegisterSwitch = within(dialog).getByRole("checkbox");
 
       const textarea = within(dialog).getByRole("textbox", {
         name: "You can add the reason to promote the schema (optional)",
       });
 
       const confirmationButton = within(dialog).getByRole("button", {
-        name: "Request schema promotion",
+        name: "Force register",
       });
 
       await user.click(forceRegisterSwitch);

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionModal.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionModal.tsx
@@ -33,13 +33,14 @@ const SchemaPromotionModal = ({
       title={`Promote schema to ${targetEnvironment}`}
       close={onClose}
       primaryAction={{
-        text: "Request schema promotion",
+        text: showForceRegister ? "Force register" : "Request schema promotion",
         onClick: () =>
           onSubmit({
             remarks,
             forceRegister,
           }),
         loading: isLoading,
+        disabled: showForceRegister && !forceRegister,
       }}
       secondaryAction={{
         text: "Cancel",
@@ -51,14 +52,6 @@ const SchemaPromotionModal = ({
         <p>
           {`Promote the Version ${version} of the schema to ${targetEnvironment}?`}
         </p>
-        {showForceRegister && (
-          <Box marginBottom={"l1"}>
-            <Alert type={"warning"}>
-              Uploaded schema appears invalid. Are you sure you want to force
-              register it?
-            </Alert>
-          </Box>
-        )}
         <Textarea
           labelText="You can add the reason to promote the schema (optional)"
           placeholder="Write a message..."
@@ -70,16 +63,34 @@ const SchemaPromotionModal = ({
           disabled={isLoading}
         />
         {showForceRegister && (
-          <Checkbox
-            disabled={isLoading}
-            checked={forceRegister}
-            caption={
-              "Overrides standard validation processes of the schema registry."
-            }
-            onChange={(e) => setForceRegister(e.target.checked)}
-          >
-            Force register
-          </Checkbox>
+          <>
+            <Box>
+              <Alert type={"warning"}>Uploaded schema appears invalid.</Alert>
+            </Box>
+
+            <Checkbox
+              disabled={isLoading}
+              checked={forceRegister}
+              caption={
+                <>
+                  Warning: This will override standard validation process of the
+                  schema registry.{" "}
+                  <a
+                    target="_blank"
+                    rel="noreferrer"
+                    href={
+                      "https://www.klaw-project.io/docs/HowTo/schemas/Promote-a-schema/#how-does-force-register-work"
+                    }
+                  >
+                    Learn more
+                  </a>
+                </>
+              }
+              onChange={(e) => setForceRegister(e.target.checked)}
+            >
+              Force register schema promotion
+            </Checkbox>
+          </>
         )}
       </Box>
     </Modal>

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -65,6 +65,7 @@ const testFile: File = new File(["{}"], fileName, {
 });
 
 describe("TopicSchemaRequest", () => {
+  const user = userEvent.setup();
   const getForm = () => {
     return screen.getByRole("form", {
       name: `Request a new schema`,
@@ -481,9 +482,9 @@ describe("TopicSchemaRequest", () => {
       });
 
       select.focus();
-      await userEvent.keyboard("{ArrowDown}");
-      await userEvent.keyboard("{ESC}");
-      await userEvent.tab();
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ESC}");
+      await user.tab();
 
       const error = await screen.findByText(
         "Selection Error: Please select an environment"
@@ -498,7 +499,7 @@ describe("TopicSchemaRequest", () => {
         within(form).getByLabelText<HTMLInputElement>(/Upload AVRO Schema/i);
 
       fileInput.focus();
-      await userEvent.tab();
+      await user.tab();
 
       const fileRequiredError = screen.getAllByText(
         "File missing: Upload the AVRO schema file."
@@ -519,8 +520,8 @@ describe("TopicSchemaRequest", () => {
       });
       expect(button).toBeEnabled();
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
+      await user.selectOptions(select, option);
+      await user.tab();
 
       expect(button).toBeEnabled();
     });
@@ -560,7 +561,7 @@ describe("TopicSchemaRequest", () => {
         name: "Cancel",
       });
 
-      await userEvent.click(button);
+      await user.click(button);
 
       expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
     });
@@ -571,13 +572,13 @@ describe("TopicSchemaRequest", () => {
       const remarkInput = screen.getByRole("textbox", {
         name: "Message for approval",
       });
-      await userEvent.type(remarkInput, "Important information");
+      await user.type(remarkInput, "Important information");
 
       const button = within(form).getByRole("button", {
         name: "Cancel",
       });
 
-      await userEvent.click(button);
+      await user.click(button);
       const dialog = screen.getByRole("dialog");
 
       expect(dialog).toBeVisible();
@@ -595,20 +596,20 @@ describe("TopicSchemaRequest", () => {
       const remarkInput = screen.getByRole("textbox", {
         name: "Message for approval",
       });
-      await userEvent.type(remarkInput, "Important information");
+      await user.type(remarkInput, "Important information");
 
       const button = within(form).getByRole("button", {
         name: "Cancel",
       });
 
-      await userEvent.click(button);
+      await user.click(button);
       const dialog = screen.getByRole("dialog");
 
       const returnButton = screen.getByRole("button", {
         name: "Continue with request",
       });
 
-      await userEvent.click(returnButton);
+      await user.click(returnButton);
 
       expect(mockedUsedNavigate).not.toHaveBeenCalled();
 
@@ -621,19 +622,19 @@ describe("TopicSchemaRequest", () => {
       const remarkInput = screen.getByRole("textbox", {
         name: "Message for approval",
       });
-      await userEvent.type(remarkInput, "Important information");
+      await user.type(remarkInput, "Important information");
 
       const button = within(form).getByRole("button", {
         name: "Cancel",
       });
 
-      await userEvent.click(button);
+      await user.click(button);
 
       const returnButton = screen.getByRole("button", {
         name: "Cancel request",
       });
 
-      await userEvent.click(returnButton);
+      await user.click(returnButton);
 
       expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
     });
@@ -690,10 +691,10 @@ describe("TopicSchemaRequest", () => {
       });
       expect(button).toBeEnabled();
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
-      await userEvent.upload(fileInput, testFile);
-      await userEvent.click(button);
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
+      await user.click(button);
 
       expect(mockCreateSchemaRequest).toHaveBeenCalled();
 
@@ -729,10 +730,10 @@ describe("TopicSchemaRequest", () => {
       });
       expect(button).toBeEnabled();
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
-      await userEvent.upload(fileInput, testFile);
-      await userEvent.click(button);
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
+      await user.click(button);
 
       await waitFor(() =>
         expect(screen.getByText("Error in request")).toBeVisible()
@@ -789,7 +790,7 @@ describe("TopicSchemaRequest", () => {
 
       expect(select).toHaveDisplayValue("-- Please select --");
 
-      await userEvent.selectOptions(select, option);
+      await user.selectOptions(select, option);
 
       expect(select).toHaveValue(mockedEnvironments[1].id);
       expect(select).toHaveDisplayValue(mockedEnvironments[1].name);
@@ -802,7 +803,7 @@ describe("TopicSchemaRequest", () => {
 
       expect(fileInput.files?.[0]).toBeUndefined();
 
-      await userEvent.upload(fileInput, testFile);
+      await user.upload(fileInput, testFile);
 
       expect(fileInput.files?.[0]).toBe(testFile);
     });
@@ -812,7 +813,7 @@ describe("TopicSchemaRequest", () => {
       const fileInput =
         within(form).getByLabelText<HTMLInputElement>(/Upload AVRO Schema/i);
 
-      await userEvent.upload(fileInput, testFile);
+      await user.upload(fileInput, testFile);
       const editor = await screen.findByTestId("topic-schema");
 
       await waitFor(() => expect(editor).toHaveDisplayValue("{}"));
@@ -835,9 +836,9 @@ describe("TopicSchemaRequest", () => {
       });
       expect(button).toBeEnabled();
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
-      await userEvent.upload(fileInput, testFile);
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
 
       expect(button).toBeEnabled();
     });
@@ -859,10 +860,10 @@ describe("TopicSchemaRequest", () => {
       });
       expect(button).toBeEnabled();
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
-      await userEvent.upload(fileInput, testFile);
-      await userEvent.click(button);
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
+      await user.click(button);
 
       expect(mockCreateSchemaRequest).toHaveBeenCalledWith({
         environment: "1",
@@ -884,11 +885,11 @@ describe("TopicSchemaRequest", () => {
       });
       expect(button).toBeEnabled();
 
-      await userEvent.upload(fileInput, testFile);
+      await user.upload(fileInput, testFile);
 
       expect(button).toBeEnabled();
-      await userEvent.click(button);
-      await userEvent.tab();
+      await user.click(button);
+      await user.tab();
 
       expect(mockCreateSchemaRequest).not.toHaveBeenCalled();
       expect(mockedUseToast).not.toHaveBeenCalled();
@@ -911,10 +912,10 @@ describe("TopicSchemaRequest", () => {
       });
       expect(button).toBeEnabled();
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
-      await userEvent.upload(fileInput, testFile);
-      await userEvent.click(button);
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
+      await user.click(button);
 
       expect(mockCreateSchemaRequest).toHaveBeenCalled();
       await waitFor(() =>
@@ -973,7 +974,7 @@ describe("TopicSchemaRequest", () => {
       cleanup();
     });
 
-    it("gives user the option to force register", async () => {
+    it("gives user the option to force register with a warning information", async () => {
       const form = getForm();
 
       const checkBoxBefore = within(form).queryByRole("checkbox", {
@@ -993,30 +994,63 @@ describe("TopicSchemaRequest", () => {
       const fileInput =
         within(form).getByLabelText<HTMLInputElement>(/Upload AVRO Schema/i);
 
-      const button = within(form).getByRole("button", {
+      const submitButton = within(form).getByRole("button", {
         name: "Submit request",
       });
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
-      await userEvent.upload(fileInput, testFile);
-      await userEvent.click(button);
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
+      await user.click(submitButton);
 
       const warningForceRegister = screen.getByRole("alert");
       const checkboxForceRegister = within(form).getByRole("checkbox", {
-        name: "Force register Overrides standard validation processes of the schema registry.",
+        name: "Force register schema creation/changes Warning: This will override standard validation process of the schema registry. Learn more",
       });
+
       expect(warningForceRegister).toBeVisible();
       expect(warningForceRegister).toHaveTextContent(
-        "Uploaded schema appears invalid. Are you sure you want to" +
-          " force register it?"
+        "Uploaded schema appears invalid."
       );
-
-      expect(checkboxForceRegister).toBeVisible();
+      expect(checkboxForceRegister).toBeEnabled();
       expect(console.error).toHaveBeenCalledWith({
         message: "failure: Schema is not compatible",
         success: false,
       });
+    });
+
+    it("enables user to only send the request if they confirm force register", async () => {
+      const form = getForm();
+      const select = within(form).getByRole("combobox", {
+        name: /Environment/i,
+      });
+      const option = within(select).getByRole("option", {
+        name: mockedEnvironments[0].name,
+      });
+      const fileInput =
+        within(form).getByLabelText<HTMLInputElement>(/Upload AVRO Schema/i);
+
+      const submitButton = within(form).getByRole("button", {
+        name: "Submit request",
+      });
+      expect(submitButton).toBeEnabled();
+
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
+      await user.click(submitButton);
+
+      const checkboxForceRegister = within(form).getByRole("checkbox", {
+        name: "Force register schema creation/changes Warning: This will override standard validation process of the schema registry. Learn more",
+      });
+
+      expect(submitButton).toHaveAccessibleName(
+        "Submit request to force register"
+      );
+      expect(submitButton).toBeDisabled();
+
+      await user.click(checkboxForceRegister);
+      expect(submitButton).toBeEnabled();
     });
 
     it("shows a notification informing user that force register for schema request was successful and redirects them", async () => {
@@ -1034,17 +1068,20 @@ describe("TopicSchemaRequest", () => {
         name: "Submit request",
       });
 
-      await userEvent.selectOptions(select, option);
-      await userEvent.tab();
-      await userEvent.upload(fileInput, testFile);
-      await userEvent.click(submitButton);
+      await user.selectOptions(select, option);
+      await user.tab();
+      await user.upload(fileInput, testFile);
+      await user.click(submitButton);
 
       const checkboxForceRegister = within(form).getByRole("checkbox", {
-        name: "Force register Overrides standard validation processes of the schema registry.",
+        name: "Force register schema creation/changes Warning: This will override standard validation process of the schema registry. Learn more",
       });
 
-      await userEvent.click(checkboxForceRegister);
-      await userEvent.click(submitButton);
+      expect(submitButton).toBeDisabled();
+      await user.click(checkboxForceRegister);
+
+      expect(submitButton).toBeEnabled();
+      await user.click(submitButton);
 
       expect(mockCreateSchemaRequest).toHaveBeenNthCalledWith(2, {
         forceRegister: true,

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -172,14 +172,6 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
             </Alert>
           </Box>
         )}
-        {isValidationError && (
-          <Box marginBottom={"l1"}>
-            <Alert type={"warning"}>
-              Uploaded schema appears invalid. Are you sure you want to force
-              register it?
-            </Alert>
-          </Box>
-        )}
         <Form
           {...form}
           ariaLabel={"Request a new schema"}
@@ -241,21 +233,45 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
             placeholder="Comments about this request for the approver."
           />
           {isValidationError && (
-            <Box marginBottom={"l2"}>
-              {/*We only allow users to use the forceRegister option when the promotion request failed*/}
-              {/*And the failure is because of a schema compatibility issue*/}
-              <Checkbox<TopicRequestFormSchema>
-                name={"forceRegister"}
-                caption={
-                  "Overrides standard validation processes of the schema registry."
-                }
-              >
-                Force register
-              </Checkbox>
-            </Box>
+            <>
+              <Box marginBottom={"l1"}>
+                <Alert type={"warning"}>Uploaded schema appears invalid.</Alert>
+              </Box>
+
+              <Box marginBottom={"l2"}>
+                {/*We only allow users to use the forceRegister option when the promotion request failed*/}
+                {/*And the failure is because of a schema compatibility issue*/}
+                <Checkbox<TopicRequestFormSchema>
+                  name={"forceRegister"}
+                  caption={
+                    <>
+                      Warning: This will override standard validation process of
+                      the schema registry.{" "}
+                      <a
+                        target="_blank"
+                        rel="noreferrer"
+                        href={
+                          "https://www.klaw-project.io/docs/HowTo/schemas/Promote-a-schema/#how-does-force-register-work"
+                        }
+                      >
+                        Learn more
+                      </a>
+                    </>
+                  }
+                >
+                  Force register schema creation/changes
+                </Checkbox>
+              </Box>
+            </>
           )}
           <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
-            <SubmitButton>Submit request</SubmitButton>
+            <SubmitButton
+              disabled={isValidationError && !form.watch("forceRegister")}
+            >
+              {isValidationError
+                ? "Submit request to force register"
+                : "Submit request"}
+            </SubmitButton>
             <Button
               type="button"
               kind={"secondary"}


### PR DESCRIPTION
Resolves: #1882

# What kind of change does this PR introduce?

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update


## Description

This PR adds a consistent flow how user can force register a schema:

- first call to create / promote a schema is done in the usual flow
- in case a _specific_ error returns, the user gets the option to force register the schema
- this option is shown with a warning and a checkbox. 
- when the error was returned, buttons (to submit, promote etc) are _disabled_ and show a more specific text
- the buttons only are enabled once the user has checked the box
(otherwise, user could click the button again, get the same error, but nothing in the UI changes, so it's very confusing)
- if they did, the request will be sent with the option "forceRegister" true

This is done in the TopicSchemaRequest form (this is used for creating and requesting a new version) as well as in the promotion modal. 


Additionally, the PR adds a new column to the schema approvals table, to show approvers which schema requests have this option turned on. It also adds more detailed information in the details modal, so approvers can read it there, in case they are not sure what this means. 


## Recordings / Screenshots


### Creating new schema (version)

(pls ignore error at the end)

https://github.com/Aiven-Open/klaw/assets/943800/38f319a5-9ddd-4893-817d-9bb6193c841e


### Promoting a schema

https://github.com/Aiven-Open/klaw/assets/943800/48b611aa-fc56-4cfb-adc7-6499e3e57f6f


### Schema approvals table

<img width="1008" alt="status" src="https://github.com/Aiven-Open/klaw/assets/943800/08a57940-063d-4a77-a30e-84b4628a698e">


### Schema request details modal

<img width="848" alt="Screenshot 2023-10-18 at 12 30 08" src="https://github.com/Aiven-Open/klaw/assets/943800/12c5844a-a6a6-4cd4-b199-157b98afac4f">
