### PR TITLE
feat(coral): View users

### DIFF
--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -41,156 +41,315 @@ const WrappedTeamFilter = withFiltersContext({
   element: <TeamFilter />,
 });
 
+const WrappedTeamFilterForTeamName = withFiltersContext({
+  element: <TeamFilter useTeamName={true} />,
+});
+
 const filterLabel = "Filter by team";
 describe("TeamFilter.tsx", () => {
-  describe("renders default view when no query is set", () => {
-    beforeAll(async () => {
-      mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+  describe("handles the teamId per default", () => {
+    describe("renders default view when no query is set", () => {
+      beforeAll(async () => {
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
 
-      customRender(<WrappedTeamFilter />, {
-        memoryRouter: true,
-        queryClient: true,
-      });
-      await waitForElementToBeRemoved(
-        screen.getByTestId("select-team-loading")
-      );
-    });
-
-    afterAll(cleanup);
-
-    it("shows a select element for Team", () => {
-      const select = screen.getByRole("combobox", {
-        name: filterLabel,
+        customRender(<WrappedTeamFilter />, {
+          memoryRouter: true,
+          queryClient: true,
+        });
+        await waitForElementToBeRemoved(
+          screen.getByTestId("select-team-loading")
+        );
       });
 
-      expect(select).toBeEnabled();
-    });
+      afterAll(cleanup);
 
-    it("renders a list of given options for teams plus a option for `All teams`", () => {
-      mockedTeamsResponse.forEach((team) => {
-        const option = screen.getByRole("option", {
-          name: team.teamname,
+      it("shows a select element for Team", () => {
+        const select = screen.getByRole("combobox", {
+          name: filterLabel,
         });
 
-        expect(option).toBeEnabled();
+        expect(select).toBeEnabled();
       });
-      expect(screen.getAllByRole("option")).toHaveLength(
-        mockedTeamsResponse.length + 1
-      );
+
+      it("renders a list of given options for teams plus a option for `All teams`", () => {
+        mockedTeamsResponse.forEach((team) => {
+          const option = screen.getByRole("option", {
+            name: team.teamname,
+          });
+
+          expect(option).toBeEnabled();
+        });
+        expect(screen.getAllByRole("option")).toHaveLength(
+          mockedTeamsResponse.length + 1
+        );
+      });
+
+      it("shows `All teams` as the active option one", () => {
+        const option = screen.getByRole("option", {
+          selected: true,
+        });
+        expect(option).toHaveAccessibleName("All teams");
+      });
     });
 
-    it("shows `All teams` as the active option one", () => {
-      const option = screen.getByRole("option", {
-        selected: true,
+    describe("sets the active team based on a query param", () => {
+      const optionName = "Ospo";
+      const optionId = "1003";
+
+      beforeEach(async () => {
+        const routePath = `/topics?teamId=${optionId}`;
+
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+
+        customRender(<WrappedTeamFilter />, {
+          memoryRouter: true,
+          queryClient: true,
+          customRoutePath: routePath,
+        });
+        await waitForElementToBeRemoved(
+          screen.getByTestId("select-team-loading")
+        );
       });
-      expect(option).toHaveAccessibleName("All teams");
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it("shows `Ospo` as the active option one", async () => {
+        const option = await screen.findByRole("option", {
+          name: optionName,
+          selected: true,
+        });
+        expect(option).toBeVisible();
+      });
+    });
+
+    describe("handles user selecting a team", () => {
+      const optionToSelect = "Ospo";
+      const optionId = "1003";
+
+      beforeEach(async () => {
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+
+        customRender(<WrappedTeamFilter />, {
+          queryClient: true,
+          memoryRouter: true,
+        });
+        await waitForElementToBeRemoved(
+          screen.getByTestId("select-team-loading")
+        );
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it("sets the team the user choose as active option", async () => {
+        const select = screen.getByRole("combobox", {
+          name: filterLabel,
+        });
+        const option = screen.getByRole("option", { name: optionToSelect });
+
+        await userEvent.selectOptions(select, option);
+
+        expect(select).toHaveValue(optionId);
+        expect(select).toHaveDisplayValue(optionToSelect);
+      });
+    });
+
+    describe("updates the search param to preserve team in url", () => {
+      const optionToSelect = "DevRel";
+      const optionId = "1004";
+
+      beforeEach(async () => {
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+        customRender(<WrappedTeamFilter />, {
+          queryClient: true,
+          browserRouter: true,
+        });
+        await waitFor(() => {
+          expect(screen.getByRole("combobox")).toBeVisible();
+        });
+      });
+
+      afterEach(() => {
+        // resets url to get to clean state again
+        window.history.pushState({}, "No page title", "/");
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it("shows no search param by default", async () => {
+        expect(window.location.search).toEqual("");
+      });
+
+      it("sets `teamId=1` and `page=1` as search param when user selected it", async () => {
+        const select = screen.getByRole("combobox", {
+          name: filterLabel,
+        });
+
+        const option = screen.getByRole("option", { name: optionToSelect });
+
+        await userEvent.selectOptions(select, option);
+
+        await waitFor(() => {
+          expect(window.location.search).toEqual(`?teamId=${optionId}&page=1`);
+        });
+      });
     });
   });
 
-  describe("sets the active team based on a query param", () => {
-    const optionName = "Ospo";
-    const optionId = "1003";
+  describe("handles the teamName optional instead of id", () => {
+    describe("renders default view when no query is set", () => {
+      beforeAll(async () => {
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
 
-    beforeEach(async () => {
-      const routePath = `/topics?teamId=${optionId}`;
-
-      mockGetTeams.mockResolvedValue(mockedTeamsResponse);
-
-      customRender(<WrappedTeamFilter />, {
-        memoryRouter: true,
-        queryClient: true,
-        customRoutePath: routePath,
+        customRender(<WrappedTeamFilterForTeamName />, {
+          memoryRouter: true,
+          queryClient: true,
+        });
+        await waitForElementToBeRemoved(
+          screen.getByTestId("select-team-loading")
+        );
       });
-      await waitForElementToBeRemoved(
-        screen.getByTestId("select-team-loading")
-      );
-    });
 
-    afterEach(() => {
-      jest.resetAllMocks();
-      cleanup();
-    });
+      afterAll(cleanup);
 
-    it("shows `Ospo` as the active option one", async () => {
-      const option = await screen.findByRole("option", {
-        name: optionName,
-        selected: true,
+      it("shows a select element for Team", () => {
+        const select = screen.getByRole("combobox", {
+          name: filterLabel,
+        });
+
+        expect(select).toBeEnabled();
       });
-      expect(option).toBeVisible();
-    });
-  });
 
-  describe("handles user selecting a team", () => {
-    const optionToSelect = "Ospo";
-    const optionId = "1003";
+      it("renders a list of given options for teams plus a option for `All teams`", () => {
+        mockedTeamsResponse.forEach((team) => {
+          const option = screen.getByRole("option", {
+            name: team.teamname,
+          });
 
-    beforeEach(async () => {
-      mockGetTeams.mockResolvedValue(mockedTeamsResponse);
-
-      customRender(<WrappedTeamFilter />, {
-        queryClient: true,
-        memoryRouter: true,
+          expect(option).toBeEnabled();
+        });
+        expect(screen.getAllByRole("option")).toHaveLength(
+          mockedTeamsResponse.length + 1
+        );
       });
-      await waitForElementToBeRemoved(
-        screen.getByTestId("select-team-loading")
-      );
-    });
 
-    afterEach(() => {
-      jest.resetAllMocks();
-      cleanup();
-    });
-
-    it("sets the team the user choose as active option", async () => {
-      const select = screen.getByRole("combobox", {
-        name: filterLabel,
-      });
-      const option = screen.getByRole("option", { name: optionToSelect });
-
-      await userEvent.selectOptions(select, option);
-
-      expect(select).toHaveValue(optionId);
-      expect(select).toHaveDisplayValue(optionToSelect);
-    });
-  });
-
-  describe("updates the search param to preserve team in url", () => {
-    const optionToSelect = "DevRel";
-    const optionId = "1004";
-
-    beforeEach(async () => {
-      mockGetTeams.mockResolvedValue(mockedTeamsResponse);
-      customRender(<WrappedTeamFilter />, {
-        queryClient: true,
-        browserRouter: true,
-      });
-      await waitFor(() => {
-        expect(screen.getByRole("combobox")).toBeVisible();
+      it("shows `All teams` as the active option one", () => {
+        const option = screen.getByRole("option", {
+          selected: true,
+        });
+        expect(option).toHaveAccessibleName("All teams");
       });
     });
 
-    afterEach(() => {
-      // resets url to get to clean state again
-      window.history.pushState({}, "No page title", "/");
-      jest.resetAllMocks();
-      cleanup();
-    });
+    describe("sets the active team based on a query param", () => {
+      const optionName = "Ospo";
 
-    it("shows no search param by default", async () => {
-      expect(window.location.search).toEqual("");
-    });
+      beforeEach(async () => {
+        const routePath = `/topics?teamName=${optionName}`;
 
-    it("sets `teamId=1` and `page=1` as search param when user selected it", async () => {
-      const select = screen.getByRole("combobox", {
-        name: filterLabel,
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+
+        customRender(<WrappedTeamFilterForTeamName />, {
+          memoryRouter: true,
+          queryClient: true,
+          customRoutePath: routePath,
+        });
+        await waitForElementToBeRemoved(
+          screen.getByTestId("select-team-loading")
+        );
       });
 
-      const option = screen.getByRole("option", { name: optionToSelect });
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
 
-      await userEvent.selectOptions(select, option);
+      it("shows `Ospo` as the active option one", async () => {
+        const option = await screen.findByRole("option", {
+          name: optionName,
+          selected: true,
+        });
+        expect(option).toBeVisible();
+      });
+    });
 
-      await waitFor(() => {
-        expect(window.location.search).toEqual(`?teamId=${optionId}&page=1`);
+    describe("handles user selecting a team", () => {
+      const optionToSelect = "Ospo";
+
+      beforeEach(async () => {
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+
+        customRender(<WrappedTeamFilterForTeamName />, {
+          queryClient: true,
+          memoryRouter: true,
+        });
+        await waitForElementToBeRemoved(
+          screen.getByTestId("select-team-loading")
+        );
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it("sets the team the user choose as active option", async () => {
+        const select = screen.getByRole("combobox", {
+          name: filterLabel,
+        });
+        const option = screen.getByRole("option", { name: optionToSelect });
+
+        await userEvent.selectOptions(select, option);
+
+        expect(select).toHaveValue(optionToSelect);
+        expect(select).toHaveDisplayValue(optionToSelect);
+      });
+    });
+
+    describe("updates the search param to preserve team name in url", () => {
+      const optionToSelect = "DevRel";
+
+      beforeEach(async () => {
+        mockGetTeams.mockResolvedValue(mockedTeamsResponse);
+        customRender(<WrappedTeamFilterForTeamName />, {
+          queryClient: true,
+          browserRouter: true,
+        });
+        await waitFor(() => {
+          expect(screen.getByRole("combobox")).toBeVisible();
+        });
+      });
+
+      afterEach(() => {
+        // resets url to get to clean state again
+        window.history.pushState({}, "No page title", "/");
+        jest.resetAllMocks();
+        cleanup();
+      });
+
+      it("shows no search param by default", async () => {
+        expect(window.location.search).toEqual("");
+      });
+
+      it("sets `teamName=DevRel` and `page=1` as search param when user selected it", async () => {
+        const select = screen.getByRole("combobox", {
+          name: filterLabel,
+        });
+
+        const option = screen.getByRole("option", { name: optionToSelect });
+
+        await userEvent.selectOptions(select, option);
+
+        await waitFor(() => {
+          expect(window.location.search).toEqual(
+            `?teamName=${optionToSelect}&page=1`
+          );
+        });
       });
     });
   });

--- a/coral/src/app/features/components/filters/TeamFilter.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.tsx
@@ -3,14 +3,17 @@ import { useQuery } from "@tanstack/react-query";
 import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { getTeams } from "src/domain/team/team-api";
 
-function TeamFilter() {
-  const { data: topicTeams } = useQuery(["get-teams"], {
+type TeamFilterProps = {
+  useTeamName?: boolean;
+};
+function TeamFilter({ useTeamName }: TeamFilterProps) {
+  const { data: teams } = useQuery(["get-teams"], {
     queryFn: () => getTeams(),
   });
 
-  const { teamId, setFilterValue } = useFiltersContext();
+  const { teamId, teamName, setFilterValue } = useFiltersContext();
 
-  if (!topicTeams) {
+  if (!teams) {
     return (
       <div data-testid={"select-team-loading"}>
         <NativeSelect.Skeleton />
@@ -20,16 +23,22 @@ function TeamFilter() {
     return (
       <NativeSelect
         labelText="Filter by team"
-        value={teamId}
-        onChange={(event) =>
-          setFilterValue({ name: "teamId", value: event.target.value })
-        }
+        value={useTeamName ? teamName : teamId}
+        onChange={(event) => {
+          return setFilterValue({
+            name: useTeamName ? "teamName" : "teamId",
+            value: event.target.value,
+          });
+        }}
       >
         <Option key={"ALL"} value={"ALL"}>
           All teams
         </Option>
-        {topicTeams.map((team) => (
-          <Option key={team.teamId} value={team.teamId}>
+        {teams.map((team) => (
+          <Option
+            key={team.teamId}
+            value={useTeamName ? team.teamname : team.teamId}
+          >
             {team.teamname}
           </Option>
         ))}

--- a/coral/src/app/features/components/filters/useFiltersContext.tsx
+++ b/coral/src/app/features/components/filters/useFiltersContext.tsx
@@ -5,7 +5,6 @@ import {
   RequestOperationType,
   RequestStatus,
 } from "src/domain/requests/requests-types";
-import { ALL_TEAMS_VALUE } from "src/domain/team";
 
 type SetFiltersParams =
   | { name: "environment"; value: string }

--- a/coral/src/app/features/components/filters/useFiltersContext.tsx
+++ b/coral/src/app/features/components/filters/useFiltersContext.tsx
@@ -5,6 +5,7 @@ import {
   RequestOperationType,
   RequestStatus,
 } from "src/domain/requests/requests-types";
+import { ALL_TEAMS_VALUE } from "src/domain/team";
 
 type SetFiltersParams =
   | { name: "environment"; value: string }
@@ -13,7 +14,8 @@ type SetFiltersParams =
   | { name: "teamId"; value: string }
   | { name: "showOnlyMyRequests"; value: boolean }
   | { name: "requestType"; value: RequestOperationType }
-  | { name: "search"; value: string };
+  | { name: "search"; value: string }
+  | { name: "teamName"; value: string };
 
 interface UseFiltersDefaultValues {
   environment: string;
@@ -24,6 +26,7 @@ interface UseFiltersDefaultValues {
   requestType: RequestOperationType;
   search: string;
   paginated: boolean;
+  teamName: string;
 }
 
 interface UseFiltersReturnedValues
@@ -36,6 +39,7 @@ const emptyValues: UseFiltersDefaultValues = {
   aclType: "ALL",
   status: "ALL",
   teamId: "ALL",
+  teamName: "ALL",
   showOnlyMyRequests: false,
   requestType: "ALL",
   search: "",
@@ -73,6 +77,7 @@ const FiltersProvider = ({
     initialValues.requestType;
   const search = searchParams.get("search") ?? initialValues.search;
   const paginated = initialValues.paginated;
+  const teamName = searchParams.get("teamName") ?? initialValues.teamName;
 
   const setFilterValue = ({ name, value }: SetFiltersParams) => {
     const parsedValue = typeof value === "boolean" ? String(value) : value;
@@ -94,6 +99,7 @@ const FiltersProvider = ({
     aclType,
     status,
     teamId,
+    teamName,
     showOnlyMyRequests,
     requestType,
     search,

--- a/coral/src/app/features/configuration/users/Users.test.tsx
+++ b/coral/src/app/features/configuration/users/Users.test.tsx
@@ -1,0 +1,263 @@
+import {
+  cleanup,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { KlawApiError } from "src/services/api";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { getUserList, User } from "src/domain/user";
+import { Users } from "src/app/features/configuration/users/Users";
+import { userEvent } from "@testing-library/user-event";
+
+jest.mock("src/domain/user/user-api");
+
+const mockGetUsers = getUserList as jest.MockedFunction<typeof getUserList>;
+
+const userOne: User = {
+  fullname: "Jean-Luc Picard",
+  mailid: "jlpicard@ufp.org",
+  role: "CAPTAIN",
+  switchTeams: false,
+  team: "Enterprise",
+  teamId: 1,
+  tenantId: 0,
+  username: "js-picard",
+};
+
+const userTwo: User = {
+  fullname: "Chris Pike",
+  mailid: "cpike@ufp.org",
+  role: "SUPERADMIN",
+  switchAllowedTeamIds: [1, 2],
+  switchAllowedTeamNames: ["Enterprise", "Discovery"],
+  switchTeams: true,
+  team: "Discovery",
+  teamId: 2,
+  tenantId: 0,
+  username: "c-pike",
+};
+
+const mockUsers = [userOne, userTwo];
+
+describe("Users.tsx", () => {
+  describe("handles loading state", () => {
+    beforeAll(() => {
+      mockGetUsers.mockResolvedValue({
+        currentPage: 1,
+        totalPages: 1,
+        entries: [],
+      });
+      customRender(<Users />, { queryClient: true, memoryRouter: true });
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a loading information", () => {
+      const loadingAnimation = screen.getByTestId("skeleton-table");
+      expect(loadingAnimation).toBeVisible();
+    });
+  });
+
+  describe("handles empty state", () => {
+    beforeAll(async () => {
+      mockGetUsers.mockResolvedValue({
+        currentPage: 1,
+        totalPages: 1,
+        entries: [],
+      });
+      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("does not render the table", () => {
+      const table = screen.queryByRole("table");
+      expect(table).not.toBeInTheDocument();
+    });
+
+    it("shows information about the empty state", () => {
+      const heading = screen.getByRole("heading", { name: "No users" });
+      expect(heading).toBeVisible();
+    });
+  });
+
+  describe("handles error state", () => {
+    const testError: KlawApiError = {
+      message: "OH NO 😭",
+      success: false,
+    };
+
+    const originalConsoleError = console.error;
+
+    beforeAll(async () => {
+      console.error = jest.fn();
+      mockGetUsers.mockRejectedValue(testError);
+      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+      console.error = originalConsoleError;
+    });
+
+    it("does not render the table", () => {
+      const table = screen.queryByRole("table");
+      expect(table).not.toBeInTheDocument();
+
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("shows an error alert", () => {
+      const error = screen.getByRole("alert");
+
+      expect(error).toBeVisible();
+      expect(error).toHaveTextContent(testError.message);
+      expect(console.error).toHaveBeenCalledWith(testError);
+    });
+  });
+
+  describe("handles successful response with one page", () => {
+    beforeAll(async () => {
+      mockIntersectionObserver();
+      mockGetUsers.mockResolvedValue({
+        currentPage: 1,
+        totalPages: 1,
+        entries: mockUsers,
+      });
+      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a table with user overview", () => {
+      const table = screen.getByRole("table", {
+        name: "Users overview, page 1 of 1",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    it("does not render the pagination", () => {
+      const pagination = screen.queryByRole("navigation", {
+        name: /Pagination/,
+      });
+
+      expect(pagination).not.toBeInTheDocument();
+    });
+
+    mockUsers.forEach((user) => {
+      it(`renders the user name "${user.username}"`, () => {
+        const table = screen.getByRole("table", {
+          name: /Users overview/,
+        });
+        const cell = within(table).getByRole("cell", {
+          name: user.username,
+        });
+
+        expect(cell).toBeVisible();
+      });
+    });
+  });
+
+  describe("handles successful response with 3 pages", () => {
+    beforeAll(async () => {
+      mockIntersectionObserver();
+      mockGetUsers.mockResolvedValue({
+        currentPage: 2,
+        totalPages: 4,
+        entries: mockUsers,
+      });
+      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a table with user overview", () => {
+      const table = screen.getByRole("table", {
+        name: "Users overview, page 2 of 4",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    it("does the pagination with current and all pages", () => {
+      const pagination = screen.getByRole("navigation", {
+        name: "Pagination navigation, you're on page 2 of 4",
+      });
+
+      expect(pagination).toBeVisible();
+    });
+
+    mockUsers.forEach((user) => {
+      it(`renders the user name "${user.username}"`, () => {
+        const table = screen.getByRole("table", {
+          name: /Users overview/,
+        });
+        const cell = within(table).getByRole("cell", {
+          name: user.username,
+        });
+
+        expect(cell).toBeVisible();
+      });
+    });
+  });
+
+  describe("handles user stepping through pagination", () => {
+    beforeEach(async () => {
+      mockIntersectionObserver();
+      mockGetUsers.mockResolvedValue({
+        currentPage: 3,
+        totalPages: 5,
+        entries: mockUsers,
+      });
+      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      cleanup();
+    });
+
+    it("shows page 3 as currently active page and the total page number", () => {
+      const pagination = screen.getByRole("navigation", {
+        name: /Pagination/,
+      });
+
+      expect(pagination).toHaveAccessibleName(
+        "Pagination navigation, you're on page 3 of 5"
+      );
+    });
+
+    it("fetches new data when user clicks on next page", async () => {
+      const pageTwoButton = screen.getByRole("button", {
+        name: "Go to next page, page 4",
+      });
+
+      await userEvent.click(pageTwoButton);
+
+      expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
+        pageNo: "4",
+      });
+    });
+  });
+});

--- a/coral/src/app/features/configuration/users/Users.test.tsx
+++ b/coral/src/app/features/configuration/users/Users.test.tsx
@@ -71,6 +71,8 @@ const teamTwo: Team = {
 const mockedTeams = [teamOne, teamTwo];
 
 describe("Users.tsx", () => {
+  const user = userEvent.setup();
+
   describe("handles loading state", () => {
     beforeAll(() => {
       mockGetTeams.mockResolvedValue([]);
@@ -295,7 +297,7 @@ describe("Users.tsx", () => {
         name: "Go to next page, page 4",
       });
 
-      await userEvent.click(pageTwoButton);
+      await user.click(pageTwoButton);
 
       expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
         pageNo: "4",
@@ -344,24 +346,40 @@ describe("Users.tsx", () => {
 
       const option = within(select).getByRole("option", { name: teamToSelect });
 
-      await userEvent.selectOptions(select, option);
+      await user.selectOptions(select, option);
 
-      expect(mockGetUsers).toHaveBeenCalledWith({
+      //first call on load
+      expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
         pageNo: "1",
         teamName: "NCC-1701-D",
       });
     });
 
     it("removes teamName as url param when user chooses All teams", async () => {
+      const teamToSelect = mockedTeams[0].teamname;
       const select = screen.getByRole("combobox", {
         name: "Filter by team",
       });
+      const optionOne = within(select).getByRole("option", {
+        name: teamToSelect,
+      });
 
-      const option = within(select).getByRole("option", { name: "All teams" });
+      await user.selectOptions(select, optionOne);
 
-      await userEvent.selectOptions(select, option);
+      //first call on load
+      expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
+        pageNo: "1",
+        teamName: "NCC-1701-D",
+      });
 
-      expect(mockGetUsers).toHaveBeenCalledWith({
+      const optionTwo = within(select).getByRole("option", {
+        name: "All teams",
+      });
+
+      await user.selectOptions(select, optionTwo);
+
+      //first call on load, second for the first filter
+      expect(mockGetUsers).toHaveBeenNthCalledWith(3, {
         pageNo: "1",
       });
     });
@@ -403,7 +421,7 @@ describe("Users.tsx", () => {
         name: "Search username",
       });
 
-      await userEvent.type(search, usernameSearch);
+      await user.type(search, usernameSearch);
 
       await waitFor(() => {
         expect(mockGetUsers).toHaveBeenCalledWith({
@@ -420,7 +438,7 @@ describe("Users.tsx", () => {
         name: "Search username",
       });
 
-      await userEvent.type(search, usernameSearch);
+      await user.type(search, usernameSearch);
 
       await waitFor(() => {
         // first call is on load
@@ -430,7 +448,7 @@ describe("Users.tsx", () => {
         });
       });
 
-      await userEvent.clear(search);
+      await user.clear(search);
 
       await waitFor(() => {
         // first call is on load, second for search

--- a/coral/src/app/features/configuration/users/Users.tsx
+++ b/coral/src/app/features/configuration/users/Users.tsx
@@ -1,0 +1,58 @@
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import { useQuery } from "@tanstack/react-query";
+import { getUserList } from "src/domain/user";
+import { UsersTable } from "src/app/features/configuration/users/components/UsersTable";
+import { Pagination } from "src/app/components/Pagination";
+import { useSearchParams } from "react-router-dom";
+
+function Users() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = searchParams.get("page")
+    ? Number(searchParams.get("page"))
+    : 1;
+
+  const {
+    data: users,
+    isLoading,
+    isError,
+    error,
+  } = useQuery(["get-user-list", currentPage], {
+    queryFn: () => getUserList({ pageNo: String(currentPage) }),
+  });
+
+  function handleChangePage(page: number) {
+    searchParams.set("page", page.toString());
+    setSearchParams(searchParams);
+  }
+
+  const pagination =
+    users && users.totalPages > 1 ? (
+      <Pagination
+        activePage={users.currentPage}
+        totalPages={users.totalPages}
+        setActivePage={handleChangePage}
+      />
+    ) : undefined;
+
+  const table = (
+    <UsersTable
+      users={users?.entries || []}
+      ariaLabel={`Users overview, page ${users?.currentPage ?? 0} of ${
+        users?.totalPages ?? 0
+      }`}
+    />
+  );
+
+  return (
+    <TableLayout
+      filters={[]}
+      table={table}
+      pagination={pagination}
+      isLoading={isLoading}
+      isErrorLoading={isError}
+      errorMessage={error}
+    />
+  );
+}
+
+export { Users };

--- a/coral/src/app/features/configuration/users/Users.tsx
+++ b/coral/src/app/features/configuration/users/Users.tsx
@@ -60,7 +60,7 @@ function UsersWithoutFilterContext() {
   return (
     <TableLayout
       filters={[
-        <TeamFilter useTeamName={true} key={"team"} />,
+        <TeamFilter useTeamName key={"team"} />,
         <SearchFilter
           key="search"
           label="Search username"

--- a/coral/src/app/features/configuration/users/Users.tsx
+++ b/coral/src/app/features/configuration/users/Users.tsx
@@ -9,10 +9,11 @@ import {
   withFiltersContext,
 } from "src/app/features/components/filters/useFiltersContext";
 import TeamFilter from "src/app/features/components/filters/TeamFilter";
+import { SearchFilter } from "src/app/features/components/filters/SearchFilter";
 
 function UsersWithoutFilterContext() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { teamName } = useFiltersContext();
+  const { teamName, search } = useFiltersContext();
 
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
@@ -23,11 +24,12 @@ function UsersWithoutFilterContext() {
     isLoading,
     isError,
     error,
-  } = useQuery(["get-user-list", currentPage, teamName], {
+  } = useQuery(["get-user-list", currentPage, teamName, search], {
     queryFn: () =>
       getUserList({
         pageNo: String(currentPage),
         teamName: teamName === "ALL" ? undefined : teamName,
+        searchUserParam: search.length === 0 ? undefined : search,
       }),
     keepPreviousData: true,
   });
@@ -57,7 +59,16 @@ function UsersWithoutFilterContext() {
 
   return (
     <TableLayout
-      filters={[<TeamFilter useTeamName={true} key={"team"} />]}
+      filters={[
+        <TeamFilter useTeamName={true} key={"team"} />,
+        <SearchFilter
+          key="search"
+          label="Search username"
+          placeholder={"infrateam"}
+          description={`Partial match for user name`}
+          ariaDescription={`Searching starts automatically with a little delay while typing. Press "Escape" to delete all your input.`}
+        />,
+      ]}
       table={table}
       pagination={pagination}
       isLoading={isLoading}

--- a/coral/src/app/features/configuration/users/Users.tsx
+++ b/coral/src/app/features/configuration/users/Users.tsx
@@ -24,7 +24,7 @@ function UsersWithoutFilterContext() {
     isLoading,
     isError,
     error,
-  } = useQuery(["get-user-list", currentPage, teamName, search], {
+  } = useQuery(["getUserList", currentPage, teamName, search], {
     queryFn: () =>
       getUserList({
         pageNo: String(currentPage),

--- a/coral/src/app/features/configuration/users/Users.tsx
+++ b/coral/src/app/features/configuration/users/Users.tsx
@@ -4,9 +4,16 @@ import { getUserList } from "src/domain/user";
 import { UsersTable } from "src/app/features/configuration/users/components/UsersTable";
 import { Pagination } from "src/app/components/Pagination";
 import { useSearchParams } from "react-router-dom";
+import {
+  useFiltersContext,
+  withFiltersContext,
+} from "src/app/features/components/filters/useFiltersContext";
+import TeamFilter from "src/app/features/components/filters/TeamFilter";
 
-function Users() {
+function UsersWithoutFilterContext() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { teamName } = useFiltersContext();
+
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
     : 1;
@@ -16,8 +23,13 @@ function Users() {
     isLoading,
     isError,
     error,
-  } = useQuery(["get-user-list", currentPage], {
-    queryFn: () => getUserList({ pageNo: String(currentPage) }),
+  } = useQuery(["get-user-list", currentPage, teamName], {
+    queryFn: () =>
+      getUserList({
+        pageNo: String(currentPage),
+        teamName: teamName === "ALL" ? undefined : teamName,
+      }),
+    keepPreviousData: true,
   });
 
   function handleChangePage(page: number) {
@@ -45,7 +57,7 @@ function Users() {
 
   return (
     <TableLayout
-      filters={[]}
+      filters={[<TeamFilter useTeamName={true} key={"team"} />]}
       table={table}
       pagination={pagination}
       isLoading={isLoading}
@@ -54,5 +66,9 @@ function Users() {
     />
   );
 }
+
+const Users = withFiltersContext({
+  element: <UsersWithoutFilterContext />,
+});
 
 export { Users };

--- a/coral/src/app/features/configuration/users/components/UsersTable.test.tsx
+++ b/coral/src/app/features/configuration/users/components/UsersTable.test.tsx
@@ -1,0 +1,173 @@
+import { cleanup, screen, render, within } from "@testing-library/react";
+import { UsersTable } from "src/app/features/configuration/users/components/UsersTable";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { User } from "src/domain/user";
+
+const userOne: User = {
+  fullname: "Jean-Luc Picard",
+  mailid: "jlpicard@ufp.org",
+  role: "CAPTAIN",
+  switchTeams: false,
+  team: "Enterprise",
+  teamId: 1,
+  tenantId: 0,
+  username: "js-picard",
+};
+
+const userTwo: User = {
+  fullname: "Chris Pike",
+  mailid: "cpike@ufp.org",
+  role: "SUPERADMIN",
+  switchAllowedTeamIds: [1, 2],
+  switchAllowedTeamNames: ["Enterprise", "Discovery"],
+  switchTeams: true,
+  team: "Discovery",
+  teamId: 2,
+  tenantId: 0,
+  username: "c-pike",
+};
+
+const mockUsers = [userOne, userTwo];
+
+const tableRowHeader = [
+  "Username",
+  "Name",
+  "Role",
+  "Team",
+  "Email ID",
+  "Switch teams",
+  "Switch between teams",
+];
+
+const testLabel = "Users overview, page 1 of 1";
+describe("UsersTable.tsx", () => {
+  describe("handles empty state", () => {
+    beforeAll(() => {
+      render(<UsersTable users={[]} ariaLabel={testLabel} />);
+    });
+    afterAll(cleanup);
+
+    it("show empty state when there is no data", () => {
+      const heading = screen.getByRole("heading", { name: "No users" });
+      expect(heading).toBeVisible();
+    });
+
+    it("show additional information when there is no data", () => {
+      const text = screen.getByText("There are no users data available.");
+      expect(text).toBeVisible();
+    });
+  });
+
+  describe("shows all users as a table", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(<UsersTable users={mockUsers} ariaLabel={testLabel} />);
+    });
+
+    afterAll(cleanup);
+
+    it("renders a users table", async () => {
+      const table = screen.getByRole("table", {
+        name: testLabel,
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    tableRowHeader.forEach((header) => {
+      it(`renders a column header for ${header}`, () => {
+        const table = screen.getByRole("table", {
+          name: testLabel,
+        });
+        const colHeader = within(table).getByRole("columnheader", {
+          name: header,
+        });
+
+        expect(colHeader).toBeVisible();
+      });
+    });
+
+    mockUsers.forEach((user) => {
+      it(`renders the user name "${user.username}"`, () => {
+        const table = screen.getByRole("table", {
+          name: testLabel,
+        });
+        const cell = within(table).getByRole("cell", {
+          name: user.username,
+        });
+
+        expect(cell).toBeVisible();
+      });
+
+      it(`renders the users full name "${user.fullname}"`, () => {
+        const table = screen.getByRole("table", {
+          name: testLabel,
+        });
+        const cell = within(table).getByRole("cell", {
+          name: user.fullname,
+        });
+
+        expect(cell).toBeVisible();
+      });
+
+      it(`renders the users team "${user.team}"`, () => {
+        const table = screen.getByRole("table", {
+          name: testLabel,
+        });
+        const cell = within(table).getByRole("cell", {
+          name: user.team,
+        });
+
+        expect(cell).toBeVisible();
+      });
+
+      it(`renders the users email ID "${user.mailid}"`, () => {
+        const table = screen.getByRole("table", {
+          name: testLabel,
+        });
+        const cell = within(table).getByRole("cell", {
+          name: user.mailid,
+        });
+
+        expect(cell).toBeVisible();
+      });
+
+      it(`renders indicator that user can switch team`, () => {
+        const table = screen.getByRole("table", {
+          name: testLabel,
+        });
+
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${user.username}`, "i"),
+        });
+        const cell = within(row).getAllByRole("cell");
+
+        const positionOfSwitchTeamRow = tableRowHeader.indexOf("Switch teams");
+        expect(cell[positionOfSwitchTeamRow]).toHaveTextContent(
+          user.switchTeams ? "enabled" : "false"
+        );
+      });
+
+      if (user.switchAllowedTeamNames) {
+        it(`renders all teams a user can switch between if its enabled for them`, () => {
+          const table = screen.getByRole("table", {
+            name: testLabel,
+          });
+
+          const row = within(table).getByRole("row", {
+            name: new RegExp(`${user.username}`, "i"),
+          });
+          const cell = within(row).getAllByRole("cell");
+
+          const positionOfTeamsToSwitch = tableRowHeader.indexOf(
+            "Switch between teams"
+          );
+
+          user.switchAllowedTeamNames?.forEach((name) => {
+            expect(cell[positionOfTeamsToSwitch]).toHaveTextContent(name);
+          });
+        });
+      }
+    });
+  });
+});

--- a/coral/src/app/features/configuration/users/components/UsersTable.tsx
+++ b/coral/src/app/features/configuration/users/components/UsersTable.tsx
@@ -1,0 +1,119 @@
+import { Box, DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import { User } from "src/domain/user";
+import uniqueId from "lodash/uniqueId";
+
+type UsersProps = {
+  users: User[];
+  ariaLabel: string;
+};
+
+interface UsersRow {
+  id: string;
+  username: User["username"];
+  fullname: User["fullname"];
+  role: User["role"];
+  team: User["team"];
+  mailid: User["mailid"];
+  switchTeams: User["switchTeams"];
+  switchAllowedTeamNames: User["switchAllowedTeamNames"];
+}
+
+const UsersTable = ({ users, ariaLabel }: UsersProps) => {
+  const columns: Array<DataTableColumn<UsersRow>> = [
+    {
+      type: "text",
+      field: "username",
+      headerName: "Username",
+    },
+    {
+      type: "text",
+      field: "fullname",
+      headerName: "Name",
+    },
+    {
+      type: "status",
+      field: "role",
+      headerName: "Role",
+      status: ({ role }) => ({
+        status: role === "SUPERADMIN" ? "info" : "neutral",
+        text: role,
+      }),
+    },
+    {
+      type: "text",
+      field: "team",
+      headerName: "Team",
+    },
+    {
+      type: "text",
+      field: "mailid",
+      headerName: "Email ID",
+    },
+    {
+      type: "status",
+      field: "switchTeams",
+      headerName: "Switch teams",
+      status: ({ switchTeams }) => ({
+        status: switchTeams ? "success" : "neutral",
+        text: switchTeams ? "enabled" : "false",
+      }),
+    },
+    {
+      type: "custom",
+      field: "switchAllowedTeamNames",
+      width: 200,
+      headerName: "Switch between teams",
+      UNSAFE_render: ({ switchAllowedTeamNames }) => {
+        if (switchAllowedTeamNames) {
+          return (
+            <Box.Flex
+              component={"ul"}
+              width={"fit"}
+              flexWrap={"wrap"}
+              gap={"1"}
+            >
+              {switchAllowedTeamNames.map((team, index) => (
+                <li key={`${team}-${index}`}>
+                  {team}
+                  {index === switchAllowedTeamNames.length - 1 ? "" : ","}
+                </li>
+              ))}
+            </Box.Flex>
+          );
+        }
+      },
+    },
+  ];
+
+  const rows: UsersRow[] = users.map((user) => {
+    return {
+      id: uniqueId(),
+      username: user.username,
+      fullname: user.fullname,
+      role: user.role,
+      team: user.team,
+      mailid: user.mailid,
+      switchTeams: user.switchTeams,
+      switchAllowedTeamNames: user.switchAllowedTeamNames,
+    };
+  });
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState title="No users">
+        There are no users data available.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <DataTable
+      ariaLabel={ariaLabel}
+      columns={columns}
+      rows={rows}
+      noWrap={false}
+    />
+  );
+};
+
+export { UsersTable };

--- a/coral/src/app/features/configuration/users/components/UsersTable.tsx
+++ b/coral/src/app/features/configuration/users/components/UsersTable.tsx
@@ -32,7 +32,6 @@ const UsersTable = ({ users, ariaLabel }: UsersProps) => {
     },
     {
       type: "status",
-      field: "role",
       headerName: "Role",
       status: ({ role }) => ({
         status: role === "SUPERADMIN" ? "info" : "neutral",
@@ -51,7 +50,6 @@ const UsersTable = ({ users, ariaLabel }: UsersProps) => {
     },
     {
       type: "status",
-      field: "switchTeams",
       headerName: "Switch teams",
       status: ({ switchTeams }) => ({
         status: switchTeams ? "success" : "neutral",
@@ -60,7 +58,6 @@ const UsersTable = ({ users, ariaLabel }: UsersProps) => {
     },
     {
       type: "custom",
-      field: "switchAllowedTeamNames",
       width: 200,
       headerName: "Switch between teams",
       UNSAFE_render: ({ switchAllowedTeamNames }) => {

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -189,6 +189,53 @@ describe("MainNavigation.tsx", () => {
     });
   });
 
+  describe("renders links to users behind feature flag", () => {
+    afterEach(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("renders a link to the old UI when feature flag is false", async () => {
+      isFeatureFlagActiveMock.mockReturnValueOnce(false);
+      customRender(<MainNavigation />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
+
+      const button = screen.getByRole("button", {
+        name: new RegExp("Configuration", "i"),
+      });
+      await userEvent.click(button);
+      const list = screen.getByRole("list", {
+        name: `Configuration submenu`,
+      });
+
+      const link = within(list).getByRole("link", { name: "Users" });
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute("href", "/users");
+    });
+
+    it("renders a link to the users page when feature flag is true", async () => {
+      isFeatureFlagActiveMock.mockReturnValueOnce(true);
+      customRender(<MainNavigation />, {
+        memoryRouter: true,
+        queryClient: true,
+      });
+
+      const button = screen.getByRole("button", {
+        name: new RegExp("Configuration", "i"),
+      });
+      await userEvent.click(button);
+      const list = screen.getByRole("list", {
+        name: `Configuration submenu`,
+      });
+
+      const link = within(list).getByRole("link", { name: "Users" });
+      expect(link).toBeVisible();
+      expect(link).toHaveAttribute("href", "/configuration/users");
+    });
+  });
+
   describe("user can open submenus and see more links", () => {
     beforeEach(() => {
       customRender(<MainNavigation />, {

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -97,7 +97,11 @@ function MainNavigation() {
             text={"Configuration"}
             defaultExpanded={pathname.startsWith(Routes.CONFIGURATION)}
           >
-            <MainNavigationLink to={`/users`} linkText={"Users"} />
+            <MainNavigationLink
+              to={teamsUsersFeatureFlagEnabled ? Routes.USERS : "/users"}
+              linkText={"Users"}
+              active={pathname.startsWith(Routes.USERS)}
+            />
             <MainNavigationLink
               to={teamsUsersFeatureFlagEnabled ? Routes.TEAMS : "/teams"}
               linkText={"Teams"}

--- a/coral/src/app/main.module.css
+++ b/coral/src/app/main.module.css
@@ -22,6 +22,14 @@ body {
   -webkit-text-size-adjust: 100%;
 }
 
+/*!* removes the "x" in search inputs from webkit *!*/
+/*input[type="search"]::-webkit-search-decoration,*/
+/*input[type="search"]::-webkit-search-cancel-button,*/
+/*input[type="search"]::-webkit-search-results-button,*/
+/*input[type="search"]::-webkit-search-results-decoration {*/
+/*  display: none;*/
+/*}*/
+
 /*Override custom CSS variables DS*/
 :root {
   --aquarium-colors-primary-100: #0788d1;

--- a/coral/src/app/main.module.css
+++ b/coral/src/app/main.module.css
@@ -23,12 +23,12 @@ body {
 }
 
 /*!* removes the "x" in search inputs from webkit *!*/
-/*input[type="search"]::-webkit-search-decoration,*/
-/*input[type="search"]::-webkit-search-cancel-button,*/
-/*input[type="search"]::-webkit-search-results-button,*/
-/*input[type="search"]::-webkit-search-results-decoration {*/
-/*  display: none;*/
-/*}*/
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  display: none;
+}
 
 /*Override custom CSS variables DS*/
 :root {

--- a/coral/src/app/pages/configuration/users/index.tsx
+++ b/coral/src/app/pages/configuration/users/index.tsx
@@ -1,10 +1,11 @@
 import { PageHeader } from "@aivenio/aquarium";
+import { Users } from "src/app/features/configuration/users/Users";
 
 const UsersPage = () => {
   return (
     <>
       <PageHeader title={"Users"} />
-      <div>Hello</div>
+      <Users />
     </>
   );
 };

--- a/coral/src/app/pages/configuration/users/index.tsx
+++ b/coral/src/app/pages/configuration/users/index.tsx
@@ -1,0 +1,12 @@
+import { PageHeader } from "@aivenio/aquarium";
+
+const UsersPage = () => {
+  return (
+    <>
+      <PageHeader title={"Users"} />
+      <div>Hello</div>
+    </>
+  );
+};
+
+export { UsersPage };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -56,6 +56,7 @@ import { getRouterBasename } from "src/config";
 import { createRouteBehindFeatureFlag } from "src/services/feature-flags/route-utils";
 import { FeatureFlag } from "src/services/feature-flags/types";
 import { TeamsPage } from "src/app/pages/configuration/teams";
+import { UsersPage } from "src/app/pages/configuration/users";
 
 const routes: Array<RouteObject> = [
   {
@@ -238,6 +239,12 @@ const routes: Array<RouteObject> = [
             featureFlag: FeatureFlag.FEATURE_FLAG_USER_TEAMS,
             redirectRouteWithoutFeatureFlag: Routes.TOPICS,
             element: <TeamsPage />,
+          }),
+          createRouteBehindFeatureFlag({
+            path: Routes.USERS,
+            featureFlag: FeatureFlag.FEATURE_FLAG_USER_TEAMS,
+            redirectRouteWithoutFeatureFlag: Routes.TOPICS,
+            element: <UsersPage />,
           }),
         ],
       },

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -20,6 +20,7 @@ enum Routes {
   CONFIGURATION = "/configuration",
   ENVIRONMENTS = "/configuration/environments",
   TEAMS = "/configuration/teams",
+  USERS = "/configuration/users",
 }
 
 enum EnvironmentsTabEnum {

--- a/coral/src/domain/user/index.ts
+++ b/coral/src/domain/user/index.ts
@@ -1,0 +1,5 @@
+import { getUserList } from "src/domain/user/user-api";
+import { User } from "src/domain/user/user-types";
+
+export { getUserList };
+export type { User };

--- a/coral/src/domain/user/user-api.ts
+++ b/coral/src/domain/user/user-api.ts
@@ -2,14 +2,20 @@ import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
 import api, { API_PATHS } from "src/services/api";
 import { transformUserListApiResponse } from "src/domain/user/user-transformer";
 import { UserListApiResponse } from "src/domain/user/user-types";
+import { convertQueryValuesToString } from "src/services/api-helper";
 
 async function getUserList(
   params: KlawApiRequestQueryParameters<"showUsers">
 ): Promise<UserListApiResponse> {
+  const queryParams = convertQueryValuesToString({
+    ...params,
+    ...(params?.teamName && { teamName: params.teamName }),
+  });
+
   return api
     .get<KlawApiResponse<"showUsers">>(
       API_PATHS.showUsers,
-      new URLSearchParams(params)
+      new URLSearchParams(queryParams)
     )
     .then((response) =>
       transformUserListApiResponse({

--- a/coral/src/domain/user/user-api.ts
+++ b/coral/src/domain/user/user-api.ts
@@ -10,6 +10,7 @@ async function getUserList(
   const queryParams = convertQueryValuesToString({
     ...params,
     ...(params?.teamName && { teamName: params.teamName }),
+    ...(params?.searchUserParam && { searchUserParam: params.searchUserParam }),
   });
 
   return api

--- a/coral/src/domain/user/user-api.ts
+++ b/coral/src/domain/user/user-api.ts
@@ -1,0 +1,22 @@
+import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
+import api, { API_PATHS } from "src/services/api";
+import { transformUserListApiResponse } from "src/domain/user/user-transformer";
+import { UserListApiResponse } from "src/domain/user/user-types";
+
+async function getUserList(
+  params: KlawApiRequestQueryParameters<"showUsers">
+): Promise<UserListApiResponse> {
+  return api
+    .get<KlawApiResponse<"showUsers">>(
+      API_PATHS.showUsers,
+      new URLSearchParams(params)
+    )
+    .then((response) =>
+      transformUserListApiResponse({
+        apiResponse: response,
+        currentPage: Number(params?.pageNo) || 1,
+      })
+    );
+}
+
+export { getUserList };

--- a/coral/src/domain/user/user-transformer.ts
+++ b/coral/src/domain/user/user-transformer.ts
@@ -1,0 +1,26 @@
+import { KlawApiResponse } from "types/utils";
+import { UserListApiResponse } from "src/domain/user/user-types";
+
+function transformUserListApiResponse({
+  apiResponse,
+  currentPage,
+}: {
+  apiResponse: KlawApiResponse<"showUsers">;
+  currentPage: number;
+}): UserListApiResponse {
+  if (apiResponse.length === 0) {
+    return {
+      totalPages: 0,
+      currentPage,
+      entries: [],
+    };
+  }
+
+  return {
+    totalPages: Number(apiResponse[0].totalNoPages),
+    currentPage,
+    entries: apiResponse,
+  };
+}
+
+export { transformUserListApiResponse };

--- a/coral/src/domain/user/user-types.ts
+++ b/coral/src/domain/user/user-types.ts
@@ -1,0 +1,7 @@
+import { KlawApiModel, Paginated, ResolveIntersectionTypes } from "types/utils";
+
+type UserListApiResponse = ResolveIntersectionTypes<Paginated<User[]>>;
+
+type User = KlawApiModel<"UserInfoModelResponse">;
+
+export type { User, UserListApiResponse };

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -125,6 +125,7 @@ export default defineConfig(({ mode }) => {
   const environment = loadEnv(mode, process.cwd(), "");
   const usesNodeProxy = mode === "local-api";
 
+  console.log("mode", mode);
   return {
     plugins: getPlugins(environment),
     define: {


### PR DESCRIPTION
# Linked issue

Resolves: #1176 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# Description

Adds user overview based on layout and existing app, similar to teams overview. 

### Recording

https://github.com/Aiven-Open/klaw/assets/943800/9b9341f0-ff09-4183-92bf-c08c173caf58


## Description PR changes

- adds pages and links to it behind a feature flag
- adds user table with pagination
- adds `user` domain with api call and types for getting the user list
- Extents the existing `<TeamFilter />` to optional handle `teamName` instead of `teamId`
- According to that extends userFilterContext
- adds filter for team name
- adds search for user name

Unrelated change, but I noticed it:
(this may be related to a DS update since it's not as visible on staging)

- update the `main.module.css` to overwrite browser styles for the little X in a search input (was only in webkit browser)

This is how it looked before:

<img width="289" alt="Screenshot 2023-11-08 at 18 29 28" src="https://github.com/Aiven-Open/klaw/assets/943800/ca72e871-8c52-46d4-8c34-c57941b6ab51">


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
