### PR TITLE
fix(coral) - Fix `TableLayout` filters row

### DIFF
--- a/coral/src/app/features/components/layouts/TableLayout.tsx
+++ b/coral/src/app/features/components/layouts/TableLayout.tsx
@@ -28,13 +28,17 @@ function TableLayout(props: TableLayoutProps) {
         flexDirection={"row"}
         flexWrap={"wrap"}
         alignItems={"center"}
-        justifyContent={"stretch"}
+        justifyContent={"space-between"}
         colGap={"l1"}
         marginY={"l1"}
       >
         {filters.map((element) => {
           return (
-            <Box.Flex key={element.key} flexDirection={"column"}>
+            <Box.Flex
+              key={element.key}
+              flexDirection={"column"}
+              flex={"1 0 auto"}
+            >
               {element}
             </Box.Flex>
           );


### PR DESCRIPTION
# Linked issue

Resolves: #1927

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The filters rendered in the `TableLayout` are too small for most content

# What is the new behavior?

Better behaviour all around for this row:


https://github.com/Aiven-Open/klaw/assets/20607294/5de01e30-98e5-4bc7-8797-3866c8c8e2c8



# Other information

I am opening this PR as it is needed to render the UI for https://github.com/Aiven-Open/klaw/issues/1989

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
