### PR TITLE
refactor(coral): Update lint settings and apply

### DIFF
--- a/coral/.eslintrc.cjs
+++ b/coral/.eslintrc.cjs
@@ -99,6 +99,7 @@ module.exports = {
         "import/no-anonymous-default-export": "error",
         "import/group-exports": "error",
         "lodash/import-scope": "error",
-        'react/prop-types': 0
+        "react/prop-types": 0,
+        "import/no-named-as-default": "error"
 }
 }

--- a/coral/src/app/components/ComplexNativeSelect.test.tsx
+++ b/coral/src/app/components/ComplexNativeSelect.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, within, screen } from "@testing-library/react";
 import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 type TestOption = {
   id: string;

--- a/coral/src/app/components/Dialog.test.tsx
+++ b/coral/src/app/components/Dialog.test.tsx
@@ -3,7 +3,7 @@ import { Dialog } from "src/app/components/Dialog";
 import confirm from "@aivenio/aquarium/dist/src/icons/confirm";
 import warningSign from "@aivenio/aquarium/dist/src/icons/warningSign";
 import error from "@aivenio/aquarium/dist/src/icons/error";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 describe("Dialog.tsx", () => {
   const testTitle = "Dialog title";

--- a/coral/src/app/components/DisabledButtonTooltip.test.tsx
+++ b/coral/src/app/components/DisabledButtonTooltip.test.tsx
@@ -1,6 +1,6 @@
 import { DisabledButtonTooltip } from "src/app/components/DisabledButtonTooltip";
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const testTooltip = "There is a pending request.";
 const testChild = "Edit this!";

--- a/coral/src/app/components/FileInput.test.tsx
+++ b/coral/src/app/components/FileInput.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { FileInput } from "src/app/components/FileInput";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const testValid = true;
 const testLabelText = "Upload your favorite dog pic!";

--- a/coral/src/app/components/Form.test.tsx
+++ b/coral/src/app/components/Form.test.tsx
@@ -1,6 +1,6 @@
 import { RadioButton as BaseRadioButton } from "@aivenio/aquarium";
 import { cleanup, RenderResult, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import {
   ComplexNativeSelect,
   FileInput,

--- a/coral/src/app/components/Modal.test.tsx
+++ b/coral/src/app/components/Modal.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, RenderResult, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { Modal } from "src/app/components/Modal";
 
 describe("Modal.tsx", () => {

--- a/coral/src/app/components/Pagination.test.tsx
+++ b/coral/src/app/components/Pagination.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, within, screen } from "@testing-library/react";
 import { Pagination } from "src/app/components/Pagination";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 function getNavigationElement() {
   return screen.getByRole("navigation", { name: /Pagination/ });

--- a/coral/src/app/components/documentation/DocumentationEditor.test.tsx
+++ b/coral/src/app/components/documentation/DocumentationEditor.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { within } from "@testing-library/react/pure";
 import { DocumentationEditor } from "src/app/components/documentation/DocumentationEditor";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { tabThroughForward } from "src/services/test-utils/tabbing";
 import { TopicDocumentationMarkdown } from "src/domain/topic";
 

--- a/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/acls/components/AclApprovalsTable.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import AclApprovalsTable, {
   type Props,
 } from "src/app/features/approvals/acls/components/AclApprovalsTable";

--- a/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import ApprovalResourceTabs from "src/app/features/approvals/components/ApprovalResourceTabs";
 import { ApprovalsTabEnum } from "src/app/router_utils";
 import * as requestApi from "src/domain/requests/requests-api";

--- a/coral/src/app/features/approvals/components/RequestDeclineModal.test.tsx
+++ b/coral/src/app/features/approvals/components/RequestDeclineModal.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import RequestDeclineModal from "src/app/features/approvals/components/RequestDeclineModal";
 
 const baseProps = {

--- a/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/connectors/components/ConnectorApprovalsTable.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import ConnectorApprovalsTable from "src/app/features/approvals/connectors/components/ConnectorApprovalsTable";
 import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";

--- a/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/schemas/components/SchemaApprovalsTable.test.tsx
@@ -2,7 +2,7 @@ import SchemaApprovalsTable from "src/app/features/approvals/schemas/components/
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { SchemaRequest } from "src/domain/schema-request";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
 import {

--- a/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
+++ b/coral/src/app/features/approvals/topics/components/TopicApprovalsTable.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { TopicApprovalsTable } from "src/app/features/approvals/topics/components/TopicApprovalsTable";
 import { TopicRequest } from "src/domain/topic";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";

--- a/coral/src/app/features/components/ClaimBanner.test.tsx
+++ b/coral/src/app/features/components/ClaimBanner.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 
 import { ClaimBanner } from "src/app/features/components/ClaimBanner";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const mockClaimEntity = jest.fn();
 

--- a/coral/src/app/features/components/ClaimConfirmationModal.test.tsx
+++ b/coral/src/app/features/components/ClaimConfirmationModal.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { ClaimConfirmationModal } from "src/app/features/components/ClaimConfirmationModal";
 
 const mockOnClose = jest.fn();

--- a/coral/src/app/features/components/RequestDetailsModal.test.tsx
+++ b/coral/src/app/features/components/RequestDetailsModal.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import RequestDetailsModal from "src/app/features/components/RequestDetailsModal";
 
 const primaryActionText = "Approve";

--- a/coral/src/app/features/components/documentation/components/NoDocumentationBanner.test.tsx
+++ b/coral/src/app/features/components/documentation/components/NoDocumentationBanner.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { NoDocumentationBanner } from "src/app/features/components/documentation/components/NoDocumentationBanner";
 
 const testAddDocumentation = jest.fn();

--- a/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/AclTypeFilter.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 import AclTypeFilter from "src/app/features/components/filters/AclTypeFilter";
 import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import EnvironmentFilter from "src/app/features/components/filters/EnvironmentFilter";
 import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import {

--- a/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
+++ b/coral/src/app/features/components/filters/MyRequestsFilter.test.tsx
@@ -1,7 +1,7 @@
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { MyRequestsFilter } from "src/app/features/components/filters/MyRequestsFilter";
 import { cleanup, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 
 const WrappedMyRequestsFilter = withFiltersContext({

--- a/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/RequestTypeFilter.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import {
   requestOperationTypeList,
   requestOperationTypeNameMap,

--- a/coral/src/app/features/components/filters/SearchFilter.test.tsx
+++ b/coral/src/app/features/components/filters/SearchFilter.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { SearchFilter } from "src/app/features/components/filters/SearchFilter";
 import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/features/components/filters/StatusFilter.test.tsx
+++ b/coral/src/app/features/components/filters/StatusFilter.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import {
   requestStatusNameMap,
   statusList,

--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
 import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { getTeams } from "src/domain/team/team-api";

--- a/coral/src/app/features/configuration/environments/Kafka/KafkaEnvironments.test.tsx
+++ b/coral/src/app/features/configuration/environments/Kafka/KafkaEnvironments.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import KafkaEnvironments from "src/app/features/configuration/environments/Kafka/KafkaEnvironments";
 import { getPaginatedEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { transformPaginatedEnvironmentApiResponse } from "src/domain/environment/environment-transformer";

--- a/coral/src/app/features/configuration/environments/KafkaConnect/KafkaConnectEnvironments.test.tsx
+++ b/coral/src/app/features/configuration/environments/KafkaConnect/KafkaConnectEnvironments.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import KafkaConnectEnvironments from "src/app/features/configuration/environments/KafkaConnect/KafkaConnectEnvironments";
 import { getPaginatedEnvironmentsForConnector } from "src/domain/environment";
 import { transformPaginatedEnvironmentApiResponse } from "src/domain/environment/environment-transformer";

--- a/coral/src/app/features/configuration/environments/SchemaRegistry/SchemaRegistryEnvironments.test.tsx
+++ b/coral/src/app/features/configuration/environments/SchemaRegistry/SchemaRegistryEnvironments.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import SchemaRegistryEnvironments from "src/app/features/configuration/environments/SchemaRegistry/SchemaRegistryEnvironments";
 import { getPaginatedEnvironmentsForSchema } from "src/domain/environment";
 import { transformPaginatedEnvironmentApiResponse } from "src/domain/environment/environment-transformer";

--- a/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import EnvironmentStatus from "src/app/features/configuration/environments/components/EnvironmentStatus";
 import { getUpdateEnvStatus } from "src/domain/environment";
 

--- a/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import BrowseConnectors from "src/app/features/connectors/browse/BrowseConnectors";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
@@ -12,7 +12,7 @@ import {
   requestConnectorClaim,
 } from "src/domain/connector";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const mockMatches = jest.fn();
 const mockedNavigate = jest.fn();

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, screen } from "@testing-library/react";
 import { within } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { ConnectorOverviewResourcesTabs } from "src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs";
 import { ConnectorOverviewTabEnum } from "src/app/router_utils";
 import { ConnectorOverview } from "src/domain/connector";

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
@@ -1,6 +1,6 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { useConnectorDetails } from "src/app/features/connectors/details/ConnectorDetails";
 import { ConnectorDocumentation } from "src/app/features/connectors/details/documentation/ConnectorDocumentation";
 import {

--- a/coral/src/app/features/connectors/details/settings/ConnectorSettings.test.tsx
+++ b/coral/src/app/features/connectors/details/settings/ConnectorSettings.test.tsx
@@ -1,6 +1,6 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { ConnectorSettings } from "src/app/features/connectors/details/settings/ConnectorSettings";
 import {
   ConnectorOverview,

--- a/coral/src/app/features/connectors/details/settings/components/ConnectorDeleteConfirmationModal.test.tsx
+++ b/coral/src/app/features/connectors/details/settings/components/ConnectorDeleteConfirmationModal.test.tsx
@@ -1,6 +1,6 @@
 import { ConnectorDeleteConfirmationModal } from "src/app/features/connectors/details/settings/components/ConnectorDeleteConfirmationModal";
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const mockOnClose = jest.fn();
 const mockOnSubmit = jest.fn();

--- a/coral/src/app/features/connectors/request/ConnectorEditRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorEditRequest.test.tsx
@@ -1,6 +1,6 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { Route, Routes } from "react-router-dom";
 import ConnectorEditRequest from "src/app/features/connectors/request/ConnectorEditRequest";
 import {

--- a/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
@@ -14,7 +14,7 @@ import {
   requestConnectorPromotion,
 } from "src/domain/connector";
 import { waitForElementToBeRemoved, within } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 jest.mock("src/domain/environment/environment-api.ts");
 const mockGetConnectorEnvironmentRequest =

--- a/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
@@ -1,6 +1,6 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import ConnectorRequest from "src/app/features/connectors/request/ConnectorRequest";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/features/connectors/request/schemas/connector-request-form.ts
+++ b/coral/src/app/features/connectors/request/schemas/connector-request-form.ts
@@ -1,6 +1,6 @@
 import attempt from "lodash/attempt";
 import isError from "lodash/isError";
-import z from "zod";
+import { z } from "zod";
 
 const connectorRequestFormSchema = z.object({
   environment: z.string().min(1, { message: "Please select an environment" }),

--- a/coral/src/app/features/login/components/LoginForm.test.tsx
+++ b/coral/src/app/features/login/components/LoginForm.test.tsx
@@ -1,6 +1,6 @@
 import { LoginForm } from "src/app/features/login/components/LoginForm";
 import { screen, waitFor, cleanup } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { server } from "src/services/test-utils/api-mocks/server";
 import {

--- a/coral/src/app/features/login/components/LoginForm.tsx
+++ b/coral/src/app/features/login/components/LoginForm.tsx
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import {
   Form,
   PasswordInput,

--- a/coral/src/app/features/requests/RequestResourcesTabs.test.tsx
+++ b/coral/src/app/features/requests/RequestResourcesTabs.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import RequestsResourceTabs from "src/app/features/requests/RequestsResourceTabs";
 import { RequestsTabEnum } from "src/app/router_utils";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -5,7 +5,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import AclRequests from "src/app/features/requests/acls/AclRequests";
 import { deleteAclRequest, getAclRequests } from "src/domain/acl/acl-api";
 import transformAclRequestApiResponse from "src/domain/acl/acl-transformer";

--- a/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/acls/components/AclRequestsTable.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import {
   AclRequestsTable,
   AclRequestsTableProps,

--- a/coral/src/app/features/requests/components/DeleteRequestDialog.test.tsx
+++ b/coral/src/app/features/requests/components/DeleteRequestDialog.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { DeleteRequestDialog } from "src/app/features/requests/components/DeleteRequestDialog";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 describe("DeleteRequestDialog", () => {
   const cancelMock = jest.fn();

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
@@ -5,7 +5,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 import ConnectorRequests from "src/app/features/requests/connectors/ConnectorRequests";

--- a/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/connectors/components/ConnectorRequestsTable.test.tsx
@@ -5,7 +5,7 @@ import {
   ConnectorRequestsTable,
   type ConnectorRequestsTableProps,
 } from "src/app/features/requests/connectors/components/ConnectorRequestsTable";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const mockedRequests: ConnectorRequest[] = [
   {

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -16,7 +16,7 @@ import {
   mockedApiResponseSchemaRequests,
   mockedEnvironmentResponse,
 } from "src/app/features/requests/schemas/utils/mocked-api-responses";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";
 import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";

--- a/coral/src/app/features/requests/schemas/components/SchemaRequestTable.test.tsx
+++ b/coral/src/app/features/requests/schemas/components/SchemaRequestTable.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "src/domain/requests/requests-types";
 import { requestOperationTypeNameMap } from "src/app/features/approvals/utils/request-operation-type-helper";
 import { mockedApiResponses } from "src/app/features/requests/schemas/utils/mocked-api-responses";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const schemaRequests = [...mockedApiResponses];
 const deletableRequests = schemaRequests.filter((entry) => entry.deletable);

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -13,7 +13,7 @@ import { transformGetTopicRequestsResponse } from "src/domain/topic/topic-transf
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import TopicRequests from "src/app/features/requests/topics/TopicRequests";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/app/features/requests/schemas/utils/mocked-api-responses";
 import { requestStatusNameMap } from "src/app/features/approvals/utils/request-status-helper";

--- a/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
+++ b/coral/src/app/features/requests/topics/components/TopicRequestsTable.test.tsx
@@ -5,7 +5,7 @@ import {
   TopicRequestsTable,
   type TopicRequestsTableProps,
 } from "src/app/features/requests/topics/components/TopicRequestsTable";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const mockedRequests: TopicRequest[] = [
   {

--- a/coral/src/app/features/team-info/SwitchTeamsDropdown.test.tsx
+++ b/coral/src/app/features/team-info/SwitchTeamsDropdown.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, screen, within } from "@testing-library/react";
 import { SwitchTeamsDropdown } from "src/app/features/team-info/SwitchTeamsDropdown";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { KlawApiResponse } from "types/utils";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { KlawApiError } from "src/services/api";
 
 jest.mock("src/domain/team/team-api.ts");

--- a/coral/src/app/features/topics/acl-request/fields/AclTypeField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/AclTypeField.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import AclTypeField from "src/app/features/topics/acl-request/fields/AclTypeField";
 
 describe("AclTypeField", () => {

--- a/coral/src/app/features/topics/acl-request/fields/IpOrPrincipalField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/IpOrPrincipalField.test.tsx
@@ -3,7 +3,7 @@ import {
   screen,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import IpOrPrincipalField from "src/app/features/topics/acl-request/fields/IpOrPrincipalField";
 import { aclIpPrincipleType } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-shared-fields";
 import { getAivenServiceAccounts } from "src/domain/acl/acl-api";

--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -6,7 +6,7 @@ import {
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import { within } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { TopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { TopicOverview, TopicSchemaOverview } from "src/domain/topic";
 import {

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { TopicOverviewTabEnum } from "src/app/router_utils";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { TopicOverviewResourcesTabs } from "src/app/features/topics/details/components/TopicDetailsResourceTabs";

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
@@ -1,6 +1,6 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { useTopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { TopicDocumentation } from "src/app/features/topics/details/documentation/TopicDocumentation";
 import {

--- a/coral/src/app/features/topics/details/messages/TopicMessages.test.tsx
+++ b/coral/src/app/features/topics/details/messages/TopicMessages.test.tsx
@@ -4,7 +4,7 @@ import { mockIntersectionObserver } from "src/services/test-utils/mock-intersect
 import { TopicMessages } from "src/app/features/topics/details/messages/TopicMessages";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { Outlet, Route, Routes } from "react-router-dom";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 jest.mock("src/domain/topic/topic-api.ts");
 

--- a/coral/src/app/features/topics/details/messages/components/TopicMessageItem.test.tsx
+++ b/coral/src/app/features/topics/details/messages/components/TopicMessageItem.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { TopicMessageItem } from "src/app/features/topics/details/messages/components/TopicMessageItem";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 describe("TopicMessageItem", () => {
   afterEach(() => {

--- a/coral/src/app/features/topics/details/messages/components/TopicMessageOffsetFilter.test.tsx
+++ b/coral/src/app/features/topics/details/messages/components/TopicMessageOffsetFilter.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { TopicMessageOffsetFilter } from "src/app/features/topics/details/messages/components/TopicMessageOffsetFilter";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 describe("TopicMessageOffsetFilter", () => {
   afterEach(() => {

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -5,7 +5,7 @@ import { TopicDetailsSchema } from "src/app/features/topics/details/schema/Topic
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { TopicSchemaOverview } from "src/domain/topic";
 import { requestSchemaPromotion } from "src/domain/schema-request";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 jest.mock("src/domain/schema-request/schema-request-api.ts");
 const mockPromoteSchemaRequest = requestSchemaPromotion as jest.MockedFunction<

--- a/coral/src/app/features/topics/details/schema/components/NoSchemaBanner.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/NoSchemaBanner.test.tsx
@@ -1,7 +1,7 @@
 import { NoSchemaBanner } from "src/app/features/topics/details/schema/components/NoSchemaBanner";
 import { render, cleanup, screen } from "@testing-library/react";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const mockedNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionBanner.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { SchemaPromotionBanner } from "src/app/features/topics/details/schema/components/SchemaPromotionBanner";
 import { TopicSchemaOverview } from "src/domain/topic";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/features/topics/details/schema/components/SchemaPromotionModal.test.tsx
+++ b/coral/src/app/features/topics/details/schema/components/SchemaPromotionModal.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { SchemaPromotionModal } from "src/app/features/topics/details/schema/components/SchemaPromotionModal";
 
 const mockOnSubmit = jest.fn();

--- a/coral/src/app/features/topics/details/settings/TopicSettings.test.tsx
+++ b/coral/src/app/features/topics/details/settings/TopicSettings.test.tsx
@@ -1,6 +1,6 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { TopicSettings } from "src/app/features/topics/details/settings/TopicSettings";
 import { TopicOverview, requestTopicDeletion } from "src/domain/topic";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/features/topics/details/settings/components/TopicDeleteConfirmationModal.test.tsx
+++ b/coral/src/app/features/topics/details/settings/components/TopicDeleteConfirmationModal.test.tsx
@@ -1,6 +1,6 @@
 import { TopicDeleteConfirmationModal } from "src/app/features/topics/details/settings/components/TopicDeleteConfirmationModal";
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const mockOnClose = jest.fn();
 const mockOnSubmit = jest.fn();

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -6,7 +6,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import TopicSubscriptions from "src/app/features/topics/details/subscriptions/TopicSubscriptions";
 import {
   requestAclDeletion,

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptionsTable.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { TopicSubscriptionsTable } from "src/app/features/topics/details/subscriptions/TopicSubscriptionsTable";
 import { AclOverviewInfo } from "src/domain/topic/topic-types";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";

--- a/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
@@ -1,4 +1,4 @@
-import z, { RefinementCtx } from "zod";
+import { z, RefinementCtx } from "zod";
 import isNumber from "lodash/isNumber";
 import { UseFormReturn } from "react-hook-form";
 import { useEffect } from "react";

--- a/coral/src/app/features/topics/schema-request/components/TopicSchema.test.tsx
+++ b/coral/src/app/features/topics/schema-request/components/TopicSchema.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen } from "@testing-library/react/pure";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { TopicSchema } from "src/app/features/topics/schema-request/components/TopicSchema";
 import { renderForm } from "src/services/test-utils/render-form";
 import { z } from "zod";

--- a/coral/src/app/features/topics/schema-request/form-schemas/topic-schema-request-form.ts
+++ b/coral/src/app/features/topics/schema-request/form-schemas/topic-schema-request-form.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 
 const topicRequestFormSchema = z.object({
   environment: z.string({

--- a/coral/src/app/layout/header/HeaderMenuLink.test.tsx
+++ b/coral/src/app/layout/header/HeaderMenuLink.test.tsx
@@ -1,6 +1,6 @@
 import data from "@aivenio/aquarium/dist/src/icons/console";
 import { cleanup, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import HeaderMenuLink from "src/app/layout/header/HeaderMenuLink";
 import { tabNavigateTo } from "src/services/test-utils/tabbing";
 import { customRender } from "src/services/test-utils/render-with-wrappers";

--- a/coral/src/app/layout/header/ProfileDropdown.test.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import { ProfileDropdown } from "src/app/layout/header/ProfileDropdown";
 import { AuthUser, logoutUser } from "src/domain/auth-user";
 

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import MainNavigation from "src/app/layout/main-navigation/MainNavigation";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import {

--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.test.tsx
@@ -1,7 +1,7 @@
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 import { cleanup, screen, render, within } from "@testing-library/react";
 import data from "@aivenio/aquarium/dist/src/icons/console";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 const textButtonSubmenuClosed = "Topics submenu, closed. Click to open.";
 const textButtonSubmenuOpened = "Topics submenu, open. Click to close.";

--- a/coral/src/app/layout/skip-link/SkipLink.test.tsx
+++ b/coral/src/app/layout/skip-link/SkipLink.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import SkipLink from "src/app/layout/skip-link/SkipLink";
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 describe("SkipLink.tsx", () => {
   let mockedScrollFunction;

--- a/coral/src/services/test-utils/tabbing.tsx
+++ b/coral/src/services/test-utils/tabbing.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 
 async function tabThroughForward(times: number) {
   for (let i = times; i > 0; i--) {


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

## Description

After recent package updates we got eslint warnings from `eslint-plugin-import` rule "no-named-as-default". We should not have warnings - it's either an error or not. I checked and it's ok for us to set this as a warning, I only needed to update the imports for userEvent and z (both packages export the functions additonal as default which we used before, with e.g. `export { userEvent as default, userEvent }`)

Changes:
- rule is now an error
- updates imports for userEvent and z

## Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
