### PR TITLE
Isue schema promotion

### DIFF
--- a/bin/run-klaw.sh
+++ b/bin/run-klaw.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Declarations
+version=2.5.0
+core_lib=./core/target/klaw-${version}.jar
+cluster_lib=./cluster-api/target/cluster-api-${version}.jar
+core_config=./core/target/classes/application.properties
+cluster_config=./cluster-api/target/classes/application.properties
+core_log_file=core.log
+clusterapi_log_file=cluster-api.log
+
+# Start klaw
+echo "Starting Klaw servers .."
+
+echo "---------- Klaw Core ----------"
+
+# Verify if config file exists
+if ! [ -f "$core_lib" ]
+then
+  echo "$core_lib doesn't exist. Exiting .."
+  exit 1
+fi
+
+# Verify if process already exists
+if ps aux | grep 'core' | grep klaw
+then
+  echo "Core is already running" 2>&1
+else
+  echo "Starting core"
+    nohup java -jar ${core_lib} --spring.config.location=${core_config} > ${core_log_file} &
+    ps aux | grep 'core' | grep klaw
+fi
+
+echo "---------- Klaw Cluster api ----------"
+
+# Verify if config file exists
+if ! [ -f "$cluster_lib" ];
+then
+  echo "$cluster_lib doesn't exist. Exiting .."
+  exit 1
+fi
+
+# Verify if process already exists
+if ps aux | grep 'cluster-api' | grep 'java'
+then
+  echo "Cluster-api is already running" 2>&1
+else
+  echo "Starting cluster-api"
+    nohup java -jar ${cluster_lib} --spring.config.location=${cluster_config} > ${clusterapi_log_file} &
+    ps aux | grep 'cluster-api' | grep 'java'
+fi
+
+echo "Logging to $core_log_file $clusterapi_log_file"

