### PR TITLE
fix: Issue 1922 fix docker quick start setup

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -80,7 +80,6 @@ public class KwConstants {
   public static final String REPORTS_LOCATION = "/tmp/";
   public static final String MAIL_NOTIFICATIONS_ENABLE = "true";
   public static final String GETSCHEMAS_ENABLE = "false";
-  public static final String CLUSTERAPI_URL = "http://localhost:9343"; //
   public static final String TENANT_CONFIG = "{}";
 
   public static final String TENANT_CONFIG_QUICK_START =

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -327,8 +327,7 @@ public class DefaultDataService {
               "Base sync cluster, order of topic promotion environments, topic request envs");
     } else {
       kwProperties21 =
-          new KwProperties(
-              "klaw.clusterapi.url", tenantId, clusterApiUrl, "Cluster Api URL");
+          new KwProperties("klaw.clusterapi.url", tenantId, clusterApiUrl, "Cluster Api URL");
       kwProperties22 =
           new KwProperties(
               "klaw.tenant.config",

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -46,6 +46,9 @@ public class DefaultDataService {
   @Value("${klaw.quickstart.default.pwd:welcome}")
   private String quickStartUserPwd;
 
+  @Value("${klaw.clusterapi.url:http://localhost:9343}")
+  private String clusterApiUrl;
+
   public UserInfo getUser(
       int tenantId,
       String password,
@@ -325,7 +328,7 @@ public class DefaultDataService {
     } else {
       kwProperties21 =
           new KwProperties(
-              "klaw.clusterapi.url", tenantId, KwConstants.CLUSTERAPI_URL, "Cluster Api URL");
+              "klaw.clusterapi.url", tenantId, clusterApiUrl, "Cluster Api URL");
       kwProperties22 =
           new KwProperties(
               "klaw.tenant.config",

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -172,6 +172,9 @@ server.compression.min-response-size=1024
 #maximum tenants can be created
 klaw.max.tenants=200
 
+# CluserApi endpoint url
+klaw.clusterapi.url=http://localhost:9343
+
 # ClusterApi access
 klaw.clusterapi.access.username=kwclusterapiuser
 

--- a/docker-scripts/docker-compose-klaw.yaml
+++ b/docker-scripts/docker-compose-klaw.yaml
@@ -6,6 +6,7 @@ services:
     environment:
       KLAW_CLUSTERAPI_ACCESS_BASE64_SECRET: dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
       SPRING_DATASOURCE_URL: "jdbc:h2:file:/klaw/klawprodb;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;MODE=MySQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE;"
+      KLAW_UIAPI_SERVERS: "http://klaw-core:9097"
     volumes:
       - "klaw_data:/klaw"
     extra_hosts:

--- a/docker-scripts/docker-compose-klaw.yaml
+++ b/docker-scripts/docker-compose-klaw.yaml
@@ -7,6 +7,7 @@ services:
       KLAW_CLUSTERAPI_ACCESS_BASE64_SECRET: dGhpcyBpcyBhIHNlY3JldCB0byBhY2Nlc3MgY2x1c3RlcmFwaQ==
       SPRING_DATASOURCE_URL: "jdbc:h2:file:/klaw/klawprodb;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;MODE=MySQL;CASE_INSENSITIVE_IDENTIFIERS=TRUE;"
       KLAW_UIAPI_SERVERS: "http://klaw-core:9097"
+      KLAW_CLUSTERAPI_URL: "http://klaw-cluster-api:9343"
     volumes:
       - "klaw_data:/klaw"
     extra_hosts:


### PR DESCRIPTION
# Linked issue

Resolves: #1922 

# What kind of change does this PR introduce?

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Docker Compose setup won't work with the current `docker-compose-klaw.yml` due to the default of https in `klaw.uiapi.servers`.

# What is the new behavior?

`docker-compose-klaw.yml` is using the `KLAW_UIAPI_SERVERS` environment variable to overwrite the URL. Additionally a new config `klaw.clusterapi.url` has been added to `application.properties` so that the endpoint can be overwritten using the `KLAW_CLUSTERAPI_URL` environment variable and by that eliminating one manual step when using docker without the quickstart option.

# Other information

n.a.

# Requirements (all must be checked before review)

- [X] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [X] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
