### PR TITLE
refactor(coral): Replace depracted GridItem in EnvironmentStatus

### DIFF
--- a/coral/src/app/features/configuration/environments/components/EnvironmentStatus.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentStatus.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Grid,
-  GridItem,
   Skeleton,
   StatusChip,
   Typography,
@@ -68,12 +67,12 @@ const EnvironmentStatus = ({
         colGap="3"
         style={{ gridTemplateColumns: "100px 280px 20px" }}
       >
-        <GridItem>
+        <Grid.Item>
           <StatusChip dense status="neutral" text="Refreshing..." />
-        </GridItem>
-        <GridItem>
+        </Grid.Item>
+        <Grid.Item>
           <Skeleton width={275} height={20} />
-        </GridItem>
+        </Grid.Item>
         <Button.Icon
           icon={loading}
           onClick={() => setShouldUpdateStatus(true)}
@@ -93,15 +92,15 @@ const EnvironmentStatus = ({
         colGap="3"
         style={{ gridTemplateColumns: "100px 280px 20px" }}
       >
-        <GridItem>
+        <Grid.Item>
           <StatusChip dense status="danger" text="Not working" />
-        </GridItem>
-        <GridItem>
+        </Grid.Item>
+        <Grid.Item>
           <Typography.Small>
             Last update:{" "}
             {updateTime === "Unknown" ? updateTime : `${updateTime} UTC`}
           </Typography.Small>
-        </GridItem>
+        </Grid.Item>
         <Button.Icon
           icon={refresh}
           onClick={() => setShouldUpdateStatus(true)}
@@ -119,15 +118,15 @@ const EnvironmentStatus = ({
         colGap="3"
         style={{ gridTemplateColumns: "100px 280px 20px" }}
       >
-        <GridItem>
+        <Grid.Item>
           <StatusChip dense status="success" text="Working" />
-        </GridItem>
-        <GridItem>
+        </Grid.Item>
+        <Grid.Item>
           <Typography.Small>
             Last update:{" "}
             {updateTime === "Unknown" ? updateTime : `${updateTime} UTC`}
           </Typography.Small>
-        </GridItem>
+        </Grid.Item>
         <Button.Icon
           icon={refresh}
           onClick={() => setShouldUpdateStatus(true)}
@@ -145,15 +144,15 @@ const EnvironmentStatus = ({
       colGap="3"
       style={{ gridTemplateColumns: "100px 280px 20px" }}
     >
-      <GridItem>
+      <Grid.Item>
         <StatusChip dense status="neutral" text="Unknown" />
-      </GridItem>
-      <GridItem>
+      </Grid.Item>
+      <Grid.Item>
         <Typography.Small>
           Last update:{" "}
           {updateTime === "Unknown" ? updateTime : `${updateTime} UTC`}
         </Typography.Small>
-      </GridItem>
+      </Grid.Item>
       <Button.Icon
         icon={refresh}
         onClick={() => setShouldUpdateStatus(true)}


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

`EnvironmentStatus` uses the deprecated `GridItem` component. Now that `aquarium` is at v 1.43.0, we should use `Grid.Item`

# What is the new behavior?

Use `Grid.Item`

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
