### PR TITLE
Use selectAllTeamsByTenantIdAndTeamId if possible

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -894,6 +894,10 @@ public class SelectDataJdbc {
     return teamRepo.findAllByTenantId(tenantId);
   }
 
+  public List<Team> selectAllTeamsByTenantIdAndTeamId(int tenantId, int teamId) {
+    return teamRepo.findAllByTenantIdAndTeamId(tenantId, teamId);
+  }
+
   public AclRequests selectAcl(int req_no, int tenantId) {
     log.debug("selectAcl {}", req_no);
     AclRequestID aclRequestID = new AclRequestID();
@@ -983,10 +987,6 @@ public class SelectDataJdbc {
   }
 
   public List<Team> selectTeamsOfUsers(String username, int tenantId) {
-    log.debug("selectTeamsOfUsers {}", username);
-    Map<Integer, Team> allTeams =
-        selectAllTeams(tenantId).stream()
-            .collect(Collectors.toMap(Team::getTeamId, Function.identity()));
 
     Optional<UserInfo> userInfoOpt =
         userInfoRepo.findFirstByTenantIdAndUsername(tenantId, username);
@@ -996,13 +996,8 @@ public class SelectDataJdbc {
 
     Integer teamId = userInfoOpt.get().getTeamId();
 
-    Team teamSel = allTeams.get(teamId);
-
-    if (teamSel == null) {
-      return Collections.emptyList();
-    }
-
-    return List.of(teamSel);
+    log.debug("selectTeamsOfUsers {}", username);
+    return selectAllTeamsByTenantIdAndTeamId(tenantId, teamId);
   }
 
   public Map<String, String> getDashboardInfo(Integer teamId, int tenantId) {


### PR DESCRIPTION
Current implementation tries to load all teams by tenantid and then filter it by teamid in java...
At the same time there is already existing method to filter it on db level
The PR is aiming to use this to reduce java load