### PR TITLE
refactor(coral): Align info banner with links to old interface

### DIFF
--- a/coral/src/app/components/documentation/DocumentationEditor.test.tsx
+++ b/coral/src/app/components/documentation/DocumentationEditor.test.tsx
@@ -1,5 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { DocumentationEditor } from "src/app/components/documentation/DocumentationEditor";
 import { userEvent } from "@testing-library/user-event";
 import { tabThroughForward } from "src/services/test-utils/tabbing";

--- a/coral/src/app/components/documentation/DocumentationView.test.tsx
+++ b/coral/src/app/components/documentation/DocumentationView.test.tsx
@@ -1,5 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { DocumentationView } from "src/app/components/documentation/DocumentationView";
 
 const markdownInput = `# Hello world`;

--- a/coral/src/app/features/components/EntityDetailsHeader.test.tsx
+++ b/coral/src/app/features/components/EntityDetailsHeader.test.tsx
@@ -1,5 +1,4 @@
-import { cleanup, screen } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
+import { cleanup, screen, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { EntityDetailsHeader } from "src/app/features/components/EntityDetailsHeader";
 import { EnvironmentInfo } from "src/domain/environment";

--- a/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
@@ -306,11 +306,10 @@ describe("ConnectorDetails", () => {
 
       await waitForElementToBeRemoved(screen.getByPlaceholderText("Loading"));
 
-      const description = await waitFor(() =>
-        screen.getByText(
-          `This connector is currently owned by ${testConnectorOverview.connectorInfo.teamName}. Select "Claim connector" to request ownership.`
-        )
+      const description = await screen.findByText(
+        `This connector is currently owned by ${testConnectorOverview.connectorInfo.teamName}. Select "Claim connector" to request ownership.`
       );
+
       const button = await waitFor(() =>
         screen.getByRole("button", { name: "Claim connector" })
       );

--- a/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
@@ -3,8 +3,8 @@ import {
   screen,
   waitFor,
   waitForElementToBeRemoved,
+  within,
 } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
 import { ConnectorDetails } from "src/app/features/connectors/details/ConnectorDetails";
 import {
   ConnectorOverview,

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, screen } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
 import { userEvent } from "@testing-library/user-event";
 import { ConnectorOverviewResourcesTabs } from "src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs";
 import { ConnectorOverviewTabEnum } from "src/app/router_utils";
@@ -253,17 +252,6 @@ describe("ConnectorOverviewResourceTabs", () => {
       const tab = screen.getByRole("tab", { selected: true });
 
       expect(tab).toHaveAccessibleName("Overview");
-    });
-
-    it("shows a preview banner to enables users to go back to original app", () => {
-      const banner = screen.getByRole("region", { name: "Preview disclaimer" });
-      const link = within(banner).getByRole("link", { name: "old interface" });
-
-      expect(banner).toBeVisible();
-      expect(link).toHaveAttribute(
-        "href",
-        `/connectorOverview?connectorName=${testConnectorName}`
-      );
     });
   });
 

--- a/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
+++ b/coral/src/app/features/connectors/details/components/ConnectorOverviewResourcesTabs.tsx
@@ -1,7 +1,6 @@
 import { Alert, Box, Icon, Tabs } from "@aivenio/aquarium";
 import loading from "@aivenio/aquarium/icons/loading";
 import { NavigateFunction, Outlet, useNavigate } from "react-router-dom";
-import PreviewBanner from "src/app/components/PreviewBanner";
 import {
   CONNECTOR_OVERVIEW_TAB_ID_INTO_PATH,
   ConnectorOverviewTabEnum,
@@ -128,14 +127,7 @@ function ConnectorOverviewResourcesTabs({
             aria-label={tab.title}
             key={tab.title}
           >
-            {currentTab === tab.connectorOverviewTabEnum && (
-              <div>
-                <PreviewBanner
-                  linkTarget={`/connectorOverview?connectorName=${connectorName}`}
-                />
-                {renderTabContent()}
-              </div>
-            )}
+            {currentTab === tab.connectorOverviewTabEnum && renderTabContent()}
           </Tabs.Tab>
         );
       })}

--- a/coral/src/app/features/connectors/details/overview/ConnectorOverview.test.tsx
+++ b/coral/src/app/features/connectors/details/overview/ConnectorOverview.test.tsx
@@ -1,8 +1,7 @@
-import { cleanup, screen } from "@testing-library/react";
+import { cleanup, screen, within } from "@testing-library/react";
 import { ConnectorOverview } from "src/app/features/connectors/details/overview/ConnectorOverview";
 import { ConnectorOverview as ConnectorOverviewType } from "src/domain/connector";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import { within } from "@testing-library/react/pure";
 
 const mockedUseConnectorDetails = jest.fn();
 jest.mock("src/app/features/connectors/details/ConnectorDetails", () => ({

--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -4,8 +4,8 @@ import {
   screen,
   waitFor,
   waitForElementToBeRemoved,
+  within,
 } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
 import { userEvent } from "@testing-library/user-event";
 import { TopicDetails } from "src/app/features/topics/details/TopicDetails";
 import { TopicOverview, TopicSchemaOverview } from "src/domain/topic";

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -3,7 +3,6 @@ import { userEvent } from "@testing-library/user-event";
 import { TopicOverviewTabEnum } from "src/app/router_utils";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { TopicOverviewResourcesTabs } from "src/app/features/topics/details/components/TopicDetailsResourceTabs";
-import { within } from "@testing-library/react/pure";
 import { TopicOverview } from "src/domain/topic";
 
 const mockedNavigate = jest.fn();

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.test.tsx
@@ -310,17 +310,6 @@ describe("TopicDetailsResourceTabs", () => {
 
       expect(tab).toHaveAccessibleName("Overview");
     });
-
-    it("shows a preview banner to enables users to go back to original app", () => {
-      const banner = screen.getByRole("region", { name: "Preview disclaimer" });
-      const link = within(banner).getByRole("link", { name: "old interface" });
-
-      expect(banner).toBeVisible();
-      expect(link).toHaveAttribute(
-        "href",
-        `/topicOverview?topicname=${testTopicName}`
-      );
-    });
   });
 
   describe("enables users to switch panels", () => {

--- a/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
+++ b/coral/src/app/features/topics/details/components/TopicDetailsResourceTabs.tsx
@@ -1,7 +1,6 @@
 import { Alert, Box, Icon, Tabs } from "@aivenio/aquarium";
 import loading from "@aivenio/aquarium/icons/loading";
 import { NavigateFunction, Outlet, useNavigate } from "react-router-dom";
-import PreviewBanner from "src/app/components/PreviewBanner";
 import {
   TOPIC_OVERVIEW_TAB_ID_INTO_PATH,
   TopicOverviewTabEnum,
@@ -152,14 +151,7 @@ function TopicOverviewResourcesTabs({
             aria-label={tab.title}
             key={tab.title}
           >
-            {currentTab === tab.topicOverviewTabEnum && (
-              <div>
-                <PreviewBanner
-                  linkTarget={`/topicOverview?topicname=${topicName}`}
-                />
-                {renderTabContent()}
-              </div>
-            )}
+            {currentTab === tab.topicOverviewTabEnum && renderTabContent()}
           </Tabs.Tab>
         );
       })}

--- a/coral/src/app/features/topics/details/overview/TopicOverview.test.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.test.tsx
@@ -4,9 +4,8 @@ import {
   ClusterDetails as ClusterDetailsType,
   getClusterDetails,
 } from "src/domain/cluster";
-import { cleanup, RenderResult, screen } from "@testing-library/react";
+import { cleanup, RenderResult, screen, within } from "@testing-library/react";
 import { getDefinitionList } from "src/services/test-utils/custom-queries";
-import { within } from "@testing-library/react/pure";
 
 const mockedUseTopicDetails = jest.fn();
 jest.mock("src/app/features/topics/details/TopicDetails", () => ({

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -1,6 +1,5 @@
 import { Context as AquariumContext } from "@aivenio/aquarium";
-import { cleanup, screen } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
+import { cleanup, screen, within } from "@testing-library/react";
 import { TopicDetailsSchema } from "src/app/features/topics/details/schema/TopicDetailsSchema";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { TopicSchemaOverview } from "src/domain/topic";

--- a/coral/src/app/pages/approvals/acls/index.tsx
+++ b/coral/src/app/pages/approvals/acls/index.tsx
@@ -1,13 +1,7 @@
-import PreviewBanner from "src/app/components/PreviewBanner";
 import AclApprovals from "src/app/features/approvals/acls/AclApprovals";
 
 const AclApprovalsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/execAcls"} />
-      <AclApprovals />
-    </>
-  );
+  return <AclApprovals />;
 };
 
 export default AclApprovalsPage;

--- a/coral/src/app/pages/approvals/connectors/index.tsx
+++ b/coral/src/app/pages/approvals/connectors/index.tsx
@@ -1,13 +1,7 @@
-import PreviewBanner from "src/app/components/PreviewBanner";
 import ConnectorApprovals from "src/app/features/approvals/connectors/ConnectorApprovals";
 
 const ConnectorApprovalsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/execConnectors"} />
-      <ConnectorApprovals />
-    </>
-  );
+  return <ConnectorApprovals />;
 };
 
 export default ConnectorApprovalsPage;

--- a/coral/src/app/pages/approvals/index.tsx
+++ b/coral/src/app/pages/approvals/index.tsx
@@ -5,7 +5,9 @@ import {
   APPROVALS_TAB_ID_INTO_PATH,
   ApprovalsTabEnum,
   isApprovalsTabEnum,
+  APPROVALS_TAB_PATH_LINK_MAP,
 } from "src/app/router_utils";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 const ApprovalsPage = () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -14,8 +16,10 @@ const ApprovalsPage = () => {
   if (currentTab === undefined) {
     return <Navigate to={`/approvals/topics`} replace={true} />;
   }
+
   return (
     <>
+      <PreviewBanner linkTarget={APPROVALS_TAB_PATH_LINK_MAP[currentTab]} />
       <PageHeader title={"Approve requests"} />
       <ApprovalResourceTabs currentTab={currentTab} />
     </>

--- a/coral/src/app/pages/approvals/schemas/index.tsx
+++ b/coral/src/app/pages/approvals/schemas/index.tsx
@@ -1,13 +1,7 @@
-import PreviewBanner from "src/app/components/PreviewBanner";
 import SchemaApprovals from "src/app/features/approvals/schemas/SchemaApprovals";
 
 const SchemaApprovalsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/execSchemas"} />
-      <SchemaApprovals />
-    </>
-  );
+  return <SchemaApprovals />;
 };
 
 export default SchemaApprovalsPage;

--- a/coral/src/app/pages/approvals/topics/index.tsx
+++ b/coral/src/app/pages/approvals/topics/index.tsx
@@ -1,13 +1,7 @@
-import PreviewBanner from "src/app/components/PreviewBanner";
 import TopicApprovals from "src/app/features/approvals/topics/TopicApprovals";
 
 const TopicApprovalsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/execTopics"} />
-      <TopicApprovals />
-    </>
-  );
+  return <TopicApprovals />;
 };
 
 export default TopicApprovalsPage;

