### PR TITLE
Topics per cluster graph defect

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1,7 +1,8 @@
 package io.aiven.klaw.helpers.db.rdbms;
 
 import static io.aiven.klaw.helpers.KwConstants.*;
-import static org.reflections.Reflections.log;
+import static io.aiven.klaw.helpers.KwConstants.DATE_TIME_DDMMMYYYY_HHMMSS_FORMATTER;
+import static io.aiven.klaw.helpers.KwConstants.REQUESTOR_SUBSCRIPTIONS;
 
 import com.google.common.collect.Lists;
 import io.aiven.klaw.dao.*;
@@ -1284,14 +1285,15 @@ public class SelectDataJdbc {
 
       Map<String, Env> name2envsFromDb =
           StreamSupport.stream(selectEnvsDetails(envIds.keySet(), tenantId).spliterator(), false)
-              .collect(Collectors.toMap(Env::getName, Function.identity()));
+              .collect(Collectors.toMap(Env::getId, Function.identity()));
 
       for (var envIdEntry : envIds.entrySet()) {
         if (!name2envsFromDb.containsKey(envIdEntry.getKey())) {
           log.error("Error: Environment not found for env {}", envIdEntry.getKey());
         } else {
           totalTopicCount.add(
-              CommonUtilsService.ChartsOverviewItem.of(envIdEntry.getKey(), envIdEntry.getValue()));
+              CommonUtilsService.ChartsOverviewItem.of(
+                  name2envsFromDb.get(envIdEntry.getKey()).getName(), envIdEntry.getValue()));
         }
       }
     } catch (Exception e) {

--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -230,8 +230,10 @@ public class CommonUtilsService {
     List<String> labels = new ArrayList<>(size);
     List<String> colors = new ArrayList<>(size);
 
-    data.add(0);
-    labels.add("");
+    if (activityCountList.isEmpty()) {
+      data.add(0);
+      labels.add("");
+    }
 
     int totalCount = 0;
 

--- a/core/src/main/resources/templates/index.html
+++ b/core/src/main/resources/templates/index.html
@@ -444,7 +444,7 @@
                         </p>
                 </div>
             </div>
-
+            </div>
             <div class="row">
                 <!-- col -->
 


### PR DESCRIPTION
# Linked issue



# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?
Currently the graph Topics per Cluster is not rendering

# What is the new behavior?
Now renders as expected and also made an improvement to remove the initial white space entry that was added.
![image](https://github.com/Aiven-Open/klaw/assets/121855584/756c0215-402d-417b-9362-a9f514a31454)



# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
