### PR TITLE
refactor: Inform superadmin user better about coral

### DIFF
--- a/coral/src/app/NoCoralAccessSuperAdmin.test.tsx
+++ b/coral/src/app/NoCoralAccessSuperAdmin.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { NoCoralAccessSuperadmin } from "src/app/components/NoCoralAccessSuperadmin";
+
+describe("NoCoralAccessSuperadmin.tsx", () => {
+  beforeAll(() => {
+    render(<NoCoralAccessSuperadmin />);
+  });
+
+  afterAll(cleanup);
+
+  it("shows an dialog for accessing new user interfacne", () => {
+    const dialog = screen.getByRole("dialog", {
+      name: "You're currently logged in as superadmin.",
+    });
+
+    expect(dialog).toBeVisible();
+  });
+
+  it("informs user that they can access new user interface with user account", () => {
+    const dialog = screen.getByRole("dialog", {
+      name: "You're currently logged in as superadmin.",
+    });
+
+    const text = within(dialog).getByText(
+      "To experience the new user interface, switch to your user account."
+    );
+
+    expect(text).toBeVisible();
+  });
+
+  it("informs user that they can continue to old UI and stay superadmin", () => {
+    const dialog = screen.getByRole("dialog", {
+      name: "You're currently logged in as superadmin.",
+    });
+
+    const text = within(dialog).getByText(
+      "To continue as superadmin, go to the old interface."
+    );
+
+    expect(text).toBeVisible();
+  });
+
+  it("shows a link to login page", () => {
+    const link = screen.getByRole("link", {
+      name: "Login as user",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute("href", "/login");
+  });
+
+  it("shows a link to the start page", () => {
+    const link = screen.getByRole("link", {
+      name: "Go to old interface",
+    });
+
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute("href", "/");
+  });
+});

--- a/coral/src/app/components/NoCoralAccessSuperadmin.tsx
+++ b/coral/src/app/components/NoCoralAccessSuperadmin.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Typography } from "@aivenio/aquarium";
+
+function NoCoralAccessSuperadmin() {
+  return (
+    <Box
+      role="dialog"
+      aria-labelledby={"superadmin-coral-access"}
+      display={"flex"}
+      flexDirection={"column"}
+      paddingTop={"l6"}
+      justifyContent={"center"}
+      alignItems={"center"}
+      rowGap={"l1"}
+    >
+      <Typography.Heading color={"primary-100"}>
+        <span id={"superadmin-coral-access"}>
+          You&apos;re currently logged in as superadmin.
+        </span>
+      </Typography.Heading>
+
+      <Typography.LargeStrong htmlTag={"p"}>
+        To experience the new user interface, switch to your user account.
+      </Typography.LargeStrong>
+      <Typography.LargeStrong htmlTag={"p"}>
+        To continue as superadmin, go to the old interface.
+      </Typography.LargeStrong>
+      <Box.Flex colGap={"l2"}>
+        <Button.ExternalLink href={"/login"}>Login as user</Button.ExternalLink>
+        <Button.ExternalLink href={"/"} kind="secondary">
+          Go to old interface
+        </Button.ExternalLink>
+      </Box.Flex>
+    </Box>
+  );
+}
+
+export { NoCoralAccessSuperadmin };

--- a/coral/src/app/context-provider/AuthProvider.tsx
+++ b/coral/src/app/context-provider/AuthProvider.tsx
@@ -1,9 +1,10 @@
 import { createContext, ReactNode, useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { AuthUser, getAuth } from "src/domain/auth-user";
+import { AuthUser, getAuth, isSuperAdmin } from "src/domain/auth-user";
 import { BasePage } from "src/app/layout/page/BasePage";
 import { Box, Icon } from "@aivenio/aquarium";
 import loading from "@aivenio/aquarium/icons/loading";
+import { NoCoralAccessSuperadmin } from "src/app/components/NoCoralAccessSuperadmin";
 
 /** We don't do Authentication on Corals side
  * at the moment, so we only have a AuthUser
@@ -18,6 +19,14 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
     ["user-getAuth-data"],
     getAuth
   );
+
+  // SUPERADMIN does not have access to coral, so we show a reduced page with
+  // information about that and nothing else.
+  if (!isLoading && authUser && isSuperAdmin(authUser)) {
+    return (
+      <BasePage headerContent={<></>} content={<NoCoralAccessSuperadmin />} />
+    );
+  }
 
   if (!isLoading && authUser) {
     return (

--- a/coral/src/domain/auth-user/auth-user-api.ts
+++ b/coral/src/domain/auth-user/auth-user-api.ts
@@ -1,5 +1,5 @@
 import { AuthUser } from "src/domain/auth-user/auth-user-types";
-import api, { API_PATHS, HTTPError } from "src/services/api";
+import api, { API_PATHS } from "src/services/api";
 import { KlawApiResponse } from "types/utils";
 
 // user roles are added dynamically by admins, we can't make them enums
@@ -13,21 +13,6 @@ function isSuperAdmin(user: AuthUser): user is SuperAdminUser {
 }
 
 function transformAuthResponse(response: KlawApiResponse<"getAuth">): AuthUser {
-  const headers = {} as Headers;
-
-  if (isSuperAdmin(response)) {
-    // We're marking the SUPERADMIN as not authorized
-    // by manually throwing the correct error that will
-    // be caught by isUnauthorizedError
-    const error: HTTPError = {
-      data: " ",
-      headers,
-      status: 401,
-      statusText: "Not authorized to access Coral.",
-    };
-    throw error;
-  }
-
   return {
     username: response.username,
     teamname: response.teamname,
@@ -47,4 +32,4 @@ function logoutUser() {
   return api.post<KlawApiResponse<"logout">, never>(API_PATHS.logout);
 }
 
-export { getAuth, logoutUser };
+export { getAuth, logoutUser, isSuperAdmin };

--- a/coral/src/domain/auth-user/index.ts
+++ b/coral/src/domain/auth-user/index.ts
@@ -1,5 +1,9 @@
-import { getAuth, logoutUser } from "src/domain/auth-user/auth-user-api";
+import {
+  getAuth,
+  logoutUser,
+  isSuperAdmin,
+} from "src/domain/auth-user/auth-user-api";
 import { AuthUser } from "src/domain/auth-user/auth-user-types";
 
-export { getAuth, logoutUser };
+export { getAuth, logoutUser, isSuperAdmin };
 export type { AuthUser };

--- a/core/src/main/java/io/aiven/klaw/model/response/AuthenticationInfo.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/AuthenticationInfo.java
@@ -55,6 +55,7 @@ public class AuthenticationInfo {
   @NotNull private String addDeleteEditClusters;
   @NotNull private String addDeleteEditEnvs;
   @NotNull private String coralEnabled;
+  @NotNull private String coralAvailableForUser;
   @NotNull private String adAuthRoleEnabled;
   @NotNull private String supportlink;
   @NotNull private String myteamtopics;

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -648,6 +648,8 @@ public class UtilControllerService implements InitializingBean {
       authenticationInfo.setCoralEnabled(
           Boolean.toString(coralEnabled && isCoralBuilt && !isUserSuperadmin));
 
+      authenticationInfo.setCoralAvailableForUser(Boolean.toString(coralEnabled && isCoralBuilt));
+
       return authenticationInfo;
     } else return null;
   }

--- a/core/src/main/resources/templates/index.html
+++ b/core/src/main/resources/templates/index.html
@@ -436,6 +436,13 @@
             <!-- Bread crumb and right sidebar toggle -->
             <!-- ============================================================== -->
             <div class="row page-titles">
+                <div class="row" ng-if="dashboardDetails.coralAvailableForUser === 'true' && userrole === 'SUPERADMIN'">
+                    <div class="ribbon-wrapper card">
+                        <div class="ribbon ribbon-success">Explore the new user interface</div>
+                        <p class="ribbon-content">
+                            You're currently logged in as superadmin. To experience the new user interface, switch to your user account.
+                        </p>
+                </div>
             </div>
 
             <div class="row">

--- a/core/src/test/java/io/aiven/klaw/controller/UtilControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/UtilControllerTest.java
@@ -56,6 +56,7 @@ public class UtilControllerTest {
   public void getAuth() throws Exception {
     AuthenticationInfo authenticationInfo = new AuthenticationInfo();
     authenticationInfo.setCoralEnabled("true");
+    authenticationInfo.setCoralAvailableForUser("true");
     when(utilControllerService.getAuth()).thenReturn(authenticationInfo);
 
     mvc.perform(


### PR DESCRIPTION
**NOTE: Stays draft until OK from Harshini and Venla**


# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

- superadmin user don't see a preview banner when coral is enabled
- if a superadmin tries to access a coral route, they are redirected to /login

# What is the new behavior?

- superadmin see a banner informing them about the new interface for users if coral is enabled in built
- if a superadmin tries to access a coral route, they get a reduced page informing them about that coral is only for users and offers a link to either login or the old ui

# Recording functionality
(on my local built)

### When coral is enabled

https://github.com/Aiven-Open/klaw/assets/943800/901376d0-9e7f-40df-b3ca-5d18072e4e80



### When coral is NOT enabled


https://github.com/Aiven-Open/klaw/assets/943800/1f25687d-80c0-4740-9ce7-4bf8b1460ef3


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
