### PR TITLE
feat(coral): View teams

### DIFF
--- a/coral/src/app/features/components/filters/TeamFilter.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.tsx
@@ -4,7 +4,7 @@ import { useFiltersContext } from "src/app/features/components/filters/useFilter
 import { getTeams } from "src/domain/team/team-api";
 
 function TeamFilter() {
-  const { data: topicTeams } = useQuery(["topic-get-teams"], {
+  const { data: topicTeams } = useQuery(["get-teams"], {
     queryFn: () => getTeams(),
   });
 

--- a/coral/src/app/features/configuration/teams/Teams.test.tsx
+++ b/coral/src/app/features/configuration/teams/Teams.test.tsx
@@ -1,0 +1,154 @@
+import { getTeams, Team } from "src/domain/team";
+import { Teams } from "src/app/features/configuration/teams/Teams";
+import {
+  cleanup,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { KlawApiError } from "src/services/api";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+
+jest.mock("src/domain/team/team-api");
+
+const mockGetTeams = getTeams as jest.MockedFunction<typeof getTeams>;
+
+const teamOne: Team = {
+  app: "",
+  contactperson: "Picard",
+  envList: [],
+  serviceAccounts: {},
+  showDeleteTeam: false,
+  teamId: 1111,
+  teammail: "",
+  teamname: "NCC-1701-D",
+  teamphone: "12345",
+  tenantId: 0,
+  tenantName: "UFP",
+};
+const teamTwo: Team = {
+  contactperson: "Pike",
+  showDeleteTeam: false,
+  teamId: 2222,
+  teamname: "NCC-1701",
+  teamphone: "67890",
+  tenantId: 0,
+  tenantName: "default",
+};
+
+const mockedTeams = [teamOne, teamTwo];
+
+describe("Teams.tsx", () => {
+  describe("handles loading state", () => {
+    beforeAll(() => {
+      mockGetTeams.mockResolvedValue([]);
+      customRender(<Teams />, { queryClient: true });
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a loading information", () => {
+      const loadingAnimation = screen.getByTestId("skeleton-table");
+      expect(loadingAnimation).toBeVisible();
+    });
+  });
+
+  describe("handles empty state", () => {
+    beforeAll(async () => {
+      mockGetTeams.mockResolvedValue([]);
+      customRender(<Teams />, { queryClient: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("does not render the table", () => {
+      const table = screen.queryByRole("table");
+      expect(table).not.toBeInTheDocument();
+    });
+
+    it("shows information about the empty state", () => {
+      const heading = screen.getByRole("heading", { name: "No teams" });
+      expect(heading).toBeVisible();
+    });
+  });
+
+  describe("handles error state", () => {
+    const testError: KlawApiError = {
+      message: "OH NO 😭",
+      success: false,
+    };
+
+    const originalConsoleError = console.error;
+
+    beforeAll(async () => {
+      console.error = jest.fn();
+      mockGetTeams.mockRejectedValue(testError);
+      customRender(<Teams />, { queryClient: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+      console.error = originalConsoleError;
+    });
+
+    it("does not render the table", () => {
+      const table = screen.queryByRole("table");
+      expect(table).not.toBeInTheDocument();
+
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("shows an error alert", () => {
+      const error = screen.getByRole("alert");
+
+      expect(error).toBeVisible();
+      expect(error).toHaveTextContent(testError.message);
+      expect(console.error).toHaveBeenCalledWith(testError);
+    });
+  });
+
+  describe("handles rendering of team data", () => {
+    beforeAll(async () => {
+      mockIntersectionObserver();
+      mockGetTeams.mockResolvedValue(mockedTeams);
+      customRender(<Teams />, { queryClient: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a table with team overview", () => {
+      const table = screen.getByRole("table", {
+        name: "Teams overview",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    mockedTeams.forEach((team) => {
+      it(`renders the team name "${team.teamname}"`, () => {
+        const table = screen.getByRole("table", {
+          name: "Teams overview",
+        });
+        const cell = within(table).getByRole("cell", {
+          name: team.teamname,
+        });
+
+        expect(cell).toBeVisible();
+      });
+    });
+  });
+});

--- a/coral/src/app/features/configuration/teams/Teams.tsx
+++ b/coral/src/app/features/configuration/teams/Teams.tsx
@@ -1,13 +1,27 @@
 import { useQuery } from "@tanstack/react-query";
 import { getTeams } from "src/domain/team";
+import { TeamsTable } from "src/app/features/configuration/teams/components/TeamsTable";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 
 function Teams() {
-  const { data: teams } = useQuery(["get-teams"], {
+  const {
+    data: teams,
+    isLoading,
+    isError,
+    error,
+  } = useQuery(["get-teams"], {
     queryFn: () => getTeams(),
   });
 
-  console.log(teams);
-  return <div>Hello</div>;
+  return (
+    <TableLayout
+      filters={[]}
+      table={<TeamsTable teams={teams || []} />}
+      isLoading={isLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
+    />
+  );
 }
 
 export { Teams };

--- a/coral/src/app/features/configuration/teams/Teams.tsx
+++ b/coral/src/app/features/configuration/teams/Teams.tsx
@@ -1,0 +1,5 @@
+function Teams() {
+  return <div>Hello</div>;
+}
+
+export { Teams };

--- a/coral/src/app/features/configuration/teams/Teams.tsx
+++ b/coral/src/app/features/configuration/teams/Teams.tsx
@@ -1,4 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getTeams } from "src/domain/team";
+
 function Teams() {
+  const { data: teams } = useQuery(["get-teams"], {
+    queryFn: () => getTeams(),
+  });
+
+  console.log(teams);
   return <div>Hello</div>;
 }
 

--- a/coral/src/app/features/configuration/teams/components/TeamsTable.test.tsx
+++ b/coral/src/app/features/configuration/teams/components/TeamsTable.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, screen, within, render } from "@testing-library/react";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { TeamsTable } from "src/app/features/configuration/teams/components/TeamsTable";
+import { Team } from "src/domain/team";
+
+const teamOne: Team = {
+  app: "",
+  contactperson: "Picard",
+  envList: [],
+  serviceAccounts: {},
+  showDeleteTeam: false,
+  teamId: 1111,
+  teammail: "",
+  teamname: "NCC-1701-D",
+  teamphone: "12345",
+  tenantId: 0,
+  tenantName: "UFP",
+};
+const teamTwo: Team = {
+  contactperson: "Pike",
+  showDeleteTeam: false,
+  teamId: 2222,
+  teamname: "NCC-1701",
+  teamphone: "67890",
+  tenantId: 0,
+  tenantName: "default",
+};
+
+const mockTeams = [teamOne, teamTwo];
+const tableRowHeader = [
+  "Team name",
+  "Team email",
+  "Team phone",
+  "Contact person",
+  "Tenant",
+];
+
+describe("TeamsTable.tsx", () => {
+  describe("handles empty state", () => {
+    beforeAll(() => {
+      render(<TeamsTable teams={[]} />);
+    });
+    afterAll(cleanup);
+
+    it("show empty state when there is no data", () => {
+      const heading = screen.getByRole("heading", { name: "No teams" });
+      expect(heading).toBeVisible();
+    });
+
+    it("show additional information when there is no data", () => {
+      const text = screen.getByText("There are no teams data available.");
+      expect(text).toBeVisible();
+    });
+  });
+
+  describe("shows all teams data as a table", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(<TeamsTable teams={mockTeams} />);
+    });
+
+    afterAll(cleanup);
+
+    it("renders a team table", async () => {
+      const table = screen.getByRole("table", {
+        name: "Teams overview",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    tableRowHeader.forEach((header) => {
+      it(`renders a column header for ${header}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Teams overview",
+        });
+        const colHeader = within(table).getByRole("columnheader", {
+          name: header,
+        });
+
+        expect(colHeader).toBeVisible();
+      });
+    });
+
+    mockTeams.forEach((team) => {
+      it(`renders the team name "${team.teamname}"`, () => {
+        const table = screen.getByRole("table", {
+          name: "Teams overview",
+        });
+        const cell = within(table).getByRole("cell", {
+          name: team.teamname,
+        });
+
+        expect(cell).toBeVisible();
+      });
+
+      if (team.teammail) {
+        it(`renders the team email if available`, () => {
+          const table = screen.getByRole("table", {
+            name: "Teams overview",
+          });
+          const cell = within(table).getByRole("cell", {
+            name: team.teammail,
+          });
+
+          expect(cell).toBeVisible();
+        });
+      }
+
+      it(`renders the team phone`, () => {
+        const table = screen.getByRole("table", {
+          name: "Teams overview",
+        });
+        const cell = within(table).getByRole("cell", {
+          name: team.teamname,
+        });
+
+        expect(cell).toBeVisible();
+      });
+
+      it(`renders the contact person`, () => {
+        const table = screen.getByRole("table", {
+          name: "Teams overview",
+        });
+        const cell = within(table).getByRole("cell", {
+          name: team.contactperson,
+        });
+
+        expect(cell).toBeVisible();
+      });
+
+      it(`renders the team tenant`, () => {
+        const table = screen.getByRole("table", {
+          name: "Teams overview",
+        });
+        const cell = within(table).getByRole("cell", {
+          name: team.tenantName,
+        });
+
+        expect(cell).toBeVisible();
+      });
+    });
+  });
+});

--- a/coral/src/app/features/configuration/teams/components/TeamsTable.tsx
+++ b/coral/src/app/features/configuration/teams/components/TeamsTable.tsx
@@ -1,0 +1,75 @@
+import { DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import { Team } from "src/domain/team";
+
+type TeamsTableProps = {
+  teams: Team[];
+};
+
+interface TeamsTableRow {
+  id: Team["teamId"];
+  teamname: Team["teamname"];
+  teammail: Team["teammail"];
+  teamphone: Team["teamphone"];
+  contactperson: Team["contactperson"];
+  tenantName: Team["tenantName"];
+}
+
+const TeamsTable = ({ teams }: TeamsTableProps) => {
+  const columns: Array<DataTableColumn<TeamsTableRow>> = [
+    {
+      type: "text",
+      field: "teamname",
+      headerName: "Team name",
+    },
+    {
+      type: "text",
+      field: "teammail",
+      headerName: "Team email",
+    },
+    {
+      type: "text",
+      field: "teamphone",
+      headerName: "Team phone",
+    },
+    {
+      type: "text",
+      field: "contactperson",
+      headerName: "Contact person",
+    },
+    {
+      type: "text",
+      field: "tenantName",
+      headerName: "Tenant",
+    },
+  ];
+
+  const rows: TeamsTableRow[] = teams.map((team) => {
+    return {
+      id: team.teamId,
+      teamname: team.teamname,
+      teammail: team.teammail,
+      teamphone: team.teamphone,
+      contactperson: team.contactperson,
+      tenantName: team.tenantName,
+    };
+  });
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState title="No teams">
+        There are no teams data available.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={"Teams overview"}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+};
+
+export { TeamsTable };

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -7,8 +7,7 @@ import {
   getAllEnvironmentsForTopicAndAcl,
 } from "src/domain/environment";
 import { mockedEnvironmentResponse } from "src/domain/environment/environment-test-helper";
-import { getTeams } from "src/domain/team";
-import { AllTeams } from "src/domain/team/team-types";
+import { getTeams, Team } from "src/domain/team";
 import { getTopics } from "src/domain/topic";
 import {
   mockedResponseTransformed,
@@ -39,7 +38,7 @@ const mockedGetTopicsResponseSinglePage: TopicApiResponse =
 const mockedGetTopicsResponseMultiplePages: TopicApiResponse =
   mockedResponseMultiplePageTransformed;
 const mockGetEnvironmentResponse: Environment[] = mockedEnvironmentResponse;
-const mockGetTeamsResponse: AllTeams = [
+const mockGetTeamsResponse: Team[] = [
   {
     teamname: "TEST_TEAM_01",
     teamphone: "000",

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -11,9 +11,14 @@ import { TeamInfo } from "src/app/features/team-info/TeamInfo";
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 import { Routes } from "src/app/router_utils";
+import useFeatureFlag from "src/services/feature-flags/hook/useFeatureFlag";
+import { FeatureFlag } from "src/services/feature-flags/types";
 
 function MainNavigation() {
   const { pathname } = useLocation();
+  const teamsUsersFeatureFlagEnabled = useFeatureFlag(
+    FeatureFlag.FEATURE_FLAG_USER_TEAMS
+  );
 
   return (
     <Box
@@ -93,7 +98,11 @@ function MainNavigation() {
             defaultExpanded={pathname.startsWith(Routes.CONFIGURATION)}
           >
             <MainNavigationLink to={`/users`} linkText={"Users"} />
-            <MainNavigationLink to={`/teams`} linkText={"Teams"} />
+            <MainNavigationLink
+              to={teamsUsersFeatureFlagEnabled ? Routes.TEAMS : "/teams"}
+              linkText={"Teams"}
+              active={pathname.startsWith(Routes.TEAMS)}
+            />
             <MainNavigationLink
               to={Routes.ENVIRONMENTS}
               linkText={"Environments"}

--- a/coral/src/app/pages/configuration/teams/index.tsx
+++ b/coral/src/app/pages/configuration/teams/index.tsx
@@ -1,10 +1,11 @@
 import { PageHeader } from "@aivenio/aquarium";
+import { Teams } from "src/app/features/configuration/teams/Teams";
 
 const TeamsPage = () => {
   return (
     <>
       <PageHeader title={"Teams"} />
-      <div>hello!</div>
+      <Teams />
     </>
   );
 };

--- a/coral/src/app/pages/configuration/teams/index.tsx
+++ b/coral/src/app/pages/configuration/teams/index.tsx
@@ -1,0 +1,12 @@
+import { PageHeader } from "@aivenio/aquarium";
+
+const TeamsPage = () => {
+  return (
+    <>
+      <PageHeader title={"Teams"} />
+      <div>hello!</div>
+    </>
+  );
+};
+
+export { TeamsPage };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -53,6 +53,9 @@ import {
   TopicOverviewTabEnum,
 } from "src/app/router_utils";
 import { getRouterBasename } from "src/config";
+import { createRouteBehindFeatureFlag } from "src/services/feature-flags/route-utils";
+import { FeatureFlag } from "src/services/feature-flags/types";
+import { TeamsPage } from "src/app/pages/configuration/teams";
 
 const routes: Array<RouteObject> = [
   {
@@ -230,6 +233,12 @@ const routes: Array<RouteObject> = [
               },
             ],
           },
+          createRouteBehindFeatureFlag({
+            path: Routes.TEAMS,
+            featureFlag: FeatureFlag.FEATURE_FLAG_USER_TEAMS,
+            redirectRouteWithoutFeatureFlag: Routes.TOPICS,
+            element: <TeamsPage />,
+          }),
         ],
       },
     ],

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -19,6 +19,7 @@ enum Routes {
   APPROVALS = "/approvals",
   CONFIGURATION = "/configuration",
   ENVIRONMENTS = "/configuration/environments",
+  TEAMS = "/configuration/teams",
 }
 
 enum EnvironmentsTabEnum {

--- a/coral/src/domain/team/index.ts
+++ b/coral/src/domain/team/index.ts
@@ -1,10 +1,5 @@
-import {
-  ALL_TEAMS_VALUE,
-  TeamName,
-  Team,
-  TEAM_NOT_INITIALIZED,
-} from "src/domain/team/team-types";
+import { Team } from "src/domain/team/team-types";
 import { getTeams, getTeamsOfUser } from "src/domain/team/team-api";
 
-export type { TeamName, Team };
-export { getTeams, ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED, getTeamsOfUser };
+export type { Team };
+export { getTeams, getTeamsOfUser };

--- a/coral/src/domain/team/index.ts
+++ b/coral/src/domain/team/index.ts
@@ -1,9 +1,10 @@
 import {
   ALL_TEAMS_VALUE,
   TeamName,
+  Team,
   TEAM_NOT_INITIALIZED,
 } from "src/domain/team/team-types";
 import { getTeams, getTeamsOfUser } from "src/domain/team/team-api";
 
-export type { TeamName };
+export type { TeamName, Team };
 export { getTeams, ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED, getTeamsOfUser };

--- a/coral/src/domain/team/index.ts
+++ b/coral/src/domain/team/index.ts
@@ -1,9 +1,9 @@
 import {
   ALL_TEAMS_VALUE,
-  Team,
+  TeamName,
   TEAM_NOT_INITIALIZED,
 } from "src/domain/team/team-types";
 import { getTeams, getTeamsOfUser } from "src/domain/team/team-api";
 
-export type { Team };
+export type { TeamName };
 export { getTeams, ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED, getTeamsOfUser };

--- a/coral/src/domain/team/team-transformer.ts
+++ b/coral/src/domain/team/team-transformer.ts
@@ -1,9 +1,9 @@
-import { Team } from "src/domain/team/team-types";
+import { TeamName } from "src/domain/team/team-types";
 import { KlawApiResponse } from "types/utils";
 
 function transformTeamNamesGetResponse(
   response: KlawApiResponse<"getAllTeamsSUOnly">
-): Team[] {
+): TeamName[] {
   return response.filter((name) => name !== "All teams");
 }
 

--- a/coral/src/domain/team/team-transformer.ts
+++ b/coral/src/domain/team/team-transformer.ts
@@ -1,9 +1,8 @@
-import { TeamName } from "src/domain/team/team-types";
 import { KlawApiResponse } from "types/utils";
 
 function transformTeamNamesGetResponse(
   response: KlawApiResponse<"getAllTeamsSUOnly">
-): TeamName[] {
+): string[] {
   return response.filter((name) => name !== "All teams");
 }
 

--- a/coral/src/domain/team/team-types.ts
+++ b/coral/src/domain/team/team-types.ts
@@ -9,8 +9,8 @@ import { KlawApiResponse } from "types/utils";
 const ALL_TEAMS_VALUE = "f5ed03b4-c0da-4b18-a534-c7e9a13d1342";
 const TEAM_NOT_INITIALIZED = "931bd061-fb50-4b92-ae49-b1e8004324d3";
 
-type Team = string | typeof ALL_TEAMS_VALUE;
+type TeamName = string | typeof ALL_TEAMS_VALUE;
 type AllTeams = KlawApiResponse<"getAllTeamsSU">;
 
-export type { Team, AllTeams };
+export type { TeamName, AllTeams };
 export { ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED };

--- a/coral/src/domain/team/team-types.ts
+++ b/coral/src/domain/team/team-types.ts
@@ -1,16 +1,5 @@
-// "teamName" is an optional parameter for the getTopics api,
-// but we still need an identifier in frontend
-// to be able to set "All teams" as a visible option
-// for the user, UUID makes sure we don't overlap with an
-
 import { KlawApiModel } from "types/utils";
 
-// actual team name in the future
-const ALL_TEAMS_VALUE = "f5ed03b4-c0da-4b18-a534-c7e9a13d1342";
-const TEAM_NOT_INITIALIZED = "931bd061-fb50-4b92-ae49-b1e8004324d3";
-
-type TeamName = string | typeof ALL_TEAMS_VALUE;
 type Team = KlawApiModel<"TeamModelResponse">;
 
-export type { TeamName, Team };
-export { ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED };
+export type { Team };

--- a/coral/src/domain/team/team-types.ts
+++ b/coral/src/domain/team/team-types.ts
@@ -3,14 +3,14 @@
 // to be able to set "All teams" as a visible option
 // for the user, UUID makes sure we don't overlap with an
 
-import { KlawApiResponse } from "types/utils";
+import { KlawApiModel } from "types/utils";
 
 // actual team name in the future
 const ALL_TEAMS_VALUE = "f5ed03b4-c0da-4b18-a534-c7e9a13d1342";
 const TEAM_NOT_INITIALIZED = "931bd061-fb50-4b92-ae49-b1e8004324d3";
 
 type TeamName = string | typeof ALL_TEAMS_VALUE;
-type AllTeams = KlawApiResponse<"getAllTeamsSU">;
+type Team = KlawApiModel<"TeamModelResponse">;
 
-export type { TeamName, AllTeams };
+export type { TeamName, Team };
 export { ALL_TEAMS_VALUE, TEAM_NOT_INITIALIZED };

--- a/coral/src/services/feature-flags/types.ts
+++ b/coral/src/services/feature-flags/types.ts
@@ -1,3 +1,5 @@
-enum FeatureFlag {}
+enum FeatureFlag {
+  FEATURE_FLAG_USER_TEAMS = "FEATURE_FLAG_USER_TEAMS",
+}
 
 export { FeatureFlag };

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -125,6 +125,7 @@ export default defineConfig(({ mode }) => {
   const environment = loadEnv(mode, process.cwd(), "");
   const usesNodeProxy = mode === "local-api";
 
+  console.log("mode", mode);
   return {
     plugins: getPlugins(environment),
     define: {
@@ -137,6 +138,9 @@ export default defineConfig(({ mode }) => {
       "process.env": {
         ROUTER_BASENAME: getRouterBasename(environment),
         API_BASE_URL: getApiBaseUrl(environment),
+        FEATURE_FLAG_USER_TEAMS: ["development", "remote-api"]
+          .includes(mode)
+          .toString(),
       },
     },
     css: {

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -125,7 +125,6 @@ export default defineConfig(({ mode }) => {
   const environment = loadEnv(mode, process.cwd(), "");
   const usesNodeProxy = mode === "local-api";
 
-  console.log("mode", mode);
   return {
     plugins: getPlugins(environment),
     define: {


### PR DESCRIPTION
# Linked issue

Resolves: #1182 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

## Description

This PR introduces the Teams view based on the current UI.

Note: There's no layout for teams in Figma, but for users. I synced with Venla and we're keeping the currently implemented "1 page for teams, 1 page for users" structure, as it mirrors the Angular app. This is why there are no tabs. 

<img width="1447" alt="Screenshot 2023-11-08 at 11 35 15" src="https://github.com/Aiven-Open/klaw/assets/943800/2ba748c5-4e33-401f-8d1e-6dae53ca7ac4">

## Details
- renames `Team` and `AllTeams` types to be more fitting
- renames query for getting teams for topics, as it's the same endpoint and enables better caching
- adds a feature flag for team and user view
- adds new team page and link to it behind feature flag

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
