### PR TITLE
feat(coral) - Add breadcrumbs to `EntityDetailsHeader` 

### DIFF
--- a/coral/src/app/features/components/EntityDetailsHeader.test.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.test.tsx
@@ -8,12 +8,10 @@ import { customRender } from "src/services/test-utils/render-with-wrappers";
 const testTopic = {
   name: "my-nice-topic",
   type: "topic" as "topic" | "connector",
-  breadcrumbsPaths: ["Topics", "my-nice-topic"],
 };
 const testConnector = {
   name: "my-nice-connector",
   type: "connector" as "topic" | "connector",
-  breadcrumbsPaths: ["Connectors", "my-nice-connector"],
 };
 const testEnvironments: EnvironmentInfo[] = [
   { id: "1", name: "DEV" },
@@ -22,6 +20,10 @@ const testEnvironments: EnvironmentInfo[] = [
 const mockSetEnvironmentId = jest.fn();
 
 const defaultTopicProps = {
+  breadcrumbs: [
+    { path: "topics", name: "Topics" },
+    { path: "my-nice-topic", name: "my-nice-topic" },
+  ],
   entity: testTopic,
   entityEditLink: "/hello/topic",
   showEditButton: true,
@@ -34,6 +36,10 @@ const defaultTopicProps = {
 };
 
 const defaultConnectorProps = {
+  breadcrumbs: [
+    { path: "connectors", name: "Connectors" },
+    { path: "my-nice-connector", name: "my-nice-connector" },
+  ],
   entity: testConnector,
   entityEditLink: "/hello/connector",
   showEditButton: true,

--- a/coral/src/app/features/components/EntityDetailsHeader.test.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen } from "@testing-library/react";
 import { within } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { EntityDetailsHeader } from "src/app/features/components/EntityDetailsHeader";
 import { EnvironmentInfo } from "src/domain/environment";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
@@ -8,10 +8,12 @@ import { customRender } from "src/services/test-utils/render-with-wrappers";
 const testTopic = {
   name: "my-nice-topic",
   type: "topic" as "topic" | "connector",
+  breadcrumbsPaths: ["Topics", "my-nice-topic"],
 };
 const testConnector = {
   name: "my-nice-connector",
   type: "connector" as "topic" | "connector",
+  breadcrumbsPaths: ["Connectors", "my-nice-connector"],
 };
 const testEnvironments: EnvironmentInfo[] = [
   { id: "1", name: "DEV" },
@@ -127,6 +129,21 @@ describe("EntityDetailsHeader", () => {
         });
 
         expect(name).toBeVisible();
+      });
+
+      it("shows breadcrumbs", () => {
+        const breadcrumbs = screen.getByRole("navigation", {
+          name: "Breadcrumbs",
+        });
+        const topicsLink = within(breadcrumbs).getByRole("link", {
+          name: "Topics",
+        });
+        const topicName = within(breadcrumbs).getByRole("link", {
+          name: testTopic.name,
+        });
+
+        expect(topicsLink).toBeVisible();
+        expect(topicName).toBeVisible();
       });
 
       it("shows a select element for environments", () => {
@@ -311,6 +328,21 @@ describe("EntityDetailsHeader", () => {
         });
 
         expect(name).toBeVisible();
+      });
+
+      it("shows breadcrumbs", () => {
+        const breadcrumbs = screen.getByRole("navigation", {
+          name: "Breadcrumbs",
+        });
+        const connectorsLink = within(breadcrumbs).getByRole("link", {
+          name: "Connectors",
+        });
+        const connectorName = within(breadcrumbs).getByRole("link", {
+          name: testConnector.name,
+        });
+
+        expect(connectorsLink).toBeVisible();
+        expect(connectorName).toBeVisible();
       });
 
       it("shows a select element for environments", () => {

--- a/coral/src/app/features/components/EntityDetailsHeader.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.tsx
@@ -12,10 +12,10 @@ import { BreadCrumbsWithLinks } from "src/app/pages/BreadCrumbsWithLinks";
 import { EnvironmentInfo } from "src/domain/environment";
 
 type TopicOverviewHeaderProps = {
+  breadcrumbs: { path: string; name: string }[];
   entity: {
     name: string;
     type: "connector" | "topic";
-    breadcrumbsPaths: string[];
   };
   entityEditLink: string;
   showEditButton: boolean;
@@ -29,6 +29,7 @@ type TopicOverviewHeaderProps = {
 
 function EntityDetailsHeader(props: TopicOverviewHeaderProps) {
   const {
+    breadcrumbs,
     entity,
     showEditButton,
     hasPendingRequest,
@@ -42,7 +43,7 @@ function EntityDetailsHeader(props: TopicOverviewHeaderProps) {
 
   return (
     <Box.Flex flexDirection={"column"} gap={"l2"}>
-      <BreadCrumbsWithLinks paths={entity.breadcrumbsPaths} />
+      <BreadCrumbsWithLinks breadcrumbs={breadcrumbs} />
       <Box
         display={"flex"}
         flexDirection={"row"}

--- a/coral/src/app/features/components/EntityDetailsHeader.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.tsx
@@ -8,10 +8,15 @@ import {
 import database from "@aivenio/aquarium/dist/src/icons/database";
 import { DisabledButtonTooltip } from "src/app/components/DisabledButtonTooltip";
 import { InternalLinkButton } from "src/app/components/InternalLinkButton";
+import { BreadCrumbsWithLinks } from "src/app/pages/BreadCrumbsWithLinks";
 import { EnvironmentInfo } from "src/domain/environment";
 
 type TopicOverviewHeaderProps = {
-  entity: { name: string; type: "connector" | "topic" };
+  entity: {
+    name: string;
+    type: "connector" | "topic";
+    breadcrumbsPaths: string[];
+  };
   entityEditLink: string;
   showEditButton: boolean;
   hasPendingRequest: boolean;
@@ -36,87 +41,90 @@ function EntityDetailsHeader(props: TopicOverviewHeaderProps) {
   } = props;
 
   return (
-    <Box
-      display={"flex"}
-      flexDirection={"row"}
-      alignItems={"start"}
-      justifyContent={"space-between"}
-      marginBottom={"l2"}
-    >
+    <Box.Flex flexDirection={"column"} gap={"l2"}>
+      <BreadCrumbsWithLinks paths={entity.breadcrumbsPaths} />
       <Box
         display={"flex"}
         flexDirection={"row"}
-        alignItems={"center"}
-        colGap={"l2"}
+        alignItems={"start"}
+        justifyContent={"space-between"}
+        marginBottom={"l2"}
       >
-        <Typography.Heading>{entity.name}</Typography.Heading>
+        <Box
+          display={"flex"}
+          flexDirection={"row"}
+          alignItems={"center"}
+          colGap={"l2"}
+        >
+          <Typography.Heading>{entity.name}</Typography.Heading>
 
-        <Box width={"l6"}>
-          {!environments && (
-            <NativeSelectBase
-              placeholder={"Loading"}
-              disabled={true}
-            ></NativeSelectBase>
-          )}
-          {environments && entityExists && (
-            <NativeSelectBase
-              aria-label={"Select environment"}
-              value={environmentId}
-              onChange={(event) => {
-                setEnvironmentId(event.target.value);
-              }}
-            >
-              {environments?.length === 1 && (
-                <Option
-                  aria-readonly={true}
-                  disabled={true}
-                  value={environments[0].id}
-                >
-                  {environments[0].name}
-                </Option>
-              )}
-              {environments.length > 1 &&
-                environments.map((env) => {
-                  return (
-                    <Option key={env.id} value={env.id}>
-                      {env.name}
-                    </Option>
-                  );
-                })}
-            </NativeSelectBase>
+          <Box width={"l6"}>
+            {!environments && (
+              <NativeSelectBase
+                placeholder={"Loading"}
+                disabled={true}
+              ></NativeSelectBase>
+            )}
+            {environments && entityExists && (
+              <NativeSelectBase
+                aria-label={"Select environment"}
+                value={environmentId}
+                onChange={(event) => {
+                  setEnvironmentId(event.target.value);
+                }}
+              >
+                {environments?.length === 1 && (
+                  <Option
+                    aria-readonly={true}
+                    disabled={true}
+                    value={environments[0].id}
+                  >
+                    {environments[0].name}
+                  </Option>
+                )}
+                {environments.length > 1 &&
+                  environments.map((env) => {
+                    return (
+                      <Option key={env.id} value={env.id}>
+                        {env.name}
+                      </Option>
+                    );
+                  })}
+              </NativeSelectBase>
+            )}
+          </Box>
+
+          {entityExists && environments && environments.length > 0 && (
+            <Box display={"flex"} alignItems={"center"} colGap={"2"}>
+              <Typography.SmallStrong color={"grey-40"}>
+                <Icon icon={database} />
+              </Typography.SmallStrong>
+              <Typography.SmallStrong color={"grey-40"}>
+                {environments.length}{" "}
+                {environments.length === 1 ? "Environment" : "Environments"}
+              </Typography.SmallStrong>
+            </Box>
           )}
         </Box>
+        {showEditButton && !hasPendingRequest && (
+          <InternalLinkButton
+            to={entityEditLink}
+            disabled={!entityExists || entityUpdating}
+          >
+            {`Edit ${entity.type}`}
+          </InternalLinkButton>
+        )}
 
-        {entityExists && environments && environments.length > 0 && (
-          <Box display={"flex"} alignItems={"center"} colGap={"2"}>
-            <Typography.SmallStrong color={"grey-40"}>
-              <Icon icon={database} />
-            </Typography.SmallStrong>
-            <Typography.SmallStrong color={"grey-40"}>
-              {environments.length}{" "}
-              {environments.length === 1 ? "Environment" : "Environments"}
-            </Typography.SmallStrong>
-          </Box>
+        {showEditButton && hasPendingRequest && (
+          <DisabledButtonTooltip
+            tooltip={`You cannot edit the ${entity.type} at this time. ${entity.name} has a pending request.`}
+            role={"link"}
+          >
+            {`Edit ${entity.type}`}
+          </DisabledButtonTooltip>
         )}
       </Box>
-      {showEditButton && !hasPendingRequest && (
-        <InternalLinkButton
-          to={entityEditLink}
-          disabled={!entityExists || entityUpdating}
-        >
-          {`Edit ${entity.type}`}
-        </InternalLinkButton>
-      )}
-
-      {showEditButton && hasPendingRequest && (
-        <DisabledButtonTooltip
-          tooltip={`You cannot edit the ${entity.type} at this time. ${entity.name} has a pending request.`}
-          role={"link"}
-        >
-          {`Edit ${entity.type}`}
-        </DisabledButtonTooltip>
-      )}
-    </Box>
+    </Box.Flex>
   );
 }
 

--- a/coral/src/app/features/connectors/details/ConnectorDetails.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.tsx
@@ -163,10 +163,13 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
         />
       )}
       <EntityDetailsHeader
+        breadcrumbs={[
+          { name: "Connectors", path: "connectors" },
+          { name: connectorName, path: connectorName },
+        ]}
         entity={{
           name: connectorName,
           type: "connector",
-          breadcrumbsPaths: ["Connectors", connectorName],
         }}
         entityExists={Boolean(connectorData?.connectorExists)}
         entityUpdating={connectorIsRefetching}

--- a/coral/src/app/features/connectors/details/ConnectorDetails.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.tsx
@@ -163,7 +163,11 @@ function ConnectorDetails(props: ConnectorOverviewProps) {
         />
       )}
       <EntityDetailsHeader
-        entity={{ name: connectorName, type: "connector" }}
+        entity={{
+          name: connectorName,
+          type: "connector",
+          breadcrumbsPaths: ["Connectors", connectorName],
+        }}
         entityExists={Boolean(connectorData?.connectorExists)}
         entityUpdating={connectorIsRefetching}
         entityEditLink={`/connector/${connectorName}/request-update?env=${selectedEnvironmentId}`}

--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -157,10 +157,13 @@ function TopicDetails(props: TopicOverviewProps) {
         />
       )}
       <EntityDetailsHeader
+        breadcrumbs={[
+          { name: "Topics", path: "topics" },
+          { name: topicName, path: topicName },
+        ]}
         entity={{
           name: topicName,
           type: "topic",
-          breadcrumbsPaths: ["Topics", topicName],
         }}
         entityExists={Boolean(topicData?.topicExists)}
         entityEditLink={`/topic/${topicName}/request-update?env=${selectedEnvironmentId}`}

--- a/coral/src/app/features/topics/details/TopicDetails.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.tsx
@@ -157,7 +157,11 @@ function TopicDetails(props: TopicOverviewProps) {
         />
       )}
       <EntityDetailsHeader
-        entity={{ name: topicName, type: "topic" }}
+        entity={{
+          name: topicName,
+          type: "topic",
+          breadcrumbsPaths: ["Topics", topicName],
+        }}
         entityExists={Boolean(topicData?.topicExists)}
         entityEditLink={`/topic/${topicName}/request-update?env=${selectedEnvironmentId}`}
         showEditButton={Boolean(topicData?.topicInfo.showEditTopic)}

--- a/coral/src/app/pages/BreadCrumbsWithLinks.test.tsx
+++ b/coral/src/app/pages/BreadCrumbsWithLinks.test.tsx
@@ -5,9 +5,17 @@ import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 describe("BreadCrumbsWithLinks", () => {
   beforeEach(() =>
-    customRender(<BreadCrumbsWithLinks paths={["hello", "there"]} />, {
-      browserRouter: true,
-    })
+    customRender(
+      <BreadCrumbsWithLinks
+        breadcrumbs={[
+          { path: "hello", name: "Hello" },
+          { path: "there", name: "there" },
+        ]}
+      />,
+      {
+        browserRouter: true,
+      }
+    )
   );
 
   afterEach(cleanup);
@@ -17,7 +25,7 @@ describe("BreadCrumbsWithLinks", () => {
       name: "Breadcrumbs",
     });
     const linkBreadcrumb = within(breadcrumbs).getByRole("link", {
-      name: "hello",
+      name: "Hello",
     });
     const inactiveLinkBreadcrumb = within(breadcrumbs).queryByRole("link", {
       name: "there",
@@ -47,7 +55,7 @@ describe("BreadCrumbsWithLinks", () => {
     });
 
     const linkBreadcrumb = within(breadcrumbs).getByRole("link", {
-      name: "hello",
+      name: "Hello",
     });
 
     expect(linkBreadcrumb).toBeEnabled();

--- a/coral/src/app/pages/BreadCrumbsWithLinks.test.tsx
+++ b/coral/src/app/pages/BreadCrumbsWithLinks.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { BreadCrumbsWithLinks } from "src/app/pages/BreadCrumbsWithLinks";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+
+describe("BreadCrumbsWithLinks", () => {
+  beforeEach(() =>
+    customRender(<BreadCrumbsWithLinks paths={["hello", "there"]} />, {
+      browserRouter: true,
+    })
+  );
+
+  afterEach(cleanup);
+
+  it("shows breadcrumbs to the provided paths", async () => {
+    const breadcrumbs = screen.getByRole("navigation", {
+      name: "Breadcrumbs",
+    });
+    const linkBreadcrumb = within(breadcrumbs).getByRole("link", {
+      name: "hello",
+    });
+    const inactiveLinkBreadcrumb = within(breadcrumbs).queryByRole("link", {
+      name: "there",
+    });
+
+    expect(linkBreadcrumb).toBeVisible();
+    expect(inactiveLinkBreadcrumb).toBeVisible();
+  });
+
+  it("shows inactive link for last element of breadcrumbs", async () => {
+    const breadcrumbs = screen.getByRole("navigation", {
+      name: "Breadcrumbs",
+    });
+
+    const inactiveLinkBreadcrumb = within(breadcrumbs).getByRole("link", {
+      name: "there",
+    });
+
+    await userEvent.click(inactiveLinkBreadcrumb);
+
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("shows active link for first elements of breadcrumbs", async () => {
+    const breadcrumbs = screen.getByRole("navigation", {
+      name: "Breadcrumbs",
+    });
+
+    const linkBreadcrumb = within(breadcrumbs).getByRole("link", {
+      name: "hello",
+    });
+
+    expect(linkBreadcrumb).toBeEnabled();
+
+    await userEvent.click(linkBreadcrumb);
+
+    expect(window.location.pathname).toBe("/hello");
+  });
+});

--- a/coral/src/app/pages/BreadCrumbsWithLinks.tsx
+++ b/coral/src/app/pages/BreadCrumbsWithLinks.tsx
@@ -1,0 +1,23 @@
+import { Breadcrumbs, asCrumb } from "@aivenio/aquarium";
+import { Link, LinkProps } from "react-router-dom";
+
+const LinkCrumb = asCrumb<HTMLAnchorElement, LinkProps>(
+  // asCrumb assserts a very specific return type which does not fit when passing a react-router-dom v6 LInk
+  // This will be fixed in aquarium, and we can then remove the following two lines
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  //@ts-ignore
+  Link,
+  "LinkCrumb"
+);
+
+export const BreadCrumbsWithLinks = ({ paths }: { paths: string[] }) => {
+  const crumbs = paths.map((item) => {
+    return (
+      <LinkCrumb key={item} to={`/${item.toLowerCase()}`}>
+        {item}
+      </LinkCrumb>
+    );
+  });
+
+  return <Breadcrumbs>{crumbs}</Breadcrumbs>;
+};

--- a/coral/src/app/pages/BreadCrumbsWithLinks.tsx
+++ b/coral/src/app/pages/BreadCrumbsWithLinks.tsx
@@ -10,11 +10,15 @@ const LinkCrumb = asCrumb<HTMLAnchorElement, LinkProps>(
   "LinkCrumb"
 );
 
-export const BreadCrumbsWithLinks = ({ paths }: { paths: string[] }) => {
-  const crumbs = paths.map((item) => {
+export const BreadCrumbsWithLinks = ({
+  breadcrumbs,
+}: {
+  breadcrumbs: { path: string; name: string }[];
+}) => {
+  const crumbs = breadcrumbs.map(({ path, name }) => {
     return (
-      <LinkCrumb key={item} to={`/${item.toLowerCase()}`}>
-        {item}
+      <LinkCrumb key={`${path}-${name}`} to={`/${path}`}>
+        {name}
       </LinkCrumb>
     );
   });


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

There is no breadcrumbs in the nested routes (mostly the individual connectors and topics pages).

# What is the new behavior?

Add breadcrumbs to Topic details and Connector details pages through `EntityDetailsHeader`.

https://github.com/Aiven-Open/klaw/assets/20607294/45e8bcc3-3749-4592-8253-51790dff1b72



# Other information

This unpleasantness with `ts-ignore` will be fixed in a subsequent version of `aquarium`: https://github.com/Aiven-Open/klaw/pull/1932/files#diff-805d4419c6d9a1a062e4daa353ee8b9f17e7a0a70df1db782699559982c0cc95R4-R11

The reason for it is a wrong assertion of the return type of `asCrumb`.

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
