### PR TITLE
refactor(coral): Move `mockedEnvironmentResponse` to helper file

### DIFF
--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -18,7 +18,7 @@ import {
   Environment,
   getAllEnvironmentsForTopicAndAcl,
 } from "src/domain/environment";
-import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-test-helper";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -3,7 +3,7 @@ import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { userEvent } from "@testing-library/user-event";
 import TopicApprovals from "src/app/features/approvals/topics/TopicApprovals";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
-import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-test-helper";
 import { getTeams } from "src/domain/team/team-api";
 import { TopicRequest } from "src/domain/topic";
 import {

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -6,7 +6,7 @@ import {
   Environment,
   getAllEnvironmentsForTopicAndAcl,
 } from "src/domain/environment";
-import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-test-helper";
 import { getTeams } from "src/domain/team";
 import { AllTeams } from "src/domain/team/team-types";
 import { getTopics } from "src/domain/topic";

--- a/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.test.tsx
@@ -5,7 +5,7 @@ import { userEvent } from "@testing-library/user-event";
 import { Route, Routes } from "react-router-dom";
 import TopicEditRequest from "src/app/features/topics/request/TopicEditRequest";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
-import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-test-helper";
 import { getTopicDetailsPerEnv, requestTopicEdit } from "src/domain/topic";
 import { getTopicAdvancedConfigOptions } from "src/domain/topic/topic-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
@@ -4,7 +4,7 @@ import { userEvent } from "@testing-library/user-event";
 import { Route, Routes } from "react-router-dom";
 import TopicPromotionRequest from "src/app/features/topics/request/TopicPromotionRequest";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
-import { mockedEnvironmentResponse } from "src/domain/environment/environment-api.msw";
+import { mockedEnvironmentResponse } from "src/domain/environment/environment-test-helper";
 import { getTopicDetailsPerEnv, requestTopicPromotion } from "src/domain/topic";
 import { getTopicAdvancedConfigOptions } from "src/domain/topic/topic-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/domain/environment/environment-api.msw.ts
+++ b/coral/src/domain/environment/environment-api.msw.ts
@@ -1,6 +1,5 @@
 import { SetupServer } from "msw/node";
 import { rest } from "msw";
-import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { getHTTPBaseAPIUrl } from "src/config";
 import { KlawApiResponse } from "types/utils";
 import { operations } from "types/api";
@@ -37,11 +36,6 @@ function mockgetEnvironmentsForTopicRequest({
   );
 }
 
-const mockedEnvironmentResponse = [
-  createMockEnvironmentDTO({ name: "DEV", id: "1" }),
-  createMockEnvironmentDTO({ name: "TST", id: "2" }),
-];
-
 interface GetClusterInfoFromEnvRequestArgs {
   mswInstance: SetupServer;
   response: KlawApiResponse<"getClusterInfoFromEnv">;
@@ -63,6 +57,5 @@ function mockGetClusterInfoFromEnv({
 export {
   mockgetAllEnvironmentsForTopicAndAcl,
   mockgetEnvironmentsForTopicRequest,
-  mockedEnvironmentResponse,
   mockGetClusterInfoFromEnv,
 };

--- a/coral/src/domain/environment/environment-test-helper.ts
+++ b/coral/src/domain/environment/environment-test-helper.ts
@@ -37,4 +37,9 @@ function createMockEnvironmentDTO(
   return { ...defaultEnvironmentDTO, ...environment };
 }
 
-export { createMockEnvironmentDTO };
+const mockedEnvironmentResponse = [
+  createMockEnvironmentDTO({ name: "DEV", id: "1" }),
+  createMockEnvironmentDTO({ name: "TST", id: "2" }),
+];
+
+export { createMockEnvironmentDTO, mockedEnvironmentResponse };


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

We are currently exporting `mockedEnvironmentResponse` from `environment-api.msw.ts`. We are removing our use of `msw`, and there is a `environment-test-helper.test.ts` which is used to export such helper values.

# What is the new behavior?

Export `mockedEnvironmentResponse` from  `environment-test-helper.test.ts`

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
