### PR TITLE
fix(coral): Disable creating schema version when open promotion request

### DIFF
--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -373,7 +373,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `You cannot promote the schema at this time. An promotion request for ${testTopicName} is already in progress.`
+        `You cannot promote the schema at this time. A promotion request for ${testTopicName} is already in progress.`
       );
 
       expect(information).toBeVisible();
@@ -411,7 +411,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `You cannot promote the topic at this time. An promotion request for ${testTopicName} is already in progress.`
+        `You cannot promote the topic at this time. A promotion request for ${testTopicName} is already in progress.`
       );
 
       expect(information).toBeVisible();
@@ -451,7 +451,7 @@ describe("PromotionBanner", () => {
 
     it("shows information about the open request", () => {
       const information = screen.getByText(
-        `You cannot promote the connector at this time. An promotion request for ${testConnectorName} is already in progress.`
+        `You cannot promote the connector at this time. A promotion request for ${testConnectorName} is already in progress.`
       );
 
       expect(information).toBeVisible();

--- a/coral/src/app/features/topics/details/components/PromotionBanner.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.tsx
@@ -64,7 +64,7 @@ function createText({
   const defaultText = `You cannot promote the ${type} at this time.`;
 
   if (requestType === "PROMOTE") {
-    return `${defaultText} An promotion request for ${entityName} is already in progress.`;
+    return `${defaultText} A promotion request for ${entityName} is already in progress.`;
   }
   if (requestType === "CLAIM") {
     return `${defaultText} A claim request for ${entityName} is in progress.`;

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -323,6 +323,63 @@ describe("TopicDetailsSchema", () => {
       });
     });
 
+    describe("when topic has (multiple) schema(s) and a promotion request is pending", () => {
+      beforeAll(() => {
+        mockPromoteSchemaRequest.mockResolvedValue({
+          success: true,
+          message: "",
+        });
+        mockedUseTopicDetails.mockReturnValue({
+          topicOverviewIsRefetching: false,
+          topicSchemasIsRefetching: false,
+          topicName: testTopicName,
+          environmentId: testEnvironmentId,
+          topicSchemas: {
+            ...testTopicSchemas,
+            schemaPromotionDetails: {
+              ...testTopicSchemas.schemaPromotionDetails,
+              status: "REQUEST_OPEN",
+            },
+          },
+          setSchemaVersion: mockSetSchemaVersion,
+          topicOverview: {
+            topicInfo: { topicOwner: true, hasOpenSchemaRequest: false },
+          },
+        });
+        customRender(
+          <AquariumContext>
+            <TopicDetailsSchema />
+          </AquariumContext>,
+          {
+            memoryRouter: true,
+            queryClient: true,
+          }
+        );
+      });
+
+      afterAll(() => {
+        cleanup();
+        jest.clearAllMocks();
+      });
+
+      it("shows a disabled link to request a new version", () => {
+        const link = screen.getByRole("link", {
+          name: "Request a new version",
+        });
+
+        expect(link).toBeDisabled();
+        expect(link).not.toHaveAttribute("href");
+      });
+
+      it("shows information that there is a pending request", () => {
+        const info = screen.getByText(
+          `You cannot promote the schema at this time. A promotion request for ${testTopicName} is already in progress.`
+        );
+
+        expect(info).toBeVisible();
+      });
+    });
+
     describe("when topic has no schema yet and `createSchemaAllowed` is true (default)", () => {
       beforeAll(() => {
         mockPromoteSchemaRequest.mockResolvedValue({

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -181,7 +181,14 @@ function TopicDetailsSchema() {
           <Box alignSelf={"top"} aria-hidden={!createSchemaAllowed}>
             <InternalLinkButton
               to={`/topic/${topicName}/request-schema?env=${schemaDetailsPerEnv.env}`}
-              disabled={!createSchemaAllowed || hasOpenSchemaRequest}
+              // user can not promote a schema when it it's forbidden, when there is an open request
+              // or an open promotion request
+
+              disabled={
+                !createSchemaAllowed ||
+                hasOpenSchemaRequest ||
+                schemaPromotionDetails.status === "REQUEST_OPEN"
+              }
             >
               <Box.Flex component={"span"} alignItems={"center"} colGap={"3"}>
                 <InlineIcon


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

While we disable the "Create a new schema version" button when there is an open request, we didn't disable it when there was an open promotion request. But user can't create a new version when there is an open promotion request. This is a frontend-only issue, since the creating in the backend (rightfully) failed anyway.


#### Behaviour before


https://github.com/Aiven-Open/klaw/assets/943800/47471872-5934-4d61-8de5-8b6e53c7ac29



# What is the new behavior?

Now we disable this button in case there is an open request, so user don't go through the process of creating a new version and then get an error. 


https://github.com/Aiven-Open/klaw/assets/943800/92ab11ad-ba81-4a27-a4a2-c1b32b5c092a



# Other information

I noticed a typo in the promotion banner and fixed that. It said "A**n** promotion request for..." instead of "a promotion request". I think we had "An open promotion request" before, but changed that sentences and overlooked the little "n:

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
