### PR TITLE
refactor(coral): Remove handcrafted Environment type 

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -5,7 +5,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import AclApprovals from "src/app/features/approvals/acls/AclApprovals";
 import {
   approveAclRequest,
@@ -19,7 +19,6 @@ import {
   getAllEnvironmentsForTopicAndAcl,
 } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
@@ -104,8 +103,7 @@ const mockedAclRequestsForApproverApiResponse: AclRequest[] = [
       "Team : Ospo, Users : muralibasani,josepprat,samulisuortti,mirjamaulbach,smustafa,aindriul,",
   },
 ];
-const mockGetEnvironmentResponse: Environment[] =
-  transformEnvironmentApiResponse(mockedEnvironmentResponse);
+const mockGetEnvironmentResponse: Environment[] = mockedEnvironmentResponse;
 
 const mockGetAclRequestsForApproverResponse = transformAclRequestApiResponse(
   mockedAclRequestsForApproverApiResponse

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import ConnectorApprovals from "src/app/features/approvals/connectors/ConnectorApprovals";
 import {
   ConnectorRequest,
@@ -11,7 +11,6 @@ import {
 import { transformConnectorRequestApiResponse } from "src/domain/connector/connector-transformer";
 import { getAllEnvironmentsForConnector } from "src/domain/environment";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
@@ -51,10 +50,10 @@ const mockedEnvironments = [
   },
 ];
 
-const mockedEnvironmentResponse = transformEnvironmentApiResponse([
+const mockedEnvironmentResponse = [
   createMockEnvironmentDTO(mockedEnvironments[0]),
   createMockEnvironmentDTO(mockedEnvironments[1]),
-]);
+];
 
 const mockedConnectorRequests: ConnectorRequest[] = [
   {

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -1,10 +1,9 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import SchemaApprovals from "src/app/features/approvals/schemas/SchemaApprovals";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import {
   getSchemaRequestsForApprover,
   SchemaRequest,
@@ -42,10 +41,10 @@ const mockedEnvironments = [
   { name: "RANDOM", id: "3" },
 ];
 
-const mockedEnvironmentResponse = transformEnvironmentApiResponse([
+const mockedEnvironmentResponse = [
   createMockEnvironmentDTO(mockedEnvironments[0]),
   createMockEnvironmentDTO(mockedEnvironments[1]),
-]);
+];
 
 const mockedResponseSchemaRequests: SchemaRequest[] = [
   {

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -1,10 +1,9 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import TopicApprovals from "src/app/features/approvals/topics/TopicApprovals";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { getTeams } from "src/domain/team/team-api";
 import { TopicRequest } from "src/domain/topic";
 import {
@@ -128,9 +127,7 @@ const mockedTeamsResponse = [
 
 const mockedApiResponse: TopicRequestApiResponse =
   transformGetTopicRequestsResponse(mockedTopicRequestsResponse);
-const mockGetEnvironmentResponse = transformEnvironmentApiResponse(
-  mockedEnvironmentResponse
-);
+const mockGetEnvironmentResponse = mockedEnvironmentResponse;
 
 const mockApproveTopicRequest = approveTopicRequest as jest.MockedFunction<
   typeof approveSchemaRequest

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -7,7 +7,7 @@ import {
   getAllEnvironmentsForTopicAndAcl,
   getAllEnvironmentsForConnector,
 } from "src/domain/environment";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 jest.mock("src/domain/environment/environment-api.ts");
@@ -23,11 +23,11 @@ const mockGetSyncConnectorsEnvironments =
   >;
 
 const mockEnvironments = [
-  createEnvironment({
+  createMockEnvironmentDTO({
     name: "DEV",
     id: "1",
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     name: "TST",
     id: "2",
   }),
@@ -150,18 +150,18 @@ describe("EnvironmentFilter.tsx", () => {
     };
 
     const mockEnvironmentsSchema = [
-      createEnvironment({
+      createMockEnvironmentDTO({
         name: "DEV",
         id: "1",
         associatedEnv: associatedEnvDev,
       }),
-      createEnvironment({
+      createMockEnvironmentDTO({
         name: "TST",
         id: "2",
         associatedEnv: associatedEnvTst,
       }),
 
-      createEnvironment({
+      createMockEnvironmentDTO({
         name: "DIV",
         id: "3",
       }),

--- a/coral/src/app/features/configuration/environments/Kafka/components/KafkaEnvironmentsTable.test.tsx
+++ b/coral/src/app/features/configuration/environments/Kafka/components/KafkaEnvironmentsTable.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, within } from "@testing-library/react";
 import KafkaEnvironmentsTable from "src/app/features/configuration/environments/Kafka/components/KafkaEnvironmentsTable";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { Environment } from "src/domain/environment/environment-types";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -14,42 +14,42 @@ jest.mock("@aivenio/aquarium", () => ({
 }));
 
 const mockEnvironments: Environment[] = [
-  createEnvironment({
+  createMockEnvironmentDTO({
     name: "DEV",
     id: "1",
     clusterName: "DEV_CL",
     envStatus: "ONLINE",
     params: {
-      defaultPartitions: 1,
-      defaultRepFactor: 2,
-      maxPartitions: 3,
-      maxRepFactor: 4,
+      defaultPartitions: "1",
+      defaultRepFactor: "2",
+      maxPartitions: "3",
+      maxRepFactor: "4",
     },
     envStatusTimeString: TEST_UPDATE_TIME,
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     name: "TST",
     id: "2",
     clusterName: "TST_CL",
     envStatus: "OFFLINE",
     params: {
-      defaultPartitions: 2,
-      defaultRepFactor: 4,
-      maxPartitions: 3,
-      maxRepFactor: 5,
+      defaultPartitions: "2",
+      defaultRepFactor: "4",
+      maxPartitions: "3",
+      maxRepFactor: "5",
     },
     envStatusTimeString: TEST_UPDATE_TIME,
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     name: "PROD",
     id: "3",
     clusterName: "PROD_CL",
     envStatus: "NOT_KNOWN",
     params: {
-      defaultPartitions: 5,
-      defaultRepFactor: 7,
-      maxPartitions: 6,
-      maxRepFactor: 8,
+      defaultPartitions: "5",
+      defaultRepFactor: "7",
+      maxPartitions: "6",
+      maxRepFactor: "8",
     },
     envStatusTimeString: TEST_UPDATE_TIME,
   }),

--- a/coral/src/app/features/configuration/environments/Kafka/components/KafkaEnvironmentsTable.tsx
+++ b/coral/src/app/features/configuration/environments/Kafka/components/KafkaEnvironmentsTable.tsx
@@ -18,8 +18,8 @@ interface KafkaEnvironmentsTableRow {
   environmentName: Environment["name"];
   clusterName: Environment["clusterName"];
   tenantName: Environment["tenantName"];
-  replicationFactor: { default: number; max: number };
-  partition: { default: number; max: number };
+  replicationFactor: { default: string; max: string };
+  partition: { default: string; max: string };
   status: Environment["envStatus"];
   envStatusTimeString: Environment["envStatusTimeString"];
 }
@@ -118,12 +118,12 @@ const KafkaEnvironmentsTable = (props: KafkaEnvironmentsTableProps) => {
       clusterName: env.clusterName,
       tenantName: env.tenantName,
       replicationFactor: {
-        default: env.params?.defaultRepFactor || 0,
-        max: env.params?.maxRepFactor || 0,
+        default: env.params?.defaultRepFactor || "0",
+        max: env.params?.maxRepFactor || "0",
       },
       partition: {
-        default: env.params?.defaultPartitions || 0,
-        max: env.params?.maxPartitions || 0,
+        default: env.params?.defaultPartitions || "0",
+        max: env.params?.maxPartitions || "0",
       },
       status: env.envStatus,
       envStatusTimeString: env.envStatusTimeString,

--- a/coral/src/app/features/configuration/environments/KafkaConnect/components/KafkaConnectEnvironmentsTable.test.tsx
+++ b/coral/src/app/features/configuration/environments/KafkaConnect/components/KafkaConnectEnvironmentsTable.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, within } from "@testing-library/react";
 import KafkaConnectEnvironmentsTable from "src/app/features/configuration/environments/KafkaConnect/components/KafkaConnectEnvironmentsTable";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { Environment } from "src/domain/environment/environment-types";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -14,7 +14,7 @@ jest.mock("@aivenio/aquarium", () => ({
 }));
 
 const mockEnvironments: Environment[] = [
-  createEnvironment({
+  createMockEnvironmentDTO({
     type: "kafkaconnect",
     name: "DEV",
     id: "1",
@@ -22,7 +22,7 @@ const mockEnvironments: Environment[] = [
     envStatus: "ONLINE",
     envStatusTimeString: TEST_UPDATE_TIME,
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     type: "kafkaconnect",
     name: "TST",
     id: "2",
@@ -30,7 +30,7 @@ const mockEnvironments: Environment[] = [
     envStatus: "OFFLINE",
     envStatusTimeString: TEST_UPDATE_TIME,
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     type: "kafkaconnect",
     name: "PROD",
     id: "3",

--- a/coral/src/app/features/configuration/environments/SchemaRegistry/components/SchemaRegistryEnvironmentsTable.test.tsx
+++ b/coral/src/app/features/configuration/environments/SchemaRegistry/components/SchemaRegistryEnvironmentsTable.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, within } from "@testing-library/react";
 import SchemaRegistryEnvironmentsTable from "src/app/features/configuration/environments/SchemaRegistry/components/SchemaRegistryEnvironmentsTable";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { Environment } from "src/domain/environment/environment-types";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -14,7 +14,7 @@ jest.mock("@aivenio/aquarium", () => ({
 }));
 
 const mockEnvironments: Environment[] = [
-  createEnvironment({
+  createMockEnvironmentDTO({
     type: "schemaregistry",
     name: "DEV_SCH",
     id: "1",
@@ -23,7 +23,7 @@ const mockEnvironments: Environment[] = [
     associatedEnv: { id: "1", name: "DEV" },
     envStatusTimeString: TEST_UPDATE_TIME,
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     type: "schemaregistry",
     name: "TST_SCH",
     id: "2",
@@ -32,7 +32,7 @@ const mockEnvironments: Environment[] = [
     associatedEnv: { id: "2", name: "TST" },
     envStatusTimeString: TEST_UPDATE_TIME,
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     type: "schemaregistry",
     name: "PROD_SCH",
     id: "3",

--- a/coral/src/app/features/configuration/environments/components/EnvironmentsTabs.test.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentsTabs.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import EnvironmentsTabs from "src/app/features/configuration/environments/components/EnvironmentsTabs";
 import {
   ENVIRONMENT_TAB_ID_INTO_PATH,
@@ -11,6 +11,7 @@ import {
   getPaginatedEnvironmentsForSchema,
   getPaginatedEnvironmentsForTopicAndAcl,
 } from "src/domain/environment";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 
 import { EnvironmentPaginatedApiResponse } from "src/domain/environment/environment-types";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -26,7 +27,7 @@ const mockedKafkaTotalEnvs: EnvironmentPaginatedApiResponse = {
   currentPage: 1,
   totalEnvs: 1,
   entries: [
-    {
+    createMockEnvironmentDTO({
       type: "kafka",
       name: "DEV",
       id: "1001",
@@ -35,7 +36,7 @@ const mockedKafkaTotalEnvs: EnvironmentPaginatedApiResponse = {
       tenantName: "default",
       envStatus: "ONLINE",
       envStatusTimeString: "21-Sep-2023 11:46:15",
-    },
+    }),
   ],
 };
 
@@ -44,7 +45,7 @@ const mockedSchemaTotalEnvs: EnvironmentPaginatedApiResponse = {
   currentPage: 1,
   totalEnvs: 2,
   entries: [
-    {
+    createMockEnvironmentDTO({
       type: "schemaregistry",
       name: "DEV",
       id: "1001",
@@ -53,8 +54,8 @@ const mockedSchemaTotalEnvs: EnvironmentPaginatedApiResponse = {
       tenantName: "default",
       envStatus: "ONLINE",
       envStatusTimeString: "21-Sep-2023 11:46:15",
-    },
-    {
+    }),
+    createMockEnvironmentDTO({
       type: "schemaregistry",
       name: "TST",
       id: "1002",
@@ -63,7 +64,7 @@ const mockedSchemaTotalEnvs: EnvironmentPaginatedApiResponse = {
       tenantName: "default",
       envStatus: "ONLINE",
       envStatusTimeString: "21-Sep-2023 11:46:15",
-    },
+    }),
   ],
 };
 

--- a/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
@@ -6,7 +6,7 @@ import { mockIntersectionObserver } from "src/services/test-utils/mock-intersect
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { Connector, getConnectors } from "src/domain/connector";
 import { getAllEnvironmentsForConnector } from "src/domain/environment";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { tabNavigateTo } from "src/services/test-utils/tabbing";
 import { getTeams } from "src/domain/team";
 
@@ -143,11 +143,11 @@ const mockTeams = [
 ];
 
 const mockEnvironments = [
-  createEnvironment({
+  createMockEnvironmentDTO({
     id: "1",
     name: "DEV",
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     id: "2",
     name: "TST",
   }),

--- a/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
@@ -7,7 +7,7 @@ import {
   Environment,
   getAllEnvironmentsForConnector,
 } from "src/domain/environment";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import {
   ConnectorDetailsForEnv,
   getConnectorDetailsPerEnv,
@@ -37,8 +37,8 @@ const testConnectorName = "test-connector-name";
 const defaultSourceEnv = "111";
 const defaultTargetEnv = "999";
 const defaultEnvironments: Environment[] = [
-  createEnvironment({ name: "DEV", id: defaultSourceEnv }),
-  createEnvironment({ name: "TST", id: defaultTargetEnv }),
+  createMockEnvironmentDTO({ name: "DEV", id: defaultSourceEnv }),
+  createMockEnvironmentDTO({ name: "TST", id: defaultTargetEnv }),
 ];
 
 const testConnectorConfig =
@@ -159,7 +159,7 @@ describe("ConnectorPromotionRequest", () => {
 
     it("informs and redirects user when sourceEnv does not exist", async () => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ name: "TST", id: defaultTargetEnv }),
+        createMockEnvironmentDTO({ name: "TST", id: defaultTargetEnv }),
       ]);
 
       renderConnectorPromotionRequest({});
@@ -183,7 +183,7 @@ describe("ConnectorPromotionRequest", () => {
 
     it("informs and redirects user when targetEnv does not exist", async () => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ name: "DEV", id: defaultSourceEnv }),
+        createMockEnvironmentDTO({ name: "DEV", id: defaultSourceEnv }),
       ]);
 
       renderConnectorPromotionRequest({});

--- a/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
@@ -2,7 +2,7 @@ import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ConnectorRequest from "src/app/features/connectors/request/ConnectorRequest";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { requestConnectorCreation } from "src/domain/connector";
 import { getAllEnvironmentsForConnector } from "src/domain/environment";
@@ -49,9 +49,9 @@ describe("<ConnectorRequest />", () => {
     describe("renders all necessary elements by default", () => {
       beforeEach(() => {
         mockGetConnectorEnvironmentRequest.mockResolvedValue([
-          createEnvironment({ id: "1", name: "DEV" }),
-          createEnvironment({ id: "2", name: "TST" }),
-          createEnvironment({ id: "3", name: "PROD" }),
+          createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+          createMockEnvironmentDTO({ id: "2", name: "TST" }),
+          createMockEnvironmentDTO({ id: "3", name: "PROD" }),
         ]);
         customRender(
           <AquariumContext>
@@ -105,9 +105,9 @@ describe("<ConnectorRequest />", () => {
     describe("when field is clicked", () => {
       beforeEach(() => {
         mockGetConnectorEnvironmentRequest.mockResolvedValue([
-          createEnvironment({ id: "1", name: "DEV" }),
-          createEnvironment({ id: "2", name: "TST" }),
-          createEnvironment({ id: "3", name: "PROD" }),
+          createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+          createMockEnvironmentDTO({ id: "2", name: "TST" }),
+          createMockEnvironmentDTO({ id: "3", name: "PROD" }),
         ]);
         customRender(
           <AquariumContext>
@@ -164,9 +164,9 @@ describe("<ConnectorRequest />", () => {
   describe("Connector name", () => {
     beforeEach(() => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ id: "1", name: "DEV" }),
-        createEnvironment({ id: "2", name: "TST" }),
-        createEnvironment({ id: "3", name: "PROD" }),
+        createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+        createMockEnvironmentDTO({ id: "2", name: "TST" }),
+        createMockEnvironmentDTO({ id: "3", name: "PROD" }),
       ]);
       customRender(
         <AquariumContext>
@@ -193,9 +193,9 @@ describe("<ConnectorRequest />", () => {
   describe("Configuration", () => {
     beforeEach(() => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ id: "1", name: "DEV" }),
-        createEnvironment({ id: "2", name: "TST" }),
-        createEnvironment({ id: "3", name: "PROD" }),
+        createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+        createMockEnvironmentDTO({ id: "2", name: "TST" }),
+        createMockEnvironmentDTO({ id: "3", name: "PROD" }),
       ]);
       customRender(
         <AquariumContext>
@@ -284,9 +284,9 @@ describe("<ConnectorRequest />", () => {
   describe("Connector description", () => {
     beforeEach(() => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ id: "1", name: "DEV" }),
-        createEnvironment({ id: "2", name: "TST" }),
-        createEnvironment({ id: "3", name: "PROD" }),
+        createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+        createMockEnvironmentDTO({ id: "2", name: "TST" }),
+        createMockEnvironmentDTO({ id: "3", name: "PROD" }),
       ]);
       customRender(
         <AquariumContext>
@@ -314,9 +314,9 @@ describe("<ConnectorRequest />", () => {
   describe("Message for approval", () => {
     beforeEach(() => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ id: "1", name: "DEV" }),
-        createEnvironment({ id: "2", name: "TST" }),
-        createEnvironment({ id: "3", name: "PROD" }),
+        createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+        createMockEnvironmentDTO({ id: "2", name: "TST" }),
+        createMockEnvironmentDTO({ id: "3", name: "PROD" }),
       ]);
       customRender(
         <AquariumContext>
@@ -339,9 +339,9 @@ describe("<ConnectorRequest />", () => {
   describe("form submission", () => {
     beforeEach(async () => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ id: "1", name: "DEV" }),
-        createEnvironment({ id: "2", name: "TST" }),
-        createEnvironment({ id: "3", name: "PROD" }),
+        createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+        createMockEnvironmentDTO({ id: "2", name: "TST" }),
+        createMockEnvironmentDTO({ id: "3", name: "PROD" }),
       ]);
       customRender(
         <AquariumContext>
@@ -487,9 +487,9 @@ describe("<ConnectorRequest />", () => {
   describe("enables user to cancel the form input", () => {
     beforeEach(async () => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue([
-        createEnvironment({ id: "1", name: "DEV" }),
-        createEnvironment({ id: "2", name: "TST" }),
-        createEnvironment({ id: "3", name: "PROD" }),
+        createMockEnvironmentDTO({ id: "1", name: "DEV" }),
+        createMockEnvironmentDTO({ id: "2", name: "TST" }),
+        createMockEnvironmentDTO({ id: "3", name: "PROD" }),
       ]);
 
       customRender(

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -10,7 +10,7 @@ import AclRequests from "src/app/features/requests/acls/AclRequests";
 import { deleteAclRequest, getAclRequests } from "src/domain/acl/acl-api";
 import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
@@ -102,7 +102,7 @@ const mockGetAclRequestsResponse = transformAclRequestApiResponse([
 ]);
 
 const mockGetEnvironmentsResponse = [
-  createEnvironment({
+  createMockEnvironmentDTO({
     name: "DEV",
     id: "1",
   }),

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
@@ -19,7 +19,7 @@ import {
   getAllEnvironmentsForConnector,
   getAllEnvironmentsForTopicAndAcl,
 } from "src/domain/environment";
-import { createEnvironment } from "src/domain/environment/environment-test-helper";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
@@ -70,11 +70,11 @@ const mockGetConnectorRequestsResponse = transformConnectorRequestApiResponse([
 ]);
 
 const mockEnvironments = [
-  createEnvironment({
+  createMockEnvironmentDTO({
     id: "1",
     name: "DEV",
   }),
-  createEnvironment({
+  createMockEnvironmentDTO({
     id: "2",
     name: "TST",
   }),

--- a/coral/src/app/features/requests/schemas/utils/mocked-api-responses.ts
+++ b/coral/src/app/features/requests/schemas/utils/mocked-api-responses.ts
@@ -1,7 +1,6 @@
 import { SchemaRequest } from "src/domain/schema-request";
 import { transformGetSchemaRequests } from "src/domain/schema-request/schema-request-transformer";
 import { SchemaRequestApiResponse } from "src/domain/schema-request/schema-request-types";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 
 const mockedApiResponses: SchemaRequest[] = [
@@ -94,10 +93,10 @@ const mockedEnvironments = [
   { name: "RANDOM", id: "2" },
 ];
 
-const mockedEnvironmentResponse = transformEnvironmentApiResponse([
+const mockedEnvironmentResponse = [
   createMockEnvironmentDTO(mockedEnvironments[0]),
   createMockEnvironmentDTO(mockedEnvironments[1]),
-]);
+];
 
 export {
   mockedApiResponses,

--- a/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/EnvironmentField.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, screen, within } from "@testing-library/react";
 import EnvironmentField from "src/app/features/topics/acl-request/fields/EnvironmentField";
 import { environment } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-shared-fields";
 import { ExtendedEnvironment } from "src/app/features/topics/acl-request/queries/useExtendedEnvironments";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { renderForm } from "src/services/test-utils/render-form";
 import { z } from "zod";
 
@@ -11,37 +12,43 @@ const schema = z.object({
 
 const mockedEnvironments: ExtendedEnvironment[] = [
   {
-    name: "DEV",
-    id: "1",
+    ...createMockEnvironmentDTO({
+      name: "DEV",
+      id: "1",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: ["hello", "there"],
     isAivenCluster: true,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
   },
   {
-    name: "TST",
-    id: "2",
+    ...createMockEnvironmentDTO({
+      name: "TST",
+      id: "2",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: ["hello", "there", "general"],
     isAivenCluster: true,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
   },
   {
-    name: "NOTOPIC",
-    id: "3",
+    ...createMockEnvironmentDTO({
+      name: "NOTOPIC",
+      id: "3",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: [],
     isAivenCluster: true,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
   },
 ];
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -15,6 +15,7 @@ import TopicConsumerForm, {
 } from "src/app/features/topics/acl-request/forms/TopicConsumerForm";
 import { ExtendedEnvironment } from "src/app/features/topics/acl-request/queries/useExtendedEnvironments";
 import { getAivenServiceAccounts } from "src/domain/acl/acl-api";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 jest.mock("src/domain/acl/acl-api");
@@ -27,37 +28,43 @@ const mockedAivenServiceAccountsResponse = ["bsisko", "odo", "quark"];
 
 const mockedEnvironments: ExtendedEnvironment[] = [
   {
-    name: "DEV",
-    id: "1",
+    ...createMockEnvironmentDTO({
+      name: "DEV",
+      id: "1",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: ["hello", "there"],
     isAivenCluster: true,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
   },
   {
-    name: "TST",
-    id: "2",
+    ...createMockEnvironmentDTO({
+      name: "TST",
+      id: "2",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: ["hello", "there", "general"],
-    isAivenCluster: false,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
+    isAivenCluster: true,
   },
   {
-    name: "NOTOPIC",
-    id: "3",
+    ...createMockEnvironmentDTO({
+      name: "NOTOPIC",
+      id: "3",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: [],
     isAivenCluster: true,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
   },
 ];
 

--- a/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicProducerForm.test.tsx
@@ -15,6 +15,7 @@ import TopicProducerForm, {
 } from "src/app/features/topics/acl-request/forms/TopicProducerForm";
 import { ExtendedEnvironment } from "src/app/features/topics/acl-request/queries/useExtendedEnvironments";
 import { getAivenServiceAccounts } from "src/domain/acl/acl-api";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 jest.mock("src/domain/acl/acl-api");
@@ -27,40 +28,45 @@ const mockedAivenServiceAccountsResponse = ["bsisko", "odo", "quark"];
 
 const mockedEnvironments: ExtendedEnvironment[] = [
   {
-    name: "DEV",
-    id: "1",
+    ...createMockEnvironmentDTO({
+      name: "DEV",
+      id: "1",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: ["hello", "there"],
     isAivenCluster: true,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
   },
   {
-    name: "TST",
-    id: "2",
+    ...createMockEnvironmentDTO({
+      name: "TST",
+      id: "2",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: ["hello", "there", "general"],
-    isAivenCluster: false,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
+    isAivenCluster: true,
   },
   {
-    name: "NOTOPIC",
-    id: "3",
+    ...createMockEnvironmentDTO({
+      name: "NOTOPIC",
+      id: "3",
+      type: "kafka",
+      clusterName: "DEV",
+      tenantName: "default",
+      envStatus: "ONLINE",
+      envStatusTimeString: "21-Sep-2023 11:46:15",
+    }),
     topicNames: [],
     isAivenCluster: true,
-    type: "kafka",
-    clusterName: "DEV",
-    tenantName: "default",
-    envStatus: "ONLINE",
-    envStatusTimeString: "21-Sep-2023 11:46:15",
   },
 ];
-
 const baseProps = {
   topicNames: ["hello", "aiventopic2", "othertopic"],
   environments: mockedEnvironments,

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -1,13 +1,12 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import BrowseTopics from "src/app/features/topics/browse/BrowseTopics";
 import {
   Environment,
   getAllEnvironmentsForTopicAndAcl,
 } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { getTeams } from "src/domain/team";
 import { AllTeams } from "src/domain/team/team-types";
 import { getTopics } from "src/domain/topic";
@@ -38,8 +37,7 @@ const mockedGetTopicsResponseSinglePage: TopicApiResponse =
   mockedResponseTransformed;
 const mockedGetTopicsResponseMultiplePages: TopicApiResponse =
   mockedResponseMultiplePageTransformed;
-const mockGetEnvironmentResponse: Environment[] =
-  transformEnvironmentApiResponse(mockedEnvironmentResponse);
+const mockGetEnvironmentResponse: Environment[] = mockedEnvironmentResponse;
 const mockGetTeamsResponse: AllTeams = [
   {
     teamname: "TEST_TEAM_01",

--- a/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
@@ -1,15 +1,14 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
+import * as ReactQuery from "@tanstack/react-query";
 import { cleanup, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { Route, Routes } from "react-router-dom";
 import TopicEditRequest from "src/app/features/topics/request/TopicEditRequest";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
-import { requestTopicEdit, getTopicDetailsPerEnv } from "src/domain/topic";
+import { getTopicDetailsPerEnv, requestTopicEdit } from "src/domain/topic";
 import { getTopicAdvancedConfigOptions } from "src/domain/topic/topic-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import * as ReactQuery from "@tanstack/react-query";
 
 const TOPIC_NAME = "test-topic-name";
 const ENV_ID = "1";
@@ -54,16 +53,14 @@ const mockError = {
   },
 };
 
-const mockEnvironments = transformEnvironmentApiResponse(
-  mockedEnvironmentResponse
-).map((env) => ({
+const mockEnvironments = mockedEnvironmentResponse.map((env) => ({
   ...env,
   params: {
     ...env.params,
-    defaultPartitions: 2,
-    defaultRepFactor: 1,
-    maxPartitions: 2,
-    maxRepFactor: 1,
+    defaultPartitions: "2",
+    defaultRepFactor: "1",
+    maxPartitions: "2",
+    maxRepFactor: "1",
   },
 }));
 

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -38,6 +38,11 @@ import {
 } from "src/domain/topic";
 import { HTTPError } from "src/services/api";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import isString from "lodash/isString";
+
+function parseNumberOrUndefined(value: string | undefined): number | undefined {
+  return isString(value) ? parseInt(value, 10) : undefined;
+}
 
 function TopicEditRequest() {
   const { topicName } = useParams();
@@ -268,7 +273,9 @@ function TopicEditRequest() {
               <SelectOrNumberInput
                 name={"topicpartitions"}
                 label={"Topic partitions"}
-                max={Number(currentEnvironment.params.maxPartitions)}
+                max={parseNumberOrUndefined(
+                  currentEnvironment.params.maxPartitions
+                )}
                 required={true}
               />
             ) : (
@@ -280,7 +287,9 @@ function TopicEditRequest() {
               <SelectOrNumberInput
                 name={"replicationfactor"}
                 label={"Replication factor"}
-                max={Number(currentEnvironment.params?.maxRepFactor)}
+                max={parseNumberOrUndefined(
+                  currentEnvironment.params?.maxRepFactor
+                )}
                 required={true}
               />
             ) : (

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -264,11 +264,11 @@ function TopicEditRequest() {
         />
         <Box.Flex gap={"l1"}>
           <Box width={"1/2"}>
-            {currentEnvironment !== undefined ? (
+            {currentEnvironment?.params.maxPartitions !== undefined ? (
               <SelectOrNumberInput
                 name={"topicpartitions"}
                 label={"Topic partitions"}
-                max={currentEnvironment.params?.maxPartitions}
+                max={Number(currentEnvironment.params.maxPartitions)}
                 required={true}
               />
             ) : (
@@ -276,11 +276,11 @@ function TopicEditRequest() {
             )}
           </Box>
           <Box width={"1/2"}>
-            {currentEnvironment !== undefined ? (
+            {currentEnvironment?.params.maxRepFactor !== undefined ? (
               <SelectOrNumberInput
                 name={"replicationfactor"}
                 label={"Replication factor"}
-                max={currentEnvironment.params?.maxRepFactor}
+                max={Number(currentEnvironment.params?.maxRepFactor)}
                 required={true}
               />
             ) : (

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
@@ -1,11 +1,10 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { Route, Routes } from "react-router-dom";
 import TopicPromotionRequest from "src/app/features/topics/request/TopicPromotionRequest";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { getTopicDetailsPerEnv, requestTopicPromotion } from "src/domain/topic";
 import { getTopicAdvancedConfigOptions } from "src/domain/topic/topic-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -49,16 +48,14 @@ const mockError = {
   },
 };
 
-const mockEnvironments = transformEnvironmentApiResponse(
-  mockedEnvironmentResponse
-).map((env) => ({
+const mockEnvironments = mockedEnvironmentResponse.map((env) => ({
   ...env,
   params: {
     ...env.params,
-    defaultPartitions: 2,
-    defaultRepFactor: 1,
-    maxPartitions: 2,
-    maxRepFactor: 1,
+    defaultPartitions: "2",
+    defaultRepFactor: "1",
+    maxPartitions: "2",
+    maxRepFactor: "1",
   },
 }));
 
@@ -443,10 +440,10 @@ describe("<TopicPromotionRequest />", () => {
           name: "TST",
           params: {
             applyRegex: undefined,
-            defaultPartitions: 2,
-            defaultRepFactor: 1,
-            maxPartitions: 2,
-            maxRepFactor: 1,
+            defaultPartitions: "2",
+            defaultRepFactor: "1",
+            maxPartitions: "2",
+            maxRepFactor: "1",
             topicPrefix: undefined,
             topicSuffix: undefined,
           },

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
@@ -35,6 +35,11 @@ import {
 } from "src/domain/topic";
 import { HTTPError } from "src/services/api";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import isString from "lodash/isString";
+
+function parseNumberOrUndefined(value: string | undefined): number | undefined {
+  return isString(value) ? parseInt(value, 10) : undefined;
+}
 
 function TopicPromotionRequest() {
   const { topicName } = useParams();
@@ -225,11 +230,13 @@ function TopicPromotionRequest() {
         />
         <Box.Flex gap={"l1"}>
           <Box width={"1/2"}>
-            {targetEnvironment?.params.maxPartitions !== undefined ? (
+            {targetEnvironment !== undefined ? (
               <SelectOrNumberInput
                 name={"topicpartitions"}
                 label={"Topic partitions"}
-                max={Number(targetEnvironment.params.maxPartitions)}
+                max={parseNumberOrUndefined(
+                  targetEnvironment.params.maxPartitions
+                )}
                 required={true}
               />
             ) : (
@@ -237,11 +244,13 @@ function TopicPromotionRequest() {
             )}
           </Box>
           <Box width={"1/2"}>
-            {targetEnvironment?.params.maxRepFactor !== undefined ? (
+            {targetEnvironment !== undefined ? (
               <SelectOrNumberInput
                 name={"replicationfactor"}
                 label={"Replication factor"}
-                max={Number(targetEnvironment.params?.maxRepFactor)}
+                max={parseNumberOrUndefined(
+                  targetEnvironment.params?.maxRepFactor
+                )}
                 required={true}
               />
             ) : (

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
@@ -225,11 +225,11 @@ function TopicPromotionRequest() {
         />
         <Box.Flex gap={"l1"}>
           <Box width={"1/2"}>
-            {targetEnvironment !== undefined ? (
+            {targetEnvironment?.params.maxPartitions !== undefined ? (
               <SelectOrNumberInput
                 name={"topicpartitions"}
                 label={"Topic partitions"}
-                max={targetEnvironment.params?.maxPartitions}
+                max={Number(targetEnvironment.params.maxPartitions)}
                 required={true}
               />
             ) : (
@@ -237,11 +237,11 @@ function TopicPromotionRequest() {
             )}
           </Box>
           <Box width={"1/2"}>
-            {targetEnvironment !== undefined ? (
+            {targetEnvironment?.params.maxRepFactor !== undefined ? (
               <SelectOrNumberInput
                 name={"replicationfactor"}
                 label={"Replication factor"}
-                max={targetEnvironment.params?.maxRepFactor}
+                max={Number(targetEnvironment.params?.maxRepFactor)}
                 required={true}
               />
             ) : (

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -1,6 +1,6 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import TopicRequest from "src/app/features/topics/request/TopicRequest";
 import { mockgetEnvironmentsForTopicRequest } from "src/domain/environment/environment-api.msw";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -24,6 +24,11 @@ import { generateTopicNameDescription } from "src/app/features/topics/request/ut
 import { Dialog } from "src/app/components/Dialog";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import isString from "lodash/isString";
+
+function parseNumberOrUndefined(value: string | undefined): number | undefined {
+  return isString(value) ? parseInt(value, 10) : undefined;
+}
 
 function TopicRequest() {
   const navigate = useNavigate();
@@ -145,7 +150,9 @@ function TopicRequest() {
                 <SelectOrNumberInput
                   name={"topicpartitions"}
                   label={"Topic partitions"}
-                  max={selectedEnvironment?.params?.maxPartitions}
+                  max={parseNumberOrUndefined(
+                    selectedEnvironment?.params.maxPartitions
+                  )}
                   required={true}
                 />
               </Box>
@@ -153,7 +160,9 @@ function TopicRequest() {
                 <SelectOrNumberInput
                   name={"replicationfactor"}
                   label={"Replication factor"}
-                  max={selectedEnvironment?.params?.maxRepFactor}
+                  max={parseNumberOrUndefined(
+                    selectedEnvironment?.params.maxRepFactor
+                  )}
                   required={true}
                 />
               </Box>

--- a/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
@@ -20,10 +20,10 @@ const topicPartitionsField = z.string();
 const replicationFactorField = z.string();
 
 const environmentParams = z.object({
-  maxRepFactor: z.number().optional(),
-  maxPartitions: z.number().optional(),
-  defaultPartitions: z.number().optional(),
-  defaultRepFactor: z.number().optional(),
+  maxRepFactor: z.string().optional(),
+  maxPartitions: z.string().optional(),
+  defaultPartitions: z.string().optional(),
+  defaultRepFactor: z.string().optional(),
   applyRegex: z.boolean().optional(),
   topicPrefix: z.array(z.string()).optional(),
   topicSuffix: z.array(z.string()).optional(),
@@ -34,7 +34,7 @@ type EnvironmentForTopicForm = Pick<Environment, "name" | "id" | "params">;
 const environmentField: z.ZodType<EnvironmentForTopicForm> = z.object({
   name: z.string(),
   id: z.string(),
-  params: environmentParams.optional(),
+  params: environmentParams,
 });
 
 const advancedConfigurationField = z.string().optional();
@@ -224,9 +224,9 @@ const useExtendedFormValidationAndTriggers = (
         currentValue: topicPartitions,
         environmentMax: environment.params?.maxPartitions,
         environmentDefault: environment.params?.defaultPartitions,
-        fallbackDefault: 2,
+        fallbackDefault: "2",
       });
-      form.setValue("topicpartitions", nextTopicPartitions.toString(), {
+      form.setValue("topicpartitions", nextTopicPartitions, {
         shouldValidate: false,
       });
 
@@ -234,15 +234,11 @@ const useExtendedFormValidationAndTriggers = (
         currentValue: replicationFactor,
         environmentMax: environment.params?.maxRepFactor,
         environmentDefault: environment.params?.defaultRepFactor,
-        fallbackDefault: 1,
+        fallbackDefault: "1",
       });
-      form.setValue(
-        "replicationfactor",
-        nextReplicationFactorValue.toString(),
-        {
-          shouldValidate: false,
-        }
-      );
+      form.setValue("replicationfactor", nextReplicationFactorValue, {
+        shouldValidate: false,
+      });
 
       if (topicName.length > 0) {
         form.trigger(["replicationfactor", "topicpartitions", "topicname"]);
@@ -269,30 +265,40 @@ const useExtendedFormValidationAndTriggers = (
   }, [topicName]);
 };
 
-type FoobarArgs = {
+type FindNextValueArgs = {
   currentValue: string;
   environmentMax: z.infer<typeof environmentParams>["maxPartitions"];
   environmentDefault: z.infer<typeof environmentParams>["defaultPartitions"];
-  fallbackDefault: number;
+  fallbackDefault: string;
 };
 function findNextValue({
   currentValue,
   environmentMax,
   environmentDefault,
   fallbackDefault,
-}: FoobarArgs): number {
-  if (isNumber(environmentDefault)) {
+}: FindNextValueArgs): string {
+  if (environmentDefault !== undefined) {
     return environmentDefault;
   }
 
   const currentValueAsNumber = parseInt(currentValue, 10);
+
   // parseInt("", 10) = NaN
   if (!Number.isNaN(currentValueAsNumber)) {
-    if (isNumber(environmentMax) && currentValueAsNumber > environmentMax) {
-      return environmentMax;
-    } else {
-      return currentValueAsNumber;
+    if (environmentMax === undefined) {
+      return currentValue;
     }
+
+    const environmentMaxAsNumber = parseInt(environmentMax, 10);
+
+    if (
+      isNumber(environmentMaxAsNumber) &&
+      currentValueAsNumber > environmentMaxAsNumber
+    ) {
+      return environmentMax;
+    }
+
+    return currentValue;
   }
   return fallbackDefault;
 }

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -6,11 +6,10 @@ import {
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { TopicSchemaRequest } from "src/app/features/topics/schema-request/TopicSchemaRequest";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { requestSchemaCreation } from "src/domain/schema-request";
 import { getTopicNames } from "src/domain/topic";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -53,12 +52,11 @@ const mockedEnvironments = [
   { name: "INFRA", id: "3", associatedEnv: { id: "9", name: "INFRA_SCH" } },
   { name: "SOME", id: "3", associatedEnv: undefined },
 ];
-const mockedGetAllEnvironmentsForTopicAndAclResponse =
-  transformEnvironmentApiResponse(
-    mockedEnvironments.map((entry) => {
-      return createMockEnvironmentDTO(entry);
-    })
-  );
+const mockedGetAllEnvironmentsForTopicAndAclResponse = mockedEnvironments.map(
+  (entry) => {
+    return createMockEnvironmentDTO(entry);
+  }
+);
 
 const fileName = "my-awesome-schema.avsc";
 const testFile: File = new File(["{}"], fileName, {

--- a/coral/src/domain/environment/environment-api.ts
+++ b/coral/src/domain/environment/environment-api.ts
@@ -1,7 +1,4 @@
-import {
-  transformEnvironmentApiResponse,
-  transformPaginatedEnvironmentApiResponse,
-} from "src/domain/environment/environment-transformer";
+import { transformPaginatedEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import {
   Environment,
   EnvironmentPaginatedApiResponse,
@@ -10,21 +7,12 @@ import api, { API_PATHS } from "src/services/api";
 import { convertQueryValuesToString } from "src/services/api-helper";
 import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
 
-//  For each entity, there should be two GET endpoints for environments:
-// - one gets *all* environments for that entity: used for browsing (list tables, Approval tables and My requests tables)
-// - one gets environments *filtered according to the admins rules*: used for creating requests (forms)
-
-// Exceptions to this rule:
-// - ACL and Topic share the same environments
-// - ACL requests cannot be promoted, so they have access to all environments in their creation form
-// - @TODO: connector currently do not have a filtered endpoint, but it is a mistake to be corrected
-
 const getAllEnvironmentsForTopicAndAcl = async (): Promise<Environment[]> => {
   const apiResponse = await api.get<KlawApiResponse<"getEnvs">>(
     API_PATHS.getEnvs
   );
 
-  return transformEnvironmentApiResponse(apiResponse);
+  return apiResponse;
 };
 
 const getPaginatedEnvironmentsForTopicAndAcl = async (
@@ -48,7 +36,7 @@ const getEnvironmentsForTopicRequest = async (): Promise<Environment[]> => {
     API_PATHS.getEnvsBaseCluster
   );
 
-  return transformEnvironmentApiResponse(apiResponse);
+  return apiResponse;
 };
 
 const getPaginatedEnvironmentsForSchema = async (
@@ -71,7 +59,7 @@ const getAllEnvironmentsForConnector = async (): Promise<Environment[]> => {
     API_PATHS.getSyncConnectorsEnv
   );
 
-  return transformEnvironmentApiResponse(apiResponse);
+  return apiResponse;
 };
 
 const getPaginatedEnvironmentsForConnector = async (

--- a/coral/src/domain/environment/environment-test-helper.ts
+++ b/coral/src/domain/environment/environment-test-helper.ts
@@ -1,4 +1,3 @@
-import { Environment } from "src/domain/environment/environment-types";
 import { KlawApiModel } from "types/utils";
 
 const defaultEnvironmentDTO: KlawApiModel<"EnvModelResponse"> = {
@@ -38,19 +37,4 @@ function createMockEnvironmentDTO(
   return { ...defaultEnvironmentDTO, ...environment };
 }
 
-const defaultEnvironment: Environment = {
-  name: "DEV",
-  id: "1",
-  params: {},
-  type: "kafka",
-  clusterName: "DEV",
-  tenantName: "default",
-  envStatus: "ONLINE",
-  envStatusTimeString: "21-Sep-2023 11:46:15",
-};
-
-function createEnvironment(environment: Partial<Environment>): Environment {
-  return { ...defaultEnvironment, ...environment };
-}
-
-export { createMockEnvironmentDTO, createEnvironment };
+export { createMockEnvironmentDTO };

--- a/coral/src/domain/environment/environment-transformer.test.ts
+++ b/coral/src/domain/environment/environment-transformer.test.ts
@@ -1,160 +1,35 @@
-import { transformEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
-import { KlawApiModel } from "types/utils";
+import { transformPaginatedEnvironmentApiResponse } from "src/domain/environment/environment-transformer";
 import { Environment } from "src/domain/environment/environment-types";
 
 describe("environment-transformer.ts", () => {
-  describe("transformEnvironmentApiResponse", () => {
-    // even though the openapi definition defines `params` as required
-    // some endpoints don't have a `params` property,
-    // so we need to add a handling for that, too
-    it("transforms API response objects into application domain model without params", () => {
-      const emptyParamsEnv: KlawApiModel<"EnvModelResponse"> =
-        createMockEnvironmentDTO({
-          name: "DEV",
-          id: "1337",
-        });
+  describe("transformPaginatedEnvironmentApiResponse", () => {
+    const apiResponse: Environment[] = [
+      createMockEnvironmentDTO({
+        name: "DEV",
+        totalNoPages: "1",
+        currentPage: "1",
+        totalRecs: 2,
+        allPageNos: ["1"],
+      }),
+      createMockEnvironmentDTO({
+        name: "TST",
+        totalNoPages: "1",
+        currentPage: "1",
+        totalRecs: 2,
+        allPageNos: ["1"],
+      }),
+    ];
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      delete emptyParamsEnv.params;
+    it("should format environments with pagination", () => {
+      const result = transformPaginatedEnvironmentApiResponse(apiResponse);
 
-      const testInput: Omit<KlawApiModel<"EnvModelResponse">, "params">[] = [
-        emptyParamsEnv,
-      ];
-
-      const expectedResult: Environment[] = [
-        {
-          name: "DEV",
-          id: "1337",
-          type: "kafka",
-          clusterName: "DEV",
-          tenantName: "default",
-          envStatus: "ONLINE",
-          envStatusTimeString: "21-Sep-2023 11:46:15",
-        },
-      ];
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      expect(transformEnvironmentApiResponse(testInput)).toEqual(
-        expectedResult
-      );
-    });
-
-    it("transforms API response objects into application domain model with a few params", () => {
-      const testInput: KlawApiModel<"EnvModelResponse">[] = [
-        createMockEnvironmentDTO({
-          name: "DEV",
-          id: "1001",
-          params: {
-            defaultPartitions: "1",
-            topicPrefix: ["dev-"],
-          },
-        }),
-      ];
-
-      const expectedResult: Environment[] = [
-        {
-          name: "DEV",
-          id: "1001",
-          type: "kafka",
-          params: {
-            defaultPartitions: 1,
-            topicPrefix: ["dev-"],
-          },
-          clusterName: "DEV",
-          tenantName: "default",
-          envStatus: "ONLINE",
-          envStatusTimeString: "21-Sep-2023 11:46:15",
-        },
-      ];
-      expect(transformEnvironmentApiResponse(testInput)).toEqual(
-        expectedResult
-      );
-    });
-
-    it("transforms API response objects into application domain model with a all params", () => {
-      const testInput: KlawApiModel<"EnvModelResponse">[] = [
-        createMockEnvironmentDTO({
-          name: "TST",
-          id: "2002",
-          params: {
-            defaultPartitions: "1",
-            maxPartitions: "2",
-            partitionsList: ["hello"],
-            defaultRepFactor: "3",
-            maxRepFactor: "4",
-            replicationFactorList: ["1", "2"],
-            topicPrefix: ["pre_"],
-            topicSuffix: ["_suffix"],
-            topicRegex: ["\\bjon snow\\b"],
-            applyRegex: false,
-          },
-        }),
-      ];
-
-      const expectedResult: Environment[] = [
-        {
-          name: "TST",
-          id: "2002",
-          type: "kafka",
-          params: {
-            defaultPartitions: 1,
-            maxPartitions: 2,
-            defaultRepFactor: 3,
-            maxRepFactor: 4,
-            topicPrefix: ["pre_"],
-            topicSuffix: ["_suffix"],
-            topicRegex: ["\\bjon snow\\b"],
-            applyRegex: false,
-          },
-          clusterName: "DEV",
-          tenantName: "default",
-          envStatus: "ONLINE",
-          envStatusTimeString: "21-Sep-2023 11:46:15",
-        },
-      ];
-
-      expect(transformEnvironmentApiResponse(testInput)).toEqual(
-        expectedResult
-      );
-    });
-
-    it("transforms API response objects into application domain model and removes empty strings where needed", () => {
-      const testInput: KlawApiModel<"EnvModelResponse">[] = [
-        createMockEnvironmentDTO({
-          name: "DEV",
-          id: "1001",
-          params: {
-            defaultPartitions: "1",
-            topicPrefix: ["dev-"],
-            topicSuffix: ["-one", "", "", "-two"],
-            topicRegex: [""],
-          },
-        }),
-      ];
-
-      const expectedResult: Environment[] = [
-        {
-          name: "DEV",
-          id: "1001",
-          type: "kafka",
-          params: {
-            defaultPartitions: 1,
-            topicPrefix: ["dev-"],
-            topicSuffix: ["-one", "-two"],
-            topicRegex: [],
-          },
-          clusterName: "DEV",
-          tenantName: "default",
-          envStatus: "ONLINE",
-          envStatusTimeString: "21-Sep-2023 11:46:15",
-        },
-      ];
-      expect(transformEnvironmentApiResponse(testInput)).toEqual(
-        expectedResult
-      );
+      expect(result).toEqual({
+        totalPages: Number(apiResponse[0].totalNoPages),
+        currentPage: Number(apiResponse[0].currentPage),
+        totalEnvs: Number(apiResponse[0].totalRecs),
+        entries: apiResponse,
+      });
     });
   });
 });

--- a/coral/src/domain/environment/environment-transformer.ts
+++ b/coral/src/domain/environment/environment-transformer.ts
@@ -1,55 +1,8 @@
-import isString from "lodash/isString";
 import {
   Environment,
   EnvironmentPaginatedApiResponse,
 } from "src/domain/environment/environment-types";
 import { KlawApiModel } from "types/utils";
-
-function parseNumberOrUndefined(value: string | undefined): number | undefined {
-  return isString(value) ? parseInt(value, 10) : undefined;
-}
-
-function transformEnvironmentApiResponse(
-  apiResponse: KlawApiModel<"EnvModelResponse">[]
-): Environment[] {
-  return apiResponse.map((environment) => {
-    const rv: Environment = {
-      name: environment.name,
-      id: environment.id,
-      ...(environment.params && {
-        params: {
-          defaultPartitions: parseNumberOrUndefined(
-            environment.params.defaultPartitions
-          ),
-          defaultRepFactor: parseNumberOrUndefined(
-            environment.params.defaultRepFactor
-          ),
-          maxPartitions: parseNumberOrUndefined(
-            environment.params.maxPartitions
-          ),
-          maxRepFactor: parseNumberOrUndefined(environment.params.maxRepFactor),
-          applyRegex: environment.params.applyRegex,
-          topicPrefix: environment.params.topicPrefix?.filter(
-            (prefix) => prefix.length > 0
-          ),
-          topicSuffix: environment.params.topicSuffix?.filter(
-            (suffix) => suffix.length > 0
-          ),
-          topicRegex: environment.params.topicRegex?.filter(
-            (regex) => regex.length > 0
-          ),
-        },
-      }),
-      type: environment?.type,
-      clusterName: environment?.clusterName,
-      tenantName: environment?.tenantName,
-      envStatus: environment?.envStatus,
-      associatedEnv: environment?.associatedEnv,
-      envStatusTimeString: environment.envStatusTimeString,
-    };
-    return rv;
-  });
-}
 
 function transformPaginatedEnvironmentApiResponse(
   apiResponse: KlawApiModel<"EnvModelResponse">[]
@@ -64,40 +17,7 @@ function transformPaginatedEnvironmentApiResponse(
   }
 
   const envData = apiResponse.map((environment) => {
-    const rv: Environment = {
-      name: environment.name,
-      id: environment.id,
-      ...(environment.params && {
-        params: {
-          defaultPartitions: parseNumberOrUndefined(
-            environment.params.defaultPartitions
-          ),
-          defaultRepFactor: parseNumberOrUndefined(
-            environment.params.defaultRepFactor
-          ),
-          maxPartitions: parseNumberOrUndefined(
-            environment.params.maxPartitions
-          ),
-          maxRepFactor: parseNumberOrUndefined(environment.params.maxRepFactor),
-          applyRegex: environment.params.applyRegex,
-          topicPrefix: environment.params.topicPrefix?.filter(
-            (prefix) => prefix.length > 0
-          ),
-          topicSuffix: environment.params.topicSuffix?.filter(
-            (suffix) => suffix.length > 0
-          ),
-          topicRegex: environment.params.topicRegex?.filter(
-            (regex) => regex.length > 0
-          ),
-        },
-      }),
-      type: environment?.type,
-      clusterName: environment?.clusterName,
-      tenantName: environment?.tenantName,
-      envStatus: environment?.envStatus,
-      associatedEnv: environment?.associatedEnv,
-      envStatusTimeString: environment.envStatusTimeString,
-    };
+    const rv: Environment = environment;
     return rv;
   });
 
@@ -105,11 +25,8 @@ function transformPaginatedEnvironmentApiResponse(
     totalPages: Number(apiResponse[0].totalNoPages),
     currentPage: Number(apiResponse[0].currentPage),
     totalEnvs: Number(apiResponse[0].totalRecs),
-    entries: envData.flat(),
+    entries: envData,
   };
 }
 
-export {
-  transformEnvironmentApiResponse,
-  transformPaginatedEnvironmentApiResponse,
-};
+export { transformPaginatedEnvironmentApiResponse };

--- a/coral/src/domain/environment/environment-types.ts
+++ b/coral/src/domain/environment/environment-types.ts
@@ -5,45 +5,7 @@ import {
   ResolveIntersectionTypes,
 } from "types/utils";
 
-type EnvironmentParams = KlawApiModel<"EnvParams">;
-// KlawApiModel<"EnvModel">
-// is only relevant when creating a new Environment and reserved to that usage
-// we're not using that right now, that's why it's commented out
-// type CreateEnvironment = KlawApiModel<"EnvModel">
-
-// KlawApiModel<"EnvModelResponse">
-// This represents the Environment in the Backend and is what we're using
-// when talking about "Environment"
-// we're redefining property types here to fit our need in app better
-// transformEnvironmentApiResponse() is taking care of transforming
-// the properties and makes sure the types are matching between BE and FE
-type Environment = {
-  name: KlawApiModel<"EnvModelResponse">["name"];
-  id: KlawApiModel<"EnvModelResponse">["id"];
-  type: KlawApiModel<"EnvModelResponse">["type"];
-  clusterName: KlawApiModel<"EnvModelResponse">["clusterName"];
-  tenantName: KlawApiModel<"EnvModelResponse">["tenantName"];
-  envStatus: KlawApiModel<"EnvModelResponse">["envStatus"];
-  envStatusTimeString: KlawApiModel<"EnvModelResponse">["envStatusTimeString"];
-  // This property is optional because only Schema Registry environments get it
-  associatedEnv?: KlawApiModel<"EnvModelResponse">["associatedEnv"];
-  // even though the openapi definition defines `params` as required
-  // some endpoints don't have a `params` property,
-  // so we need to make sure that we know where to
-  // handle a potential missing params property
-  params?: {
-    // will be changed to Integer in BE at some point,
-    // and we need it best as a number
-    defaultPartitions?: number;
-    defaultRepFactor?: number;
-    maxPartitions?: number;
-    maxRepFactor?: number;
-    applyRegex?: EnvironmentParams["applyRegex"];
-    topicRegex?: EnvironmentParams["topicRegex"];
-    topicPrefix?: EnvironmentParams["topicPrefix"];
-    topicSuffix?: EnvironmentParams["topicSuffix"];
-  };
-};
+type Environment = KlawApiModel<"EnvModelResponse">;
 
 type EnvironmentInfo = KlawApiModel<"EnvIdInfo">;
 interface PaginatedEnvironmentsWithTotalEnvs extends Paginated<Environment[]> {

--- a/coral/src/domain/topic/topic-api.test.ts
+++ b/coral/src/domain/topic/topic-api.test.ts
@@ -11,6 +11,7 @@ import {
 import { KlawApiRequestQueryParameters } from "types/utils";
 import { Schema } from "src/app/features/topics/request/form-schemas/topic-request-form";
 import { Environment } from "src/domain/environment";
+import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 
 jest.mock("src/domain/helper/documentation-helper.ts");
 
@@ -35,7 +36,7 @@ describe("topic-api", () => {
     });
     it("calls api.post with correct payload", () => {
       const postSpy = jest.spyOn(api, "post");
-      const env: Environment = {
+      const env: Environment = createMockEnvironmentDTO({
         name: "DEV",
         id: "1",
         type: "kafka",
@@ -44,7 +45,7 @@ describe("topic-api", () => {
         tenantName: "default",
         envStatus: "ONLINE",
         envStatusTimeString: "21-Sep-2023 11:46:15",
-      };
+      });
 
       const parameters: Schema = {
         description: "this-is-description",


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

This crafted `Environment` type is, I think, a remnant from when we handcrafted a separate openapi spec for the frontend, instead of relying on the autogenerated one from the backend: https://github.com/Aiven-Open/klaw/blob/main/coral/src/domain/environment/environment-types.ts#L8-L46

The objective was to provide less overwhelming data to the front end, and to focus what we exposed from `domain`. 

However, this leads to significant overhead:
- we need to process the data we get from environment endpoints with a transformer every time (https://github.com/Aiven-Open/klaw/blob/main/coral/src/domain/environment/environment-transformer.ts#L12-L52)
- we need to be careful not to have our custom type diverge from the actual type
- when we introduce a new features which rely on data from the environments that we have not exposed in our custom type, there is a lot of busywork to update it everywhere

# What is the new behavior?

This PR remove the custom `Environment` type and associated functions (transformer, test utils, etc).

The migration went pretty smoothly, with the only notable changes happening in the `topic-request-form` schema and validation (https://github.com/Aiven-Open/klaw/pull/1930/files#diff-e1f292926d06cb44398874a2a3589f2fb69282a01f14cde594e036e0eb9a2750). We used to coerce strings into numbers for the `params` values in the custom `Environment`, which means we needed to change those types in the form schema. This led to some necessary changes in the `useExtendedFormValidationAndTriggers` and `findNextValue` functions.

# Other informations

All indicators are green, but this is still a significant and risky change. I believe it is still better for the maintainability of the app in the long term, though, but if we merge this, we should be extra vigilant. Which is why it's nice to do it at the start of the sprint for the 2.7 release, so we have ample time to see possible bugs and fix them.

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
