### PR TITLE
Use  where existsConnectorRequestonly existence check is required

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -200,14 +200,12 @@ public class KafkaConnectControllerService {
     }
 
     if (manageDatabase
-            .getHandleDbRequests()
-            .getConnectorRequests(
-                connectorRequestModel.getConnectorName(),
-                connectorRequestModel.getEnvironment(),
-                RequestStatus.CREATED.value,
-                tenantId)
-            .size()
-        > 0) {
+        .getHandleDbRequests()
+        .existsConnectorRequest(
+            connectorRequestModel.getConnectorName(),
+            connectorRequestModel.getEnvironment(),
+            RequestStatus.CREATED.value,
+            tenantId)) {
       return ApiResponse.notOk(KAFKA_CONNECT_ERR_110);
     }
 
@@ -855,14 +853,12 @@ public class KafkaConnectControllerService {
             .findFirst();
 
     if (manageDatabase
-            .getHandleDbRequests()
-            .getConnectorRequests(
-                kafkaConnectorRequest.getConnectorName(),
-                kafkaConnectorRequest.getEnvironment(),
-                RequestStatus.CREATED.value,
-                tenantId)
-            .size()
-        > 0) {
+        .getHandleDbRequests()
+        .existsConnectorRequest(
+            kafkaConnectorRequest.getConnectorName(),
+            kafkaConnectorRequest.getEnvironment(),
+            RequestStatus.CREATED.value,
+            tenantId)) {
       return ApiResponse.notOk(KAFKA_CONNECT_ERR_115);
     }
 
@@ -988,10 +984,8 @@ public class KafkaConnectControllerService {
     int tenantId = commonUtilsService.getTenantId(getUserName());
 
     if (manageDatabase
-            .getHandleDbRequests()
-            .getConnectorRequests(connectorName, envId, RequestStatus.CREATED.value, tenantId)
-            .size()
-        > 0) {
+        .getHandleDbRequests()
+        .existsConnectorRequest(connectorName, envId, RequestStatus.CREATED.value, tenantId)) {
       return ApiResponse.notOk(KAFKA_CONNECT_ERR_117);
     }
 

--- a/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
@@ -223,9 +223,9 @@ public class KafkaConnectControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(handleDbRequests.getConnectorRequests(
+    when(handleDbRequests.existsConnectorRequest(
             "ConnectorOne", "1", RequestStatus.CREATED.value, TENANT_ID))
-        .thenReturn(List.of(new KafkaConnectorRequest()));
+        .thenReturn(true);
     ApiResponse apiResponse =
         kafkaConnectControllerService.createClaimConnectorRequest("ConnectorOne", "1");
 


### PR DESCRIPTION
There is no need to load whole lists to answer a question whether there is at least one entity or not within these lists