### PR TITLE
Fix pom coral build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -265,7 +265,27 @@
                 <version>3.3.1</version>
                 <executions>
                     <execution>
-                        <id>copy-coral-index</id>
+                        <id>copy-coral-index-to-resource</id>
+                        <!-- here the phase you need -->
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/src/main/resources/templates/coral</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../coral/dist/</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>index.html</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-coral-index-to-target</id>
                         <!-- here the phase you need -->
                         <phase>process-resources</phase>
                         <goals>
@@ -291,7 +311,24 @@
                 <version>3.3.1</version>
                 <executions>
                     <execution>
-                        <id>copy-coral-assets</id>
+                        <id>copy-coral-assets-to-resource</id>
+                        <!-- here the phase you need -->
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/src/main/resources/static/assets/coral</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../coral/dist/assets/coral</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-coral-assets-to-target</id>
                         <!-- here the phase you need -->
                         <phase>process-resources</phase>
                         <goals>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,12 +186,12 @@
                 <includes>
                     <include>application.properties</include>
                 </includes>
-                    <excludes>
-                        <exclude>static</exclude>
-                        <exclude>template</exclude>
-                        <exclude>**/*.sql</exclude>
-                        <exclude>**/*.yaml</exclude>
-                    </excludes>
+                <excludes>
+                    <exclude>static</exclude>
+                    <exclude>template</exclude>
+                    <exclude>**/*.sql</exclude>
+                    <exclude>**/*.yaml</exclude>
+                </excludes>
                 <filtering>true</filtering>
             </resource>
             <resource>
@@ -251,6 +251,10 @@
                                     </includes>
                                     <followSymlinks>false</followSymlinks>
                                 </fileset>
+                                <fileset>
+                                    <directory>${basedir}/../coral/dist</directory>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
                             </filesets>
                         </configuration>
                     </execution>
@@ -265,10 +269,10 @@
                         <!-- here the phase you need -->
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>copy-resources</goal>
+                            <goal>resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${basedir}/src/main/resources/templates/coral</outputDirectory>
+                            <outputDirectory>${basedir}/target/classes/templates/coral</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>../coral/dist/</directory>
@@ -291,10 +295,10 @@
                         <!-- here the phase you need -->
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>copy-resources</goal>
+                            <goal>resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${basedir}/src/main/resources/static/assets/coral</outputDirectory>
+                            <outputDirectory>${basedir}/target/classes/static/assets/coral</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>../coral/dist/assets/coral</directory>


### PR DESCRIPTION
This change moves coral resources to the target folder after the main resources folder is copied to the target folder
The change also adds a complete delete of the coral dist folder to ensure that coral is re-built every time.

# Linked issue

Resolves: #xxxxx

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The coral dist is copied to the main resources folder after the resources folder is copied to the target folder.
# What is the new behavior?

The Coral dist is copied to the target folder after the main resources folder is copied to the target folder already.
# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
