### PR TITLE
Add DefaultAttributeConverter

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/AivenAclIdConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/AivenAclIdConverter.java
@@ -1,35 +1,27 @@
 package io.aiven.klaw.helpers;
 
-import static io.aiven.klaw.service.UsersTeamsControllerService.OBJECT_MAPPER;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 @Converter
-public class AivenAclIdConverter implements AttributeConverter<Map<String, String>, String> {
+public class AivenAclIdConverter implements DefaultAttributeConverter<Map<String, String>> {
+
+  private static final TypeReference<Map<String, String>> TYPE_REFERENCE = new TypeReference<>() {};
 
   @Override
   public String convertToDatabaseColumn(Map<String, String> aclIdMap) {
-    try {
-      if (aclIdMap != null) return OBJECT_MAPPER.writer().writeValueAsString(aclIdMap);
-      else return "";
-    } catch (JsonProcessingException e) {
-      return "";
-    }
+    return convertToDatabaseColumn(aclIdMap, "");
   }
 
   @Override
   public Map<String, String> convertToEntityAttribute(String aclIdMapJson) {
-    try {
-      if (aclIdMapJson != null)
-        return OBJECT_MAPPER.readValue(aclIdMapJson, new TypeReference<>() {});
-      else return new HashMap<>();
-    } catch (JsonProcessingException e) {
-      return new HashMap<>();
-    }
+    return convertToEntityAttribute(aclIdMapJson, Collections.emptyMap());
+  }
+
+  @Override
+  public TypeReference<Map<String, String>> getTypeReference() {
+    return TYPE_REFERENCE;
   }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/DefaultAttributeConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/DefaultAttributeConverter.java
@@ -1,0 +1,67 @@
+package io.aiven.klaw.helpers;
+
+import static io.aiven.klaw.service.UsersTeamsControllerService.OBJECT_MAPPER;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.persistence.AttributeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface DefaultAttributeConverter<X> extends AttributeConverter<X, String> {
+
+  Logger LOG = LoggerFactory.getLogger(DefaultAttributeConverter.class);
+
+  @Override
+  default String convertToDatabaseColumn(X x) {
+    return convertToDatabaseColumn(x, null);
+  }
+
+  default String convertToDatabaseColumn(X x, String defaultValue) {
+    String res = defaultValue;
+    try {
+      if (x != null) {
+        res = OBJECT_MAPPER.writeValueAsString(x);
+      }
+    } catch (JsonProcessingException e) {
+      LOG.error("Exception converting object to json: {}", e.getMessage());
+    }
+    return res;
+  }
+
+  @Override
+  default X convertToEntityAttribute(String value) {
+    return convertToEntityAttribute(value, null);
+  }
+
+  default X convertToEntityAttribute(String value, X defaultValue) {
+    X res = defaultValue;
+    try {
+      if (value != null) {
+        Class<X> classOfEntityAttribute = getClassOfEntityAttribute();
+        if (classOfEntityAttribute != null) {
+          res = OBJECT_MAPPER.readValue(value, classOfEntityAttribute);
+        } else {
+          TypeReference<X> typeReference = getTypeReference();
+          if (typeReference != null) {
+            res = OBJECT_MAPPER.readValue(value, typeReference);
+          } else {
+            throw new RuntimeException(
+                "Either getClassOfEntityAttribute or getTypeReference should provide non null value");
+          }
+        }
+      }
+    } catch (JsonProcessingException e) {
+      LOG.error("Exception converting json to object: {}", e.getMessage());
+    }
+    return res;
+  }
+
+  default Class<X> getClassOfEntityAttribute() {
+    return null;
+  }
+
+  default TypeReference<X> getTypeReference() {
+    return null;
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/helpers/EnvParamsConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/EnvParamsConverter.java
@@ -1,41 +1,15 @@
 package io.aiven.klaw.helpers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.model.response.EnvParams;
-import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Converter
-public class EnvParamsConverter implements AttributeConverter<EnvParams, String> {
-
-  ObjectMapper mapper = new ObjectMapper();
+public class EnvParamsConverter implements DefaultAttributeConverter<EnvParams> {
 
   @Override
-  public String convertToDatabaseColumn(EnvParams envParams) {
-    String envParamsStr = null;
-    try {
-      if (envParams != null) {
-        envParamsStr = mapper.writeValueAsString(envParams);
-      }
-    } catch (JsonProcessingException e) {
-      log.error("Exception converting object: {} to json: {}", envParams, e.getMessage());
-    }
-    return envParamsStr;
-  }
-
-  @Override
-  public EnvParams convertToEntityAttribute(String envParamsStr) {
-    EnvParams params = null;
-    try {
-      if (envParamsStr != null) {
-        params = mapper.readValue(envParamsStr, EnvParams.class);
-      }
-    } catch (JsonProcessingException e) {
-      log.error("Exception converting json: {} to object: {}", envParamsStr, e.getMessage());
-    }
-    return params;
+  public Class<EnvParams> getClassOfEntityAttribute() {
+    return EnvParams.class;
   }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/EnvTagConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/EnvTagConverter.java
@@ -1,41 +1,15 @@
 package io.aiven.klaw.helpers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.dao.EnvTag;
-import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Converter
-public class EnvTagConverter implements AttributeConverter<EnvTag, String> {
-
-  ObjectMapper mapper = new ObjectMapper();
+public class EnvTagConverter implements DefaultAttributeConverter<EnvTag> {
 
   @Override
-  public String convertToDatabaseColumn(EnvTag envTag) {
-    String envTagStr = null;
-    try {
-      if (envTag != null) {
-        envTagStr = mapper.writeValueAsString(envTag);
-      }
-    } catch (JsonProcessingException e) {
-      log.error("Exception converting object to json: {}", e.getMessage());
-    }
-    return envTagStr;
-  }
-
-  @Override
-  public EnvTag convertToEntityAttribute(String envTagStr) {
-    EnvTag tag = null;
-    try {
-      if (envTagStr != null) {
-        tag = mapper.readValue(envTagStr, EnvTag.class);
-      }
-    } catch (JsonProcessingException e) {
-      log.error("Exception converting json to object: {}", e.getMessage());
-    }
-    return tag;
+  public Class<EnvTag> getClassOfEntityAttribute() {
+    return EnvTag.class;
   }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/ServiceAccountsConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/ServiceAccountsConverter.java
@@ -1,41 +1,15 @@
 package io.aiven.klaw.helpers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.klaw.dao.ServiceAccounts;
-import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Converter
-public class ServiceAccountsConverter implements AttributeConverter<ServiceAccounts, String> {
-
-  ObjectMapper mapper = new ObjectMapper();
+public class ServiceAccountsConverter implements DefaultAttributeConverter<ServiceAccounts> {
 
   @Override
-  public String convertToDatabaseColumn(ServiceAccounts serviceAccounts) {
-    String serviceAccountsStr = null;
-    try {
-      if (serviceAccounts != null) {
-        serviceAccountsStr = mapper.writeValueAsString(serviceAccounts);
-      }
-    } catch (JsonProcessingException e) {
-      log.error("Exception converting object to json: {}", e.getMessage());
-    }
-    return serviceAccountsStr;
-  }
-
-  @Override
-  public ServiceAccounts convertToEntityAttribute(String serviceAccountsStr) {
-    ServiceAccounts serviceAccounts = null;
-    try {
-      if (serviceAccountsStr != null) {
-        serviceAccounts = mapper.readValue(serviceAccountsStr, ServiceAccounts.class);
-      }
-    } catch (JsonProcessingException e) {
-      log.error("Exception converting json to object: {}", e.getMessage());
-    }
-    return serviceAccounts;
+  public Class<ServiceAccounts> getClassOfEntityAttribute() {
+    return ServiceAccounts.class;
   }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/SwitchTeamsConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/SwitchTeamsConverter.java
@@ -1,36 +1,27 @@
 package io.aiven.klaw.helpers;
 
-import static io.aiven.klaw.service.UsersTeamsControllerService.OBJECT_MAPPER;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 @Converter
-public class SwitchTeamsConverter implements AttributeConverter<Set<Integer>, String> {
+public class SwitchTeamsConverter implements DefaultAttributeConverter<Set<Integer>> {
+
+  private static final TypeReference<Set<Integer>> TYPE_REFERENCE = new TypeReference<>() {};
 
   @Override
   public String convertToDatabaseColumn(Set<Integer> switchTeamsList) {
-    try {
-      if (switchTeamsList != null)
-        return OBJECT_MAPPER.writer().writeValueAsString(switchTeamsList);
-      else return "";
-    } catch (JsonProcessingException e) {
-      return "";
-    }
+    return convertToDatabaseColumn(switchTeamsList, "");
   }
 
   @Override
   public Set<Integer> convertToEntityAttribute(String switchTeamsJson) {
-    try {
-      if (switchTeamsJson != null)
-        return OBJECT_MAPPER.readValue(switchTeamsJson, new TypeReference<>() {});
-      else return new HashSet<>();
-    } catch (JsonProcessingException e) {
-      return new HashSet<>();
-    }
+    return convertToEntityAttribute(switchTeamsJson, Collections.emptySet());
+  }
+
+  @Override
+  public TypeReference<Set<Integer>> getTypeReference() {
+    return TYPE_REFERENCE;
   }
 }


### PR DESCRIPTION
There is a number of converters like `AivenAclIdConverter`, `EnvParamsConverter`, `ServiceAccountsConverter`, `SwitchTeamsConverter` with duplicated logic

The PR introduces reusable `io.aiven.klaw.helpers.DefaultAttributeConverter` which could be extended to encapsulate common logic and keep it in one place