--- a/coral/src/app/pages/configuration/environments/index.tsx
+++ b/coral/src/app/pages/configuration/environments/index.tsx
@@ -6,6 +6,7 @@ import {
   EnvironmentsTabEnum,
   isEnvironmentsTabEnum,
 } from "src/app/router_utils";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 function findMatchingTab(
   matches: ReturnType<typeof useMatches>
@@ -30,6 +31,7 @@ const EnvironmentsPage = () => {
   }
   return (
     <>
+      <PreviewBanner linkTarget={"/envs"} />
       <PageHeader title={"Environments"} />
       <EnvironmentsTabs currentTab={currentTab} />
     </>

--- a/coral/src/app/pages/configuration/environments/kafka-connect/index.tsx
+++ b/coral/src/app/pages/configuration/environments/kafka-connect/index.tsx
@@ -1,11 +1,9 @@
 import { PageHeader } from "@aivenio/aquarium";
-import PreviewBanner from "src/app/components/PreviewBanner";
 import KafkaConnectEnvironments from "src/app/features/configuration/environments/KafkaConnect/KafkaConnectEnvironments";
 
 const KafkaConnectEnvironmentsPage = () => {
   return (
     <>
-      <PreviewBanner linkTarget={"/envs"} />
       <PageHeader title={"Kafka Connect Environments"} />
       <KafkaConnectEnvironments />
     </>

--- a/coral/src/app/pages/configuration/environments/kafka/index.tsx
+++ b/coral/src/app/pages/configuration/environments/kafka/index.tsx
@@ -1,11 +1,9 @@
 import { PageHeader } from "@aivenio/aquarium";
-import PreviewBanner from "src/app/components/PreviewBanner";
 import KafkaEnvironments from "src/app/features/configuration/environments/Kafka/KafkaEnvironments";
 
 const KafkaEnvironmentsPage = () => {
   return (
     <>
-      <PreviewBanner linkTarget={"/envs"} />
       <PageHeader title={"Kafka Environments"} />
       <KafkaEnvironments />
     </>

--- a/coral/src/app/pages/configuration/environments/schema-registry/index.tsx
+++ b/coral/src/app/pages/configuration/environments/schema-registry/index.tsx
@@ -1,11 +1,9 @@
 import { PageHeader } from "@aivenio/aquarium";
-import PreviewBanner from "src/app/components/PreviewBanner";
 import SchemaRegistryEnvironments from "src/app/features/configuration/environments/SchemaRegistry/SchemaRegistryEnvironments";
 
 const SchemaRegistryEnvironmentsPage = () => {
   return (
     <>
-      <PreviewBanner linkTarget={"/envs"} />
       <PageHeader title={"Schema Registry Environments"} />
       <SchemaRegistryEnvironments />
     </>

--- a/coral/src/app/pages/configuration/teams/index.tsx
+++ b/coral/src/app/pages/configuration/teams/index.tsx
@@ -1,9 +1,11 @@
 import { PageHeader } from "@aivenio/aquarium";
 import { Teams } from "src/app/features/configuration/teams/Teams";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 const TeamsPage = () => {
   return (
     <>
+      <PreviewBanner linkTarget={"/teams"} />
       <PageHeader title={"Teams"} />
       <Teams />
     </>

--- a/coral/src/app/pages/configuration/users/index.tsx
+++ b/coral/src/app/pages/configuration/users/index.tsx
@@ -1,9 +1,11 @@
 import { PageHeader } from "@aivenio/aquarium";
 import { Users } from "src/app/features/configuration/users/Users";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 const UsersPage = () => {
   return (
     <>
+      <PreviewBanner linkTarget={"/users"} />
       <PageHeader title={"Users"} />
       <Users />
     </>

--- a/coral/src/app/pages/connectors/details/index.tsx
+++ b/coral/src/app/pages/connectors/details/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { ConnectorDetails } from "src/app/features/connectors/details/ConnectorDetails";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 function ConnectorDetailsPage() {
   const { connectorName } = useParams();
@@ -10,7 +11,14 @@ function ConnectorDetailsPage() {
     return <></>;
   }
 
-  return <ConnectorDetails connectorName={connectorName} />;
+  return (
+    <>
+      <PreviewBanner
+        linkTarget={`/connectorOverview?connectorName=${connectorName}`}
+      />
+      <ConnectorDetails connectorName={connectorName} />
+    </>
+  );
 }
 
 export { ConnectorDetailsPage };

--- a/coral/src/app/pages/requests/acls/index.test.tsx
+++ b/coral/src/app/pages/requests/acls/index.test.tsx
@@ -1,5 +1,5 @@
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import { cleanup, screen, within } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import AclRequestsPage from "src/app/pages/requests/acls/index";
@@ -33,25 +33,6 @@ describe("AclRequestsPage", () => {
   });
 
   afterAll(cleanup);
-
-  it("shows a preview banner to inform users about the early version of the view", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-
-    expect(previewBanner).toBeVisible();
-    expect(previewBanner).toHaveTextContent(
-      "You are viewing a preview of the redesigned user interface. You are one of our early reviewers, and your feedback will help us improve the product. You can always go back to the old interface."
-    );
-  });
-
-  it("shows link back back to the original Klaw app for this view in the preview banner", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-    const link = within(previewBanner).getByRole("link", {
-      name: "old interface",
-    });
-
-    expect(link).toBeVisible();
-    expect(link).toHaveAttribute("href", "/myAclRequests");
-  });
 
   it("renders the Acl request view", () => {
     const emptyRequests = screen.getByText(

--- a/coral/src/app/pages/requests/acls/index.tsx
+++ b/coral/src/app/pages/requests/acls/index.tsx
@@ -1,13 +1,7 @@
 import AclRequests from "src/app/features/requests/acls/AclRequests";
-import PreviewBanner from "src/app/components/PreviewBanner";
 
 const AclRequestsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/myAclRequests"} />
-      <AclRequests />
-    </>
-  );
+  return <AclRequests />;
 };
 
 export default AclRequestsPage;

--- a/coral/src/app/pages/requests/connectors/index.test.tsx
+++ b/coral/src/app/pages/requests/connectors/index.test.tsx
@@ -1,5 +1,5 @@
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import { cleanup, screen, within } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { getAllEnvironmentsForConnector } from "src/domain/environment";
 import { getConnectorRequests } from "src/domain/connector/connector-api";
@@ -37,25 +37,6 @@ describe("ConnectorRequestsPage", () => {
   });
 
   afterAll(cleanup);
-
-  it("shows a preview banner to inform users about the early version of the view", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-
-    expect(previewBanner).toBeVisible();
-    expect(previewBanner).toHaveTextContent(
-      "You are viewing a preview of the redesigned user interface. You are one of our early reviewers, and your feedback will help us improve the product. You can always go back to the old interface."
-    );
-  });
-
-  it("shows link back back to the original Klaw app for this view in the preview banner", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-    const link = within(previewBanner).getByRole("link", {
-      name: "old interface",
-    });
-
-    expect(link).toBeVisible();
-    expect(link).toHaveAttribute("href", "/myConnectorRequests");
-  });
 
   it("renders the Connector request view", () => {
     const emptyRequests = screen.getByText(

--- a/coral/src/app/pages/requests/connectors/index.tsx
+++ b/coral/src/app/pages/requests/connectors/index.tsx
@@ -1,13 +1,7 @@
 import ConnectorRequests from "src/app/features/requests/connectors/ConnectorRequests";
-import PreviewBanner from "src/app/components/PreviewBanner";
 
 const ConnectorRequestsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/myConnectorRequests"} />
-      <ConnectorRequests />
-    </>
-  );
+  return <ConnectorRequests />;
 };
 
 export default ConnectorRequestsPage;

--- a/coral/src/app/pages/requests/index.tsx
+++ b/coral/src/app/pages/requests/index.tsx
@@ -3,9 +3,11 @@ import { Navigate, useMatches } from "react-router-dom";
 import RequestsResourceTabs from "src/app/features/requests/RequestsResourceTabs";
 import {
   REQUESTS_TAB_ID_INTO_PATH,
+  REQUESTS_TAB_PATH_LINK_MAP,
   RequestsTabEnum,
   isRequestsTabEnum,
 } from "src/app/router_utils";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 const RequestsPage = () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -16,6 +18,7 @@ const RequestsPage = () => {
   }
   return (
     <>
+      <PreviewBanner linkTarget={REQUESTS_TAB_PATH_LINK_MAP[currentTab]} />
       <PageHeader title={"My team's requests"} />
       <RequestsResourceTabs currentTab={currentTab} />
     </>

--- a/coral/src/app/pages/requests/schemas/index.test.tsx
+++ b/coral/src/app/pages/requests/schemas/index.test.tsx
@@ -1,7 +1,7 @@
 import { getSchemaRequests } from "src/domain/schema-request";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import SchemaRequestsPage from "src/app/pages/requests/schemas/index";
-import { cleanup, screen, within } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 
@@ -33,25 +33,6 @@ describe("SchemaRequestPage", () => {
   });
 
   afterAll(cleanup);
-
-  it("shows a preview banner to inform users about the early version of the view", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-
-    expect(previewBanner).toBeVisible();
-    expect(previewBanner).toHaveTextContent(
-      "You are viewing a preview of the redesigned user interface. You are one of our early reviewers, and your feedback will help us improve the product. You can always go back to the old interface."
-    );
-  });
-
-  it("shows link back back to the original Klaw app for this view in the preview banner", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-    const link = within(previewBanner).getByRole("link", {
-      name: "old interface",
-    });
-
-    expect(link).toBeVisible();
-    expect(link).toHaveAttribute("href", "/mySchemaRequests");
-  });
 
   it("renders the schema request view", () => {
     const emptyRequests = screen.getByText(

--- a/coral/src/app/pages/requests/schemas/index.tsx
+++ b/coral/src/app/pages/requests/schemas/index.tsx
@@ -1,13 +1,7 @@
 import SchemaRequests from "src/app/features/requests/schemas/SchemaRequests";
-import PreviewBanner from "src/app/components/PreviewBanner";
 
 const SchemaRequestsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/mySchemaRequests"} />
-      <SchemaRequests />
-    </>
-  );
+  return <SchemaRequests />;
 };
 
 export default SchemaRequestsPage;

--- a/coral/src/app/pages/requests/topics/index.test.tsx
+++ b/coral/src/app/pages/requests/topics/index.test.tsx
@@ -1,5 +1,5 @@
 import { customRender } from "src/services/test-utils/render-with-wrappers";
-import { cleanup, screen, within } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { getTopicRequests } from "src/domain/topic/topic-api";
@@ -33,25 +33,6 @@ describe("TopicRequestsPage", () => {
   });
 
   afterAll(cleanup);
-
-  it("shows a preview banner to inform users about the early version of the view", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-
-    expect(previewBanner).toBeVisible();
-    expect(previewBanner).toHaveTextContent(
-      "You are viewing a preview of the redesigned user interface. You are one of our early reviewers, and your feedback will help us improve the product. You can always go back to the old interface."
-    );
-  });
-
-  it("shows link back back to the original Klaw app for this view in the preview banner", () => {
-    const previewBanner = screen.getByLabelText("Preview disclaimer");
-    const link = within(previewBanner).getByRole("link", {
-      name: "old interface",
-    });
-
-    expect(link).toBeVisible();
-    expect(link).toHaveAttribute("href", "/myTopicRequests");
-  });
 
   it("renders the topic request view", () => {
     const emptyRequests = screen.getByText(

--- a/coral/src/app/pages/requests/topics/index.tsx
+++ b/coral/src/app/pages/requests/topics/index.tsx
@@ -1,13 +1,7 @@
 import TopicRequests from "src/app/features/requests/topics/TopicRequests";
-import PreviewBanner from "src/app/components/PreviewBanner";
 
 const TopicRequestsPage = () => {
-  return (
-    <>
-      <PreviewBanner linkTarget={"/myTopicRequests"} />
-      <TopicRequests />
-    </>
-  );
+  return <TopicRequests />;
 };
 
 export default TopicRequestsPage;

--- a/coral/src/app/pages/topics/details/index.tsx
+++ b/coral/src/app/pages/topics/details/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { TopicDetails } from "src/app/features/topics/details/TopicDetails";
+import PreviewBanner from "src/app/components/PreviewBanner";
 
 function TopicDetailsPage() {
   const { topicName } = useParams();
@@ -10,7 +11,12 @@ function TopicDetailsPage() {
     return <></>;
   }
 
-  return <TopicDetails topicName={topicName} />;
+  return (
+    <>
+      <PreviewBanner linkTarget={`/topicOverview?topicname=${topicName}`} />
+      <TopicDetails topicName={topicName} />
+    </>
+  );
 }
 
 export { TopicDetailsPage };

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -90,6 +90,13 @@ const REQUESTS_TAB_ID_INTO_PATH = {
   [RequestsTabEnum.CONNECTORS]: "connectors",
 } as const;
 
+const REQUESTS_TAB_PATH_LINK_MAP = {
+  [RequestsTabEnum.TOPICS]: "/myTopicRequests",
+  [RequestsTabEnum.ACLS]: "/myAclRequests",
+  [RequestsTabEnum.SCHEMAS]: "/mySchemaRequests",
+  [RequestsTabEnum.CONNECTORS]: "/myConnectorRequests",
+} as const;
+
 const APPROVALS_TAB_ID_INTO_PATH = {
   [ApprovalsTabEnum.TOPICS]: "topics",
   [ApprovalsTabEnum.ACLS]: "acls",
@@ -170,6 +177,7 @@ export {
   TOPIC_OVERVIEW_TAB_ID_INTO_PATH,
   CONNECTOR_OVERVIEW_TAB_ID_INTO_PATH,
   APPROVALS_TAB_PATH_LINK_MAP,
+  REQUESTS_TAB_PATH_LINK_MAP,
   isEnvironmentsTabEnum,
   isRequestsTabEnum,
   isApprovalsTabEnum,

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -97,6 +97,13 @@ const APPROVALS_TAB_ID_INTO_PATH = {
   [ApprovalsTabEnum.CONNECTORS]: "connectors",
 } as const;
 
+const APPROVALS_TAB_PATH_LINK_MAP = {
+  [ApprovalsTabEnum.TOPICS]: "/execTopics",
+  [ApprovalsTabEnum.ACLS]: "/execAcls",
+  [ApprovalsTabEnum.SCHEMAS]: "/execSchemas",
+  [ApprovalsTabEnum.CONNECTORS]: "/execConnectors",
+} as const;
+
 function isEnvironmentsTabEnum(value: unknown): value is EnvironmentsTabEnum {
   if (isString(value)) {
     return Object.prototype.hasOwnProperty.call(
@@ -162,6 +169,7 @@ export {
   APPROVALS_TAB_ID_INTO_PATH,
   TOPIC_OVERVIEW_TAB_ID_INTO_PATH,
   CONNECTOR_OVERVIEW_TAB_ID_INTO_PATH,
+  APPROVALS_TAB_PATH_LINK_MAP,
   isEnvironmentsTabEnum,
   isRequestsTabEnum,
   isApprovalsTabEnum,

--- a/coral/src/services/test-utils/custom-queries.ts
+++ b/coral/src/services/test-utils/custom-queries.ts
@@ -1,5 +1,4 @@
-import { RenderResult } from "@testing-library/react";
-import { within } from "@testing-library/react/pure";
+import { RenderResult, within } from "@testing-library/react";
 
 /** Custom query to be able to check for a Definition List
  * that testing-library does not provide


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

We are currently showing the `<PreviewLink />` element with links to the Angular app inconsistent:

-  on top of the page
<img width="970" alt="Screenshot 2023-11-22 at 14 07 32" src="https://github.com/Aiven-Open/klaw/assets/943800/bf26e34d-6d03-40c5-96b9-6060ed97c78e">

- under the tab navigation

<img width="970" alt="Screenshot 2023-11-22 at 14 08 01" src="https://github.com/Aiven-Open/klaw/assets/943800/028802ed-c6ef-4a6e-b3e8-905311696bbd">

- not at all (that's on me 🙈 )


<img width="1280" alt="Screenshot 2023-11-22 at 14 09 13" src="https://github.com/Aiven-Open/klaw/assets/943800/9caeb506-897b-4d4f-8672-f7b49604ba81">



# What is the new behavior?

This PR aligns the usage and puts the banner with link always on top of the page.


example


https://github.com/Aiven-Open/klaw/assets/943800/bd81c549-7609-47d0-a3e7-b33e470e93e8




# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
