### PR TITLE
Check for existence for topic requests on db level rather than on java

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -139,6 +139,8 @@ public interface HandleDbRequests {
 
   List<TopicRequest> getTopicRequests(String topicName, String envId, String status, int tenantId);
 
+  boolean existsTopicRequests(String topicName, String envId, String status, int tenantId);
+
   List<KafkaConnectorRequest> getConnectorRequests(
       String connectorName, String envId, String status, int tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -316,6 +316,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public boolean existsTopicRequests(String topicName, String envId, String status, int tenantId) {
+    return jdbcSelectHelper.existsTopicRequests(topicName, envId, status, tenantId);
+  }
+
+  @Override
   public List<KafkaConnectorRequest> getConnectorRequests(
       String connectorName, String envId, String status, int tenantId) {
     return jdbcSelectHelper.selectConnectorRequests(connectorName, envId, status, tenantId);

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1419,6 +1419,11 @@ public class SelectDataJdbc {
         status, topicName, envId, tenantId);
   }
 
+  public boolean existsTopicRequests(String topicName, String envId, String status, int tenantId) {
+    return topicRequestsRepo.existsByRequestStatusAndTopicnameAndEnvironmentAndTenantId(
+        status, topicName, envId, tenantId);
+  }
+
   public List<KafkaConnectorRequest> selectConnectorRequests(
       String connectorName, String envId, String status, int tenantId) {
     return kafkaConnectorRequestsRepo

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -39,6 +39,9 @@ public interface TopicRequestsRepo
   List<TopicRequest> findAllByRequestStatusAndTopicnameAndEnvironmentAndTenantId(
       String topicStatus, String topicName, String envId, int tenantId);
 
+  boolean existsByRequestStatusAndTopicnameAndEnvironmentAndTenantId(
+      String topicStatus, String topicName, String envId, int tenantId);
+
   boolean existsByEnvironmentAndTenantId(
       @Param("envId") String envId, @Param("tenantId") Integer tenantId);
 

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -223,9 +223,7 @@ public class TopicControllerService {
     HandleDbRequests dbHandle = manageDatabase.getHandleDbRequests();
 
     // check if already a delete topic request exists
-    if (!dbHandle
-        .getTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)
-        .isEmpty()) {
+    if (dbHandle.existsTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)) {
       return ApiResponse.notOk(TOPICS_ERR_103);
     }
 
@@ -302,9 +300,7 @@ public class TopicControllerService {
     TopicRequest topicRequestReq = new TopicRequest();
     int tenantId = commonUtilsService.getTenantId(userName);
 
-    if (!dbHandle
-        .getTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)
-        .isEmpty()) {
+    if (dbHandle.existsTopicRequests(topicName, envId, RequestStatus.CREATED.value, tenantId)) {
       return ApiResponse.notOk(TOPICS_ERR_107);
     }
 
@@ -1342,6 +1338,16 @@ public class TopicControllerService {
     return manageDatabase
         .getHandleDbRequests()
         .getTopicRequests(
+            topicRequestModel.getTopicname(),
+            topicRequestModel.getEnvironment(),
+            RequestStatus.CREATED.value,
+            tenantId);
+  }
+
+  public boolean existsTopicRequests(TopicRequestModel topicRequestModel, int tenantId) {
+    return manageDatabase
+        .getHandleDbRequests()
+        .existsTopicRequests(
             topicRequestModel.getTopicname(),
             topicRequestModel.getEnvironment(),
             RequestStatus.CREATED.value,

--- a/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/TopicRequestValidatorImpl.java
@@ -133,7 +133,7 @@ public class TopicRequestValidatorImpl
 
     // Verify if topic request already exists
     if (topics != null && topicRequestModel.getRequestId() == null) {
-      if (!topicControllerService.getExistingTopicRequests(topicRequestModel, tenantId).isEmpty()) {
+      if (topicControllerService.existsTopicRequests(topicRequestModel, tenantId)) {
         updateConstraint(constraintValidatorContext, TOPICS_VLD_ERR_110);
         return false;
       }

--- a/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
@@ -253,6 +253,7 @@ public class TopicRequestValidatorImplIT {
         .thenReturn(utilMethods.getEnvLists().get(0));
     when(topicControllerService.getExistingTopicRequests(addTopicRequest, tenantId))
         .thenReturn(List.of(topicRequest));
+    when(topicControllerService.existsTopicRequests(addTopicRequest, tenantId)).thenReturn(true);
     when(commonUtilsService.getTeamId(anyString())).thenReturn(101);
 
     Set<ConstraintViolation<TopicCreateRequestModel>> violations =
@@ -338,6 +339,7 @@ public class TopicRequestValidatorImplIT {
     when(topicControllerService.getTopicFromName(anyString(), anyInt())).thenReturn(List.of(topic));
     when(topicControllerService.getExistingTopicRequests(any(), anyInt()))
         .thenReturn(Collections.emptyList());
+    when(topicControllerService.existsTopicRequests(any(), anyInt())).thenReturn(false);
 
     Set<ConstraintViolation<TopicCreateRequestModel>> violations =
         validator.validate(addTopicRequest);

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -240,6 +240,8 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(getListTopicRequests());
+    when(handleDbRequests.existsTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+        .thenReturn(true);
     try {
       ApiResponse apiResponse =
           topicControllerService.createTopicDeleteRequest(topicName, envId, false);
@@ -262,6 +264,8 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
+    when(handleDbRequests.existsTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+        .thenReturn(false);
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
     when(commonUtilsService.getFilteredTopicsForTenant(any()))
@@ -376,6 +380,8 @@ public class TopicControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(getListTopicRequests());
+    when(handleDbRequests.existsTopicRequests(anyString(), anyString(), anyString(), anyInt()))
+        .thenReturn(true);
     try {
       ApiResponse apiResponse = topicControllerService.createClaimTopicRequest(topicName, envId);
       assertThat(apiResponse.getMessage())


### PR DESCRIPTION
The idea is to use `exists` on db level instead of select everything and then check whether list is empty or not