### PR TITLE
Use set for ordered env

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
@@ -3,12 +3,16 @@ package io.aiven.klaw.helpers;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.model.response.EnvIdInfo;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class KlawResourceUtils {
+
+  private static final LinkedHashSet<String> EMPTY_LINKED_HASH_SET = new LinkedHashSet<>(0);
 
   public static List<EnvIdInfo> getConvertedEnvs(
       List<Env> allEnvs, Collection<String> selectedEnvs) {
@@ -25,12 +29,10 @@ public class KlawResourceUtils {
     return newEnvList;
   }
 
-  public static List<String> getOrderedEnvsList(String orderOfEnvs) {
-    List<String> orderOfEnvsArrayList = new ArrayList<>();
-    if (orderOfEnvs != null && !orderOfEnvs.equals("")) {
-      String[] orderOfEnvsList = orderOfEnvs.split(",");
-      orderOfEnvsArrayList = Arrays.asList(orderOfEnvsList);
+  public static LinkedHashSet<String> getOrderedEnvsSet(String orderOfEnvs) {
+    if (orderOfEnvs == null || orderOfEnvs.isEmpty()) {
+      return EMPTY_LINKED_HASH_SET;
     }
-    return orderOfEnvsArrayList;
+    return Stream.of(orderOfEnvs.split(",")).collect(Collectors.toCollection(LinkedHashSet::new));
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -1225,7 +1225,7 @@ public class KafkaConnectControllerService {
       List<KwKafkaConnector> connectors, String envId, int tenantId) {
     ConnectorOverview overview = new ConnectorOverview();
     String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_KAFKA_CONNECT_ENVS);
-    Set<String> orderOfEnvsArrayList = KlawResourceUtils.getOrderedEnvsSet(orderOfEnvs);
+    Set<String> orderOfEnvsSet = KlawResourceUtils.getOrderedEnvsSet(orderOfEnvs);
     List<EnvIdInfo> availableEnvs = new ArrayList<>();
     List<EnvIdInfo> availableEnvsNotInPromotionOrder = new ArrayList<>();
     connectors.forEach(
@@ -1238,7 +1238,7 @@ public class KafkaConnectControllerService {
                   .map(Env::getName)
                   .findFirst()
                   .orElse("ENV_NOT_FOUND"));
-          if (orderOfEnvsArrayList.contains(envIdInfo.getId())) {
+          if (orderOfEnvsSet.contains(envIdInfo.getId())) {
             availableEnvs.add(envIdInfo);
           } else {
             availableEnvsNotInPromotionOrder.add(envIdInfo);

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -1225,7 +1225,7 @@ public class KafkaConnectControllerService {
       List<KwKafkaConnector> connectors, String envId, int tenantId) {
     ConnectorOverview overview = new ConnectorOverview();
     String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_KAFKA_CONNECT_ENVS);
-    List<String> orderOfEnvsArrayList = KlawResourceUtils.getOrderedEnvsList(orderOfEnvs);
+    Set<String> orderOfEnvsArrayList = KlawResourceUtils.getOrderedEnvsSet(orderOfEnvs);
     List<EnvIdInfo> availableEnvs = new ArrayList<>();
     List<EnvIdInfo> availableEnvsNotInPromotionOrder = new ArrayList<>();
     connectors.forEach(

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -126,7 +126,7 @@ public class TopicOverviewService extends BaseOverviewService {
     List<EnvIdInfo> availableEnvs = new ArrayList<>();
     List<EnvIdInfo> availableEnvsNotInPromotionOrder = new ArrayList<>();
     String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
-    Set<String> orderOfEnvsArrayList = KlawResourceUtils.getOrderedEnvsSet(orderOfEnvs);
+    Set<String> orderOfEnvsSet = KlawResourceUtils.getOrderedEnvsSet(orderOfEnvs);
     topics.forEach(
         topic -> {
           EnvIdInfo envIdInfo = new EnvIdInfo();
@@ -137,7 +137,7 @@ public class TopicOverviewService extends BaseOverviewService {
                   .map(Env::getName)
                   .findFirst()
                   .orElse("ENV_NOT_FOUND"));
-          if (orderOfEnvsArrayList.contains(envIdInfo.getId())) {
+          if (orderOfEnvsSet.contains(envIdInfo.getId())) {
             availableEnvs.add(envIdInfo);
           } else {
             availableEnvsNotInPromotionOrder.add(envIdInfo);

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -444,7 +444,7 @@ public class TopicOverviewService extends BaseOverviewService {
       }
       promotionStatus.setTopicName(topicSearch);
       String orderEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
-      LinkedHashSet<String> envOrderList = KlawResourceUtils.getOrderedEnvsSet(orderEnvs);
+      LinkedHashSet<String> orderedEnvsSet = KlawResourceUtils.getOrderedEnvsSet(orderEnvs);
 
       if (topics != null && topics.size() > 0) {
         List<String> envList =
@@ -455,9 +455,9 @@ public class TopicOverviewService extends BaseOverviewService {
         // T env
         if (promotionStatus.getTargetEnvId() != null) {
           String targetEnvId = promotionStatus.getTargetEnvId();
-          if (!envOrderList.contains(environmentId)
-              || !envOrderList.contains(targetEnvId)
-              || !checkIfElementsAreNeighbors(envOrderList, environmentId, targetEnvId)) {
+          if (!orderedEnvsSet.contains(environmentId)
+              || !orderedEnvsSet.contains(targetEnvId)
+              || !checkIfElementsAreNeighbors(orderedEnvsSet, environmentId, targetEnvId)) {
             promotionStatus.setStatus(PromotionStatusType.NO_PROMOTION);
           } else if (isTopicPromoteRequestOpen(
               topicSearch, promotionStatus.getTargetEnvId(), tenantId)) {

--- a/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicOverviewService.java
@@ -23,6 +23,7 @@ import io.aiven.klaw.model.response.PromotionStatus;
 import io.aiven.klaw.model.response.TopicOverview;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -125,7 +126,7 @@ public class TopicOverviewService extends BaseOverviewService {
     List<EnvIdInfo> availableEnvs = new ArrayList<>();
     List<EnvIdInfo> availableEnvsNotInPromotionOrder = new ArrayList<>();
     String orderOfEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
-    List<String> orderOfEnvsArrayList = KlawResourceUtils.getOrderedEnvsList(orderOfEnvs);
+    Set<String> orderOfEnvsArrayList = KlawResourceUtils.getOrderedEnvsSet(orderOfEnvs);
     topics.forEach(
         topic -> {
           EnvIdInfo envIdInfo = new EnvIdInfo();
@@ -418,6 +419,22 @@ public class TopicOverviewService extends BaseOverviewService {
         .isPresent();
   }
 
+  private <T> boolean checkIfElementsAreNeighbors(
+      LinkedHashSet<T> tLinkedHashSet, T element1, T element2) {
+    boolean foundFirst = false;
+    for (T elem : tLinkedHashSet) {
+      if (foundFirst && elem.equals(element2)) {
+        return true;
+      } else {
+        foundFirst = false;
+      }
+      if (elem.equals(element1)) {
+        foundFirst = true;
+      }
+    }
+    return false;
+  }
+
   private PromotionStatus getTopicPromotionEnv(
       String topicSearch, List<Topic> topics, int tenantId, String environmentId) {
     PromotionStatus promotionStatus = new PromotionStatus();
@@ -427,7 +444,7 @@ public class TopicOverviewService extends BaseOverviewService {
       }
       promotionStatus.setTopicName(topicSearch);
       String orderEnvs = commonUtilsService.getEnvProperty(tenantId, ORDER_OF_TOPIC_ENVS);
-      List<String> envOrderList = KlawResourceUtils.getOrderedEnvsList(orderEnvs);
+      LinkedHashSet<String> envOrderList = KlawResourceUtils.getOrderedEnvsSet(orderEnvs);
 
       if (topics != null && topics.size() > 0) {
         List<String> envList =
@@ -438,8 +455,9 @@ public class TopicOverviewService extends BaseOverviewService {
         // T env
         if (promotionStatus.getTargetEnvId() != null) {
           String targetEnvId = promotionStatus.getTargetEnvId();
-          if (!((envOrderList.indexOf(targetEnvId) - envOrderList.indexOf(environmentId)) == 1)
-              || !envOrderList.contains(environmentId)) {
+          if (!envOrderList.contains(environmentId)
+              || !envOrderList.contains(targetEnvId)
+              || !checkIfElementsAreNeighbors(envOrderList, environmentId, targetEnvId)) {
             promotionStatus.setStatus(PromotionStatusType.NO_PROMOTION);
           } else if (isTopicPromoteRequestOpen(
               topicSearch, promotionStatus.getTargetEnvId(), tenantId)) {


### PR DESCRIPTION
Since there is a number of contains calls agaist ordered env it would make sense to use set here to make it a bit faster.
At the same time since order is important linkedhashset will help here