### PR TITLE
Fix null pointer exception that was hidden in the logs

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -171,7 +171,7 @@ public class KafkaConnectControllerService {
             kafkaConnectorList.get(0).getTeamId(), connectorRequestModel.getTeamId())) {
       return ApiResponse.notOk(KAFKA_CONNECT_ERR_106);
     }
-
+    log.info(" Env : {} orderOfEnvs {}", connectorRequestModel.getEnvironment(), orderOfEnvs);
     boolean promotionOrderCheck =
         checkInPromotionOrder(connectorRequestModel.getEnvironment(), orderOfEnvs);
 
@@ -1202,17 +1202,21 @@ public class KafkaConnectControllerService {
         }
 
       } else {
-        connectorOverview.getPromotionDetails().setStatus(PromotionStatusType.NOT_AUTHORIZED);
+        notAuthorizedPromotionDetails(connectorOverview);
       }
 
     } catch (Exception e) {
       log.error("Exception:", e);
-      ConnectorPromotionStatus status = new ConnectorPromotionStatus();
-      status.setStatus(PromotionStatusType.NOT_AUTHORIZED);
-      connectorOverview.setPromotionDetails(status);
+      notAuthorizedPromotionDetails(connectorOverview);
     }
 
     return connectorOverview;
+  }
+
+  private static void notAuthorizedPromotionDetails(ConnectorOverview connectorOverview) {
+    ConnectorPromotionStatus status = new ConnectorPromotionStatus();
+    status.setStatus(PromotionStatusType.NOT_AUTHORIZED);
+    connectorOverview.setPromotionDetails(status);
   }
 
   private boolean checkIsHighestEnv(String envId, List<EnvIdInfo> availableEnvs) {

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -171,7 +171,7 @@ public class KafkaConnectControllerService {
             kafkaConnectorList.get(0).getTeamId(), connectorRequestModel.getTeamId())) {
       return ApiResponse.notOk(KAFKA_CONNECT_ERR_106);
     }
-    log.info(" Env : {} orderOfEnvs {}", connectorRequestModel.getEnvironment(), orderOfEnvs);
+
     boolean promotionOrderCheck =
         checkInPromotionOrder(connectorRequestModel.getEnvironment(), orderOfEnvs);
 


### PR DESCRIPTION
# Linked issue



# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

When another team loads the promotion details when setting to NOT Authorized, it throws a null pointer is caught by a catch and returns the correct NOT Authorized.
# What is the new behavior?

When another team loads the promotion details setting it to NOT Authorize (no null pointer/try-catch etc)

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
