### PR TITLE
feat(coral): Add change-password route, page and links

### DIFF
--- a/coral/src/app/layout/header/ProfileDropdown.test.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.test.tsx
@@ -39,8 +39,8 @@ const menuItems = [
   },
   {
     angularPath: "/changePwd",
-    path: "/",
-    behindFeatureFlag: false,
+    path: "/use/change-password",
+    behindFeatureFlag: true,
     name: "Change password",
   },
   {

--- a/coral/src/app/layout/header/ProfileDropdown.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.tsx
@@ -30,8 +30,8 @@ const menuItems: MenuItem[] = [
   },
   {
     angularPath: "/changePwd",
-    path: "/",
-    behindFeatureFlag: false,
+    path: "/user/change-password",
+    behindFeatureFlag: true,
     name: "Change password",
   },
   {

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -140,6 +140,7 @@ function MainNavigation() {
                   : "/changePwd"
               }
               linkText={"Change password"}
+              active={pathname.startsWith(Routes.USER_CHANGE_PASSWORD)}
             />
             <MainNavigationLink to={"/tenantInfo"} linkText={"Tenant"} />
           </MainNavigationSubmenuList>

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -134,7 +134,11 @@ function MainNavigation() {
               active={pathname.startsWith(Routes.USER_PROFILE)}
             />
             <MainNavigationLink
-              to={"/changePwd"}
+              to={
+                userInformationFeatureFlagEnabled
+                  ? Routes.USER_CHANGE_PASSWORD
+                  : "/changePwd"
+              }
               linkText={"Change password"}
             />
             <MainNavigationLink to={"/tenantInfo"} linkText={"Tenant"} />

--- a/coral/src/app/pages/user-information/change-password/index.tsx
+++ b/coral/src/app/pages/user-information/change-password/index.tsx
@@ -1,0 +1,14 @@
+import { PageHeader } from "@aivenio/aquarium";
+import PreviewBanner from "src/app/components/PreviewBanner";
+
+function ChangePassword() {
+  return (
+    <>
+      <PreviewBanner linkTarget={"/changePwd"} />
+      <PageHeader title={"Change password"} />
+      <div>Ch-ch-ch-ch-changes</div>
+    </>
+  );
+}
+
+export { ChangePassword };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -58,6 +58,7 @@ import { FeatureFlag } from "src/services/feature-flags/types";
 import { TeamsPage } from "src/app/pages/configuration/teams";
 import { UsersPage } from "src/app/pages/configuration/users";
 import { UserProfile } from "src/app/pages/user-information/profile";
+import { ChangePassword } from "src/app/pages/user-information/change-password";
 
 const routes: Array<RouteObject> = [
   {
@@ -257,6 +258,12 @@ const routes: Array<RouteObject> = [
             featureFlag: FeatureFlag.FEATURE_FLAG_USER_INFORMATION,
             redirectRouteWithoutFeatureFlag: Routes.TOPICS,
             element: <UserProfile />,
+          }),
+          createRouteBehindFeatureFlag({
+            path: Routes.USER_CHANGE_PASSWORD,
+            featureFlag: FeatureFlag.FEATURE_FLAG_USER_INFORMATION,
+            redirectRouteWithoutFeatureFlag: Routes.TOPICS,
+            element: <ChangePassword />,
           }),
         ],
       },

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -23,6 +23,7 @@ enum Routes {
   USERS = "/configuration/users",
   USER_INFORMATION = "/user",
   USER_PROFILE = "/user/profile",
+  USER_CHANGE_PASSWORD = "/user/change-password",
 }
 
 enum EnvironmentsTabEnum {


### PR DESCRIPTION
# Linked issue

Resolves: #2023

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

There is no coral routes amdpages for the change password feature

# What is the new behavior?

Add necessary routes, page and links for accessing change password feature

https://github.com/Aiven-Open/klaw/assets/20607294/25df3288-6123-467a-b93b-e9e48283e39a


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
