### PR TITLE
feat(coral): Tenant info:  add route, page, `MainNavigation` and `ProfileDropdown` links

### DIFF
--- a/coral/src/app/layout/header/ProfileDropdown.test.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.test.tsx
@@ -39,15 +39,15 @@ const menuItems = [
   },
   {
     angularPath: "/changePwd",
-    path: "/use/change-password",
+    path: "/user/change-password",
     behindFeatureFlag: true,
     name: "Change password",
   },
   {
     angularPath: "/tenantInfo",
-    path: "/",
-    behindFeatureFlag: false,
-    name: "Tenant",
+    path: "/user/tenant-info",
+    behindFeatureFlag: true,
+    name: "Tenant info",
   },
 ];
 describe("ProfileDropdown", () => {

--- a/coral/src/app/layout/header/ProfileDropdown.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.tsx
@@ -36,9 +36,9 @@ const menuItems: MenuItem[] = [
   },
   {
     angularPath: "/tenantInfo",
-    path: "/",
-    behindFeatureFlag: false,
-    name: "Tenant",
+    path: "/user/tenant-info",
+    behindFeatureFlag: true,
+    name: "Tenant info",
   },
 ];
 

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -66,7 +66,7 @@ const submenuItems = [
         linkTo: "/changePwd",
       },
       {
-        name: "Tenant",
+        name: "Tenant info",
         linkTo: "/tenantInfo",
       },
     ],

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -142,7 +142,15 @@ function MainNavigation() {
               linkText={"Change password"}
               active={pathname.startsWith(Routes.USER_CHANGE_PASSWORD)}
             />
-            <MainNavigationLink to={"/tenantInfo"} linkText={"Tenant"} />
+            <MainNavigationLink
+              to={
+                userInformationFeatureFlagEnabled
+                  ? Routes.USER_TENANT_INFO
+                  : "/tenantInfo"
+              }
+              linkText={"Tenant info"}
+              active={pathname.startsWith(Routes.USER_TENANT_INFO)}
+            />
           </MainNavigationSubmenuList>
         </li>
       </ul>

--- a/coral/src/app/pages/user-information/tenant-info/index.tsx
+++ b/coral/src/app/pages/user-information/tenant-info/index.tsx
@@ -1,0 +1,14 @@
+import { PageHeader } from "@aivenio/aquarium";
+import PreviewBanner from "src/app/components/PreviewBanner";
+
+function TenantInfo() {
+  return (
+    <>
+      <PreviewBanner linkTarget={"/tenantInfo"} />
+      <PageHeader title={"Tenant info"} />
+      <div>David Tennant</div>
+    </>
+  );
+}
+
+export { TenantInfo };

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -59,6 +59,7 @@ import { TeamsPage } from "src/app/pages/configuration/teams";
 import { UsersPage } from "src/app/pages/configuration/users";
 import { UserProfile } from "src/app/pages/user-information/profile";
 import { ChangePassword } from "src/app/pages/user-information/change-password";
+import { TenantInfo } from "src/app/pages/user-information/tenant-info";
 
 const routes: Array<RouteObject> = [
   {
@@ -264,6 +265,12 @@ const routes: Array<RouteObject> = [
             featureFlag: FeatureFlag.FEATURE_FLAG_USER_INFORMATION,
             redirectRouteWithoutFeatureFlag: Routes.TOPICS,
             element: <ChangePassword />,
+          }),
+          createRouteBehindFeatureFlag({
+            path: Routes.USER_TENANT_INFO,
+            featureFlag: FeatureFlag.FEATURE_FLAG_USER_INFORMATION,
+            redirectRouteWithoutFeatureFlag: Routes.TOPICS,
+            element: <TenantInfo />,
           }),
         ],
       },

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -24,6 +24,7 @@ enum Routes {
   USER_INFORMATION = "/user",
   USER_PROFILE = "/user/profile",
   USER_CHANGE_PASSWORD = "/user/change-password",
+  USER_TENANT_INFO = "/user/tenant-info",
 }
 
 enum EnvironmentsTabEnum {


### PR DESCRIPTION
# Linked issue

Resolves: #2047

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The links to Tenant info only direct to Angular app.

# What is the new behavior?

Add routes and components to go to `coral` when feature flag is active.

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