--- a/coral/docs/development-with-local-klaw.md
+++ b/coral/docs/development-with-local-klaw.md
@@ -42,7 +42,7 @@ Please check out the [proxy README](../proxy/README.md) for more detailed inform
     - the proxy runs on [`http://localhost:1337`](http://localhost:1337)
     - Login (❗️The correct redirect for login and authentication is **not** working in the proxy yet):
       - Go to your [local Klaw](http://localhost:9097/login)
-      - Login as superadmin with: `superadmin`, password `kwsuperadmin123$$` (see [application.properties](../../core/src/main/resources/application.properties))
+      - Login as superadmin with: `superadmin`, password `welcometoklaw` (see [application.properties](../../core/src/main/resources/application.properties))
       - Go back to the [proxy](http://localhost:1337)
 11. As superadmin, create one or more users [proxy](http://localhost:1337/users)
     "User" and "superadmin" are roles that have authorization to different views and functionality. We're migrating

--- a/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
+++ b/core/src/main/java/io/aiven/klaw/auth/KwAuthenticationSuccessHandler.java
@@ -3,6 +3,7 @@ package io.aiven.klaw.auth;
 import io.aiven.klaw.helpers.KwConstants;
 import io.aiven.klaw.helpers.UtilMethods;
 import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
+import io.aiven.klaw.service.UtilControllerService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -23,6 +24,9 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
 
   @Value("${klaw.quickstart.enabled:false}")
   private boolean quickStartEnabled;
+
+  @Value("${klaw.coral.enabled:false}")
+  private boolean coralEnabled;
 
   @Value("${klaw.ad.username.attribute:preferred_username}")
   private String preferredUsernameAttribute;
@@ -52,6 +56,16 @@ public class KwAuthenticationSuccessHandler extends SavedRequestAwareAuthenticat
                 UtilMethods.getUserName(authentication.getPrincipal(), preferredUsernameAttribute))
             .getRole()
             .equals(KwConstants.USER_ROLE)) {
+      return coralTopicsUri;
+    }
+
+    if (coralEnabled
+        && UtilControllerService.isCoralBuilt
+        && !handleDbRequests
+            .getUsersInfo(
+                UtilMethods.getUserName(authentication.getPrincipal(), preferredUsernameAttribute))
+            .getRole()
+            .equals(KwConstants.SUPERADMIN_ROLE)) {
       return coralTopicsUri;
     }
 

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -17,7 +17,8 @@ public class KwConstants {
   public static final int DEFAULT_TENANT_ID = 101;
   public static final String TENANT_CONFIG_PROPERTY = "klaw.tenant.config";
   public static final String broadCastTextProperty = "klaw.broadcast.text";
-  public static final String RETRIEVE_SCHEMAS_KEY = "klaw.getschemas.enable";
+
+  public static final String CORAL_INDEX_FILE_PATH = "classpath:templates/coral/index.html";
   public static final String KW_REPORTS_TMP_LOCATION_KEY = "klaw.reports.location";
   public static final String CLUSTER_CONN_URL_KEY = "klaw.clusterapi.url";
   public static final String EMAIL_NOTIFICATIONS_ENABLED_KEY = "klaw.mail.notifications.enable";

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -2,6 +2,7 @@ package io.aiven.klaw.service;
 
 import static io.aiven.klaw.error.KlawErrorMessages.*;
 import static io.aiven.klaw.helpers.KwConstants.APPROVER_SUBSCRIPTIONS;
+import static io.aiven.klaw.helpers.KwConstants.CORAL_INDEX_FILE_PATH;
 import static io.aiven.klaw.helpers.KwConstants.REQUESTOR_SUBSCRIPTIONS;
 import static io.aiven.klaw.model.enums.AuthenticationType.ACTIVE_DIRECTORY;
 import static io.aiven.klaw.model.enums.RolesType.SUPERADMIN;
@@ -56,7 +57,6 @@ public class UtilControllerService implements InitializingBean {
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   public static final String ANONYMOUS_USER = "anonymousUser";
   public static final String IMAGE_URI = ".imageURI";
-  public static final String CORAL_INDEX_FILE_PATH = "classpath:templates/coral/index.html";
   @Autowired ManageDatabase manageDatabase;
 
   @Autowired MailUtils mailService;
@@ -88,7 +88,7 @@ public class UtilControllerService implements InitializingBean {
 
   @Autowired private ConfigurableApplicationContext context;
 
-  private Boolean isCoralBuilt;
+  public static Boolean isCoralBuilt;
 
   @Override
   public void afterPropertiesSet() throws Exception {

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -92,7 +92,7 @@ klaw.core.ha.enable=false
 # In case of AD or Azure AD, configure an existing user from AD in the below config for username. Ex : superadmin@domain.
 # Leave it blank if this user is not required
 klaw.superadmin.default.username=superadmin
-klaw.superadmin.default.password=kwsuperadmin123$$
+klaw.superadmin.default.password=welcometoklaw
 
 # TTL for password reset token in milliseconds defaut is 60000 which is ten minutes.
 klaw.reset.password.token.ttl=60000

--- a/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
@@ -43,7 +43,7 @@ public class EnvsClustersTenantsControllerIT {
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static MockMethods mockMethods;
   private static final String superAdmin = "superadmin";
-  private static final String superAdminPwd = "kwsuperadmin123$$";
+  private static final String superAdminPwd = "welcometoklaw";
 
   @Autowired private MockMvc mvc;
 

--- a/core/src/test/java/io/aiven/klaw/RolesPermissionsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/RolesPermissionsControllerIT.java
@@ -38,7 +38,7 @@ public class RolesPermissionsControllerIT {
   private static MockMethods mockMethods;
   @Autowired private MockMvc mvc;
   private static final String superAdmin = "superadmin";
-  private static final String superAdminPwd = "kwsuperadmin123$$";
+  private static final String superAdminPwd = "welcometoklaw";
 
   @BeforeAll
   public static void setup() {

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -89,7 +89,7 @@ public class TopicAclControllerIT {
   @MockBean private static ClusterApiService clusterApiService;
 
   private static final String superAdmin = "superadmin";
-  private static final String superAdminPwd = "kwsuperadmin123$$";
+  private static final String superAdminPwd = "welcometoklaw";
   private static final String user1 = "tkwusera", user2 = "tkwuserb", user3 = "tkwuserc";
   private static final String topicName = "testtopic";
   private static final int topicId1 = 1001, topicId3 = 1004, topicId4 = 1006, topicId5 = 1008;

--- a/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
@@ -45,7 +45,7 @@ public class UsersTeamsControllerIT {
   @Autowired private MockMvc mvc;
 
   private static String superAdmin = "superadmin";
-  private static String superAdminPwd = "kwsuperadmin123$$";
+  private static String superAdminPwd = "welcometoklaw";
   private static String user1 = "kwusera",
       user2 = "kwuserb",
       switchUser1 = "kwuserc",

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -1,6 +1,5 @@
 package io.aiven.klaw.service;
 
-import static io.aiven.klaw.helpers.KwConstants.REQUEST_SCHEMA_OF_ENVS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,13 +33,7 @@ import io.aiven.klaw.model.requests.SchemaPromotion;
 import io.aiven.klaw.model.requests.SchemaRequestModel;
 import io.aiven.klaw.model.response.SchemaRequestsResponseModel;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -308,7 +301,7 @@ public class SchemaRegistryControllerServiceTest {
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     mockGetEnvironment();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("1");
+    when(manageDatabase.getEnv(eq(101), eq(1))).thenReturn(Optional.of(createEnv(1)));
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(handleDbRequests.requestForSchema(any())).thenReturn(ApiResultStatus.SUCCESS.value);
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
@@ -383,7 +376,7 @@ public class SchemaRegistryControllerServiceTest {
     when(clusterApiService.validateSchema(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(buildValidationResponse(true));
     mockSchemaCreation();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("8");
+    when(manageDatabase.getEnv(eq(101), eq(8))).thenReturn(Optional.of(createEnv(8)));
 
     ApiResponse returnedValue =
         schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
@@ -401,7 +394,8 @@ public class SchemaRegistryControllerServiceTest {
     when(clusterApiService.validateSchema(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(buildValidationResponse(true));
     mockSchemaCreation();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("8");
+
+    when(manageDatabase.getEnv(eq(101), eq(8))).thenReturn(Optional.of(createEnv(8)));
 
     ApiResponse returnedValue =
         schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "1"));
@@ -423,7 +417,7 @@ public class SchemaRegistryControllerServiceTest {
     when(clusterApiService.validateSchema(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(buildValidationResponse(true));
     mockSchemaCreation();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("8");
+    when(manageDatabase.getEnv(eq(101), eq(8))).thenReturn(Optional.of(createEnv(8)));
 
     ApiResponse returnedValue =
         schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "2"));
@@ -445,7 +439,7 @@ public class SchemaRegistryControllerServiceTest {
     when(clusterApiService.validateSchema(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(buildValidationResponse(true));
     mockSchemaCreation();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("8");
+    when(manageDatabase.getEnv(eq(101), eq(8))).thenReturn(Optional.of(createEnv(8)));
 
     ApiResponse returnedValue =
         schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "3"));
@@ -468,7 +462,7 @@ public class SchemaRegistryControllerServiceTest {
     when(clusterApiService.validateSchema(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(buildValidationResponse(true));
     mockSchemaCreation();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("8");
+    when(manageDatabase.getEnv(eq(101), eq(8))).thenReturn(Optional.of(createEnv(8)));
 
     ApiResponse returnedValue =
         schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "4"));
@@ -490,7 +484,7 @@ public class SchemaRegistryControllerServiceTest {
     when(clusterApiService.validateSchema(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(buildValidationResponse(false));
     mockSchemaCreation();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("8");
+    when(manageDatabase.getEnv(eq(101), eq(8))).thenReturn(Optional.of(createEnv(8)));
 
     ApiResponse returnedValue =
         schemaRegistryControllerService.promoteSchema(buildPromoteSchemaRequest(false, "4"));
@@ -515,7 +509,7 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     mockGetEnvironment();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("1");
+    when(manageDatabase.getEnv(eq(101), eq(1))).thenReturn(Optional.of(createEnv(1)));
 
     ApiResponse resultResp =
         schemaRegistryControllerService.uploadSchema(schemaRequest, RequestOperationType.CREATE);
@@ -623,7 +617,7 @@ public class SchemaRegistryControllerServiceTest {
         .thenReturn(List.of(topic));
     when(commonUtilsService.getFilteredTopicsForTenant(any())).thenReturn(List.of(topic));
     mockGetEnvironment();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("1");
+    when(manageDatabase.getEnv(eq(101), eq(1))).thenReturn(Optional.of(createEnv(1)));
 
     ApiResponse resultResp =
         schemaRegistryControllerService.uploadSchema(schemaRequest, RequestOperationType.CREATE);
@@ -650,7 +644,7 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     mockGetEnvironment();
-    when(commonUtilsService.getEnvProperty(eq(101), eq(REQUEST_SCHEMA_OF_ENVS))).thenReturn("1");
+    when(manageDatabase.getEnv(eq(101), eq(1))).thenReturn(Optional.of(createEnv(1)));
 
     NullPointerException ex =
         assertThrows(
@@ -806,6 +800,21 @@ public class SchemaRegistryControllerServiceTest {
     when(clusterApiService.getAvroSchema(any(), any(), any(), eq(TESTTOPIC), eq(101)))
         .thenReturn(createSchemaList())
         .thenReturn(null);
+  }
+
+  private static Env createEnv(int id) {
+
+    Env e = new Env();
+    e.setId(String.valueOf(id));
+    e.setName("Dev-" + id);
+    e.setClusterId(id);
+    e.setTenantId(101);
+    e.setType(KafkaClustersType.SCHEMA_REGISTRY.value);
+    EnvTag tag = new EnvTag();
+    tag.setId(String.valueOf(id));
+    e.setAssociatedEnv(tag);
+
+    return e;
   }
 
   private TreeMap<Integer, Map<String, Object>> createSchemaList() throws JsonProcessingException {

--- a/core/src/test/resources/test-application-rdbms-ad-authorization.properties
+++ b/core/src/test/resources/test-application-rdbms-ad-authorization.properties
@@ -125,7 +125,7 @@ klaw.prizelist.pertenant=1 month (8 $),2 months (15 $),3 months (20 $),6 months 
 
 klaw.admin.mailid=adminmailid
 klaw.superadmin.default.username=superadmin
-klaw.superadmin.default.password=kwsuperadmin123$$
+klaw.superadmin.default.password=welcometoklaw
 
 #kw saas admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"

--- a/core/src/test/resources/test-application-rdbms-sso-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-sso-ad.properties
@@ -125,7 +125,7 @@ klaw.prizelist.pertenant=1 month (8 $),2 months (15 $),3 months (20 $),6 months 
 
 klaw.admin.mailid=adminmailid
 klaw.superadmin.default.username=superadmin
-klaw.superadmin.default.password=kwsuperadmin123$$
+klaw.superadmin.default.password=welcometoklaw
 
 #kw saas admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"

--- a/core/src/test/resources/test-application-rdbms-windows-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-windows-ad.properties
@@ -76,7 +76,7 @@ klaw.core.app2app.base64.secret=dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFw
 # In case of AD or Azure AD, configure an existing user from AD in the below config for username. Ex : superadmin@domain.
 # Leave it blank if this user is not required
 klaw.superadmin.default.username=superadmin
-klaw.superadmin.default.password=kwsuperadmin123$$
+klaw.superadmin.default.password=welcometoklaw
 
 # Klaw Saas Admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"

--- a/core/src/test/resources/test-application-rdbms.properties
+++ b/core/src/test/resources/test-application-rdbms.properties
@@ -116,7 +116,7 @@ klaw.prizelist.pertenant=1 month (8 $),2 months (15 $),3 months (20 $),6 months 
 
 klaw.admin.mailid=adminmailid
 klaw.superadmin.default.username=superadmin
-klaw.superadmin.default.password=kwsuperadmin123$$
+klaw.superadmin.default.password=welcometoklaw
 
 #kw saas admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"

--- a/core/src/test/resources/test-application-rdbms1.properties
+++ b/core/src/test/resources/test-application-rdbms1.properties
@@ -116,7 +116,7 @@ klaw.prizelist.pertenant=1 month (8 $),2 months (15 $),3 months (20 $),6 months 
 
 klaw.admin.mailid=adminmailid
 klaw.superadmin.default.username=superadmin
-klaw.superadmin.default.password=kwsuperadmin123$$
+klaw.superadmin.default.password=welcometoklaw
 
 #kw saas admin
 klaw.saas.ssl.aclcommand=kafka-acls --authorizer-properties bootstrap.server=host:port --add --allow-principal User:"CN=abc..." --operation All  --cluster Cluster:kafka-cluster --topic "*"


### PR DESCRIPTION
# Linked issue

Currently there is a check in the schema Promotion that looks to see if the environment exists in the tenant Config however this has been deprecated and so is no longer required to be filled out. This PR now checks the cache to see if the environment exists for that check.

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Currently there is a check in the schema Promotion that looks to see if the environment exists in the tenant Config however this has been deprecated and so is no longer required to be filled out

# What is the new behavior?

This PR now checks the cache to see if the environment exists for that check.

# Other information



# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
