### PR TITLE
feat(coral): View and update user profile

### DIFF
--- a/coral/src/app/features/user-information/profile/Profile.test.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.test.tsx
@@ -244,7 +244,7 @@ describe("Profile.tsx", () => {
 
       expect(mockedUseToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: "No changes were made to the topic.",
+          message: "No changes were made to the profile.",
         })
       );
     });

--- a/coral/src/app/features/user-information/profile/Profile.test.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.test.tsx
@@ -1,0 +1,213 @@
+import {
+  cleanup,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
+import { Profile } from "src/app/features/user-information/profile/Profile";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { getUser, User } from "src/domain/user";
+import { KlawApiError } from "src/services/api";
+
+jest.mock("src/domain/user/user-api.ts");
+
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+
+const testUser: User = {
+  username: "c-pike",
+  fullname: "Chris Pike",
+  mailid: "cpike@ufp.org",
+  role: "USER",
+  switchTeams: false,
+  team: "Enterprise",
+  teamId: 2,
+  tenantId: 0,
+};
+
+describe("Profile.tsx", () => {
+  describe("shows information that profile is loading", () => {
+    beforeAll(() => {
+      mockGetUser.mockResolvedValue(testUser);
+      customRender(<Profile />, { queryClient: true });
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a visual hidden text", () => {
+      const info = screen.getByText("User profile loading.");
+
+      expect(info).toBeVisible();
+      expect(info).toHaveClass("visually-hidden");
+    });
+
+    it("does not show a form while loading", () => {
+      const form = screen.queryByRole("form");
+
+      expect(form).not.toBeInTheDocument();
+    });
+  });
+
+  describe("shows error message when loading profile fails", () => {
+    const testError: KlawApiError = {
+      message: "Oh no 😭",
+      success: false,
+    };
+
+    const originalConsoleError = console.error;
+
+    beforeAll(async () => {
+      console.error = jest.fn();
+      mockGetUser.mockRejectedValue(testError);
+      customRender(<Profile />, { queryClient: true });
+
+      await waitForElementToBeRemoved(
+        screen.getByText("User profile loading.")
+      );
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+      console.error = originalConsoleError;
+    });
+
+    it("shows an error message", () => {
+      const error = screen.getByRole("alert");
+      expect(error).toBeVisible();
+
+      expect(console.error).toHaveBeenCalledWith(testError);
+    });
+
+    it("does not show when there is an error", () => {
+      const form = screen.queryByRole("form");
+
+      expect(form).not.toBeInTheDocument();
+    });
+  });
+
+  describe("shows all necessary elements in a form with all required user data", () => {
+    beforeAll(async () => {
+      mockGetUser.mockResolvedValue(testUser);
+      customRender(<Profile />, { queryClient: true });
+
+      await waitForElementToBeRemoved(
+        screen.getByText("User profile loading.")
+      );
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a form", () => {
+      const form = screen.getByRole("form", { name: "Update profile" });
+
+      expect(form).toBeVisible();
+    });
+
+    it("shows a readonly textinput for username", () => {
+      const userName = screen.getByRole("textbox", { name: "User name" });
+
+      expect(userName).toBeVisible();
+      expect(userName).toHaveAttribute("readonly");
+      expect(userName).toHaveValue(testUser.username);
+    });
+
+    it("shows an editable textinput with description for full name", () => {
+      const fullName = screen.getByRole("textbox", { name: /Full name/ });
+
+      expect(fullName).toBeEnabled();
+      expect(fullName).toHaveAccessibleName(
+        "Full name Can include uppercase and lowercase letters, accented characters (including umlauts), apostrophes, and spaces. It has to be at least 4 characters."
+      );
+      expect(fullName).toHaveValue(testUser.fullname);
+    });
+
+    it("shows an editable textinput for email address", () => {
+      const emailAddress = screen.getByRole("textbox", {
+        name: "Email address",
+      });
+
+      expect(emailAddress).toBeEnabled();
+      expect(emailAddress).toHaveValue(testUser.mailid);
+    });
+
+    it("shows a readonly textinput for team", () => {
+      const currentTeam = screen.getByRole("textbox", {
+        name: "Team (currently logged in)",
+      });
+
+      expect(currentTeam).toBeVisible();
+      expect(currentTeam).toHaveValue(testUser.team);
+    });
+
+    it("shows a readonly textinput for role", () => {
+      const role = screen.getByRole("textbox", {
+        name: "Role",
+      });
+
+      expect(role).toBeVisible();
+      expect(role).toHaveValue(testUser.role);
+    });
+
+    it("does not show information that user can switch team if they can not", () => {
+      const switchTeam = screen.queryByText("User can switch teams");
+
+      expect(switchTeam).not.toBeInTheDocument();
+    });
+
+    it("does not show a team list if user is not member of multiple teams", () => {
+      const teams = screen.queryByText("Member of team");
+
+      expect(teams).not.toBeInTheDocument();
+    });
+  });
+
+  describe("shows optional elements in a form with", () => {
+    beforeAll(async () => {
+      mockGetUser.mockResolvedValue({
+        ...testUser,
+        switchTeams: true,
+        switchAllowedTeamNames: ["Discovery", "Enterprise"],
+      });
+      customRender(<Profile />, { queryClient: true });
+
+      await waitForElementToBeRemoved(
+        screen.getByText("User profile loading.")
+      );
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a disabled checkbox with information that user can switch teams", () => {
+      const switchTeam = screen.getByRole("checkbox", {
+        name: "User can switch teams",
+      });
+
+      expect(switchTeam).toBeDisabled();
+      expect(switchTeam).toBeChecked();
+    });
+
+    it("shows a list with teams the user is member of", () => {
+      const teams = screen.getByRole("list", { name: "Member of team" });
+
+      expect(teams).toBeVisible();
+    });
+
+    it("shows all teams the user is member of", () => {
+      const teams = screen.getByRole("list", { name: "Member of team" });
+      const allTeams = within(teams).getAllByRole("listitem");
+
+      expect(allTeams).toHaveLength(2);
+      expect(allTeams[0]).toHaveTextContent("Discovery");
+      expect(allTeams[1]).toHaveTextContent("Enterprise");
+    });
+  });
+});

--- a/coral/src/app/features/user-information/profile/Profile.test.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.test.tsx
@@ -2,13 +2,13 @@ import {
   cleanup,
   screen,
   waitForElementToBeRemoved,
-  within,
 } from "@testing-library/react";
 import { Profile } from "src/app/features/user-information/profile/Profile";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { getUser, updateProfile, User } from "src/domain/user";
 import { KlawApiError } from "src/services/api";
 import { userEvent } from "@testing-library/user-event";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 
 const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
 const mockUpdateProfile = updateProfile as jest.MockedFunction<
@@ -35,6 +35,8 @@ const testUser: User = {
 
 describe("Profile.tsx", () => {
   const user = userEvent.setup();
+
+  beforeAll(mockIntersectionObserver);
 
   describe("shows information that profile is loading", () => {
     beforeAll(() => {
@@ -207,32 +209,12 @@ describe("Profile.tsx", () => {
       jest.resetAllMocks();
     });
 
-    it("shows a disabled checkbox with information that user can switch teams", () => {
-      const switchTeam = screen.getByRole("checkbox", {
-        name: "User can switch teams (read-only)",
+    it("shows the team overview with table", () => {
+      const table = screen.getByRole("table", {
+        name: "Teams user belongs to",
       });
 
-      expect(switchTeam).toBeDisabled();
-      expect(switchTeam).toBeChecked();
-    });
-
-    it("shows a list with teams the user is member of", () => {
-      const teams = screen.getByRole("list", {
-        name: "Member of team (read-only)",
-      });
-
-      expect(teams).toBeVisible();
-    });
-
-    it("shows all teams the user is member of", () => {
-      const teams = screen.getByRole("list", {
-        name: "Member of team (read-only)",
-      });
-      const allTeams = within(teams).getAllByRole("listitem");
-
-      expect(allTeams).toHaveLength(2);
-      expect(allTeams[0]).toHaveTextContent("Discovery");
-      expect(allTeams[1]).toHaveTextContent("Enterprise");
+      expect(table).toBeVisible();
     });
   });
 

--- a/coral/src/app/features/user-information/profile/Profile.test.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.test.tsx
@@ -41,7 +41,7 @@ describe("Profile.tsx", () => {
   describe("shows information that profile is loading", () => {
     beforeAll(() => {
       mockGetUser.mockResolvedValue(testUser);
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
     });
 
     afterAll(() => {
@@ -74,7 +74,7 @@ describe("Profile.tsx", () => {
     beforeAll(async () => {
       console.error = jest.fn();
       mockGetUser.mockRejectedValue(testError);
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")
@@ -104,7 +104,7 @@ describe("Profile.tsx", () => {
   describe("shows all necessary elements in a form with all required user data", () => {
     beforeAll(async () => {
       mockGetUser.mockResolvedValue(testUser);
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")
@@ -197,7 +197,7 @@ describe("Profile.tsx", () => {
         switchTeams: true,
         switchAllowedTeamNames: ["Discovery", "Enterprise"],
       });
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")
@@ -225,7 +225,7 @@ describe("Profile.tsx", () => {
         switchTeams: true,
         switchAllowedTeamNames: ["Discovery", "Enterprise"],
       });
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")
@@ -259,7 +259,7 @@ describe("Profile.tsx", () => {
         switchTeams: true,
         switchAllowedTeamNames: ["Discovery", "Enterprise"],
       });
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")
@@ -416,7 +416,7 @@ describe("Profile.tsx", () => {
         switchTeams: true,
         switchAllowedTeamNames: ["Discovery", "Enterprise"],
       });
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")
@@ -502,7 +502,7 @@ describe("Profile.tsx", () => {
         switchTeams: true,
         switchAllowedTeamNames: ["Discovery", "Enterprise"],
       });
-      customRender(<Profile />, { queryClient: true });
+      customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")

--- a/coral/src/app/features/user-information/profile/Profile.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.tsx
@@ -1,12 +1,101 @@
 import { useQuery } from "@tanstack/react-query";
 import { getUser } from "src/domain/user/user-api";
+import { Box, Grid, Typography } from "@aivenio/aquarium";
+import {
+  Form,
+  SubmitButton,
+  TextInput,
+  Checkbox,
+  useForm,
+} from "src/app/components/Form";
+import {
+  profileFormSchema,
+  ProfileFormSchema,
+} from "src/app/features/user-information/profile/form-schema/profile-form";
 
 function Profile() {
   const { data: user } = useQuery({
     queryKey: ["getUser"],
     queryFn: getUser,
   });
-  return <div>This is profile page of {user?.username}</div>;
+
+  const form = useForm<ProfileFormSchema>({
+    values: {
+      userName: user?.username || "",
+      fullName: user?.fullname || "",
+      email: user?.mailid || "",
+      team: user?.team || "",
+      role: user?.role || "",
+      switchTeams: user?.switchTeams || false,
+    },
+    schema: profileFormSchema,
+  });
+
+  function onSubmitForm(userInput: ProfileFormSchema) {
+    console.log(userInput);
+  }
+
+  //updateProfile
+  return (
+    <Form {...form} ariaLabel={"Request a new schema"} onSubmit={onSubmitForm}>
+      <Grid>
+        <Grid.Item md={6} xs={12}>
+          <TextInput<ProfileFormSchema>
+            labelText={"User name"}
+            name={"userName"}
+            readOnly={true}
+          />
+          <TextInput<ProfileFormSchema>
+            labelText={"Full name"}
+            name={"fullName"}
+          />
+          <TextInput<ProfileFormSchema>
+            labelText={"Email address"}
+            name={"email"}
+          />
+          <TextInput<ProfileFormSchema>
+            labelText={"Team (currently logged in)"}
+            name={"team"}
+            readOnly={true}
+          />
+          <TextInput<ProfileFormSchema>
+            labelText={"Role"}
+            name={"role"}
+            readOnly={true}
+          />
+
+          {user?.switchAllowedTeamNames &&
+            user?.switchAllowedTeamNames?.length >= 1 && (
+              <Box.Flex
+                flexDirection={"column"}
+                rowGap={"l2"}
+                paddingBottom={"l2"}
+              >
+                <Checkbox<ProfileFormSchema>
+                  name={"switchTeams"}
+                  checked={user.switchTeams}
+                  disabled={true}
+                >
+                  User can switch teams
+                </Checkbox>
+
+                <div>
+                  <Typography.SmallStrong>
+                    Member of team
+                  </Typography.SmallStrong>
+                  <ul>
+                    {user?.switchAllowedTeamNames.map((team) => {
+                      return <li key={team}>{team}</li>;
+                    })}
+                  </ul>
+                </div>
+              </Box.Flex>
+            )}
+        </Grid.Item>
+      </Grid>
+      <SubmitButton>Update profile</SubmitButton>
+    </Form>
+  );
 }
 
 export { Profile };

--- a/coral/src/app/features/user-information/profile/Profile.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.tsx
@@ -48,6 +48,10 @@ function Profile() {
           <TextInput<ProfileFormSchema>
             labelText={"Full name"}
             name={"fullName"}
+            description={
+              "Can include uppercase and lowercase letters, accented characters (including" +
+              " umlauts), apostrophes, and spaces. It has to be at least 4 characters."
+            }
           />
           <TextInput<ProfileFormSchema>
             labelText={"Email address"}

--- a/coral/src/app/features/user-information/profile/Profile.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.tsx
@@ -31,19 +31,21 @@ function Profile() {
     queryFn: getUser,
   });
 
-  const { mutate: updateUser, isLoading: isLoadingUpdateUser } = useMutation(
-    updateProfile,
-    {
-      onSuccess: async () => {
-        toast({
-          message: "Profile successfully updated",
-          position: "bottom-left",
-          variant: "default",
-        });
-        await refetchUser();
-      },
-    }
-  );
+  const {
+    mutate: updateUser,
+    isLoading: isLoadingUpdateUser,
+    isError: isErrorUpdateUser,
+    error: errorUpdateUser,
+  } = useMutation(updateProfile, {
+    onSuccess: async () => {
+      toast({
+        message: "Profile successfully updated",
+        position: "bottom-left",
+        variant: "default",
+      });
+      await refetchUser();
+    },
+  });
 
   const form = useForm<ProfileFormSchema>({
     values: {
@@ -82,79 +84,90 @@ function Profile() {
     return <SkeletonProfile />;
   }
 
-  if (!isLoadingUser && isErrorUser) {
+  if (isErrorUser) {
     return <Alert type={"error"}>{parseErrorMsg(errorUser)}</Alert>;
   }
 
   return (
-    <Form
-      {...form}
-      ariaLabel={"Update profile"}
-      onSubmit={onSubmitForm}
-      onError={onFormError}
-    >
-      <Grid>
-        <Grid.Item md={6} xs={12}>
-          <TextInput<ProfileFormSchema>
-            labelText={"User name (read-only)"}
-            name={"userName"}
-            readOnly={true}
-          />
-          <TextInput<ProfileFormSchema>
-            labelText={"Full name"}
-            name={"fullName"}
-            description={
-              "Can include uppercase and lowercase letters, accented characters (including" +
-              " umlauts), apostrophes, and spaces. It has to be at least 4 characters."
-            }
-          />
-          <TextInput<ProfileFormSchema>
-            labelText={"Email address"}
-            name={"email"}
-          />
-          <TextInput<ProfileFormSchema>
-            labelText={"Team (read-only)"}
-            name={"team"}
-            readOnly={true}
-          />
-          <TextInput<ProfileFormSchema>
-            labelText={"Role (read-only)"}
-            name={"role"}
-            readOnly={true}
-          />
+    <>
+      {isErrorUpdateUser && (
+        <Box marginBottom={"l2"}>
+          <Alert type={"error"}>{parseErrorMsg(errorUpdateUser)}</Alert>
+        </Box>
+      )}
+      <Form
+        {...form}
+        ariaLabel={"Update profile"}
+        onSubmit={onSubmitForm}
+        onError={onFormError}
+      >
+        <Grid>
+          <Grid.Item md={6} xs={12}>
+            <TextInput<ProfileFormSchema>
+              labelText={"User name (read-only)"}
+              name={"userName"}
+              readOnly={true}
+            />
+            <TextInput<ProfileFormSchema>
+              labelText={"Full name"}
+              name={"fullName"}
+              description={
+                "Can include uppercase and lowercase letters, accented characters (including" +
+                " umlauts), apostrophes, and spaces. It has to be at least 4 characters."
+              }
+            />
+            <TextInput<ProfileFormSchema>
+              labelText={"Email address"}
+              name={"email"}
+            />
+            <TextInput<ProfileFormSchema>
+              labelText={"Team (read-only)"}
+              name={"team"}
+              readOnly={true}
+            />
+            <TextInput<ProfileFormSchema>
+              labelText={"Role (read-only)"}
+              name={"role"}
+              readOnly={true}
+            />
 
-          {user.switchTeams &&
-            user.switchAllowedTeamNames &&
-            user.switchAllowedTeamNames?.length >= 1 && (
-              <Box.Flex
-                flexDirection={"column"}
-                rowGap={"l2"}
-                paddingBottom={"l2"}
-              >
-                <Checkbox<ProfileFormSchema>
-                  name={"switchTeams"}
-                  checked={user.switchTeams}
-                  disabled={true}
+            {user.switchTeams &&
+              user.switchAllowedTeamNames &&
+              user.switchAllowedTeamNames?.length >= 1 && (
+                <Box.Flex
+                  flexDirection={"column"}
+                  rowGap={"l2"}
+                  paddingBottom={"l2"}
                 >
-                  User can switch teams (read-only)
-                </Checkbox>
+                  <Checkbox<ProfileFormSchema>
+                    name={"switchTeams"}
+                    checked={user.switchTeams}
+                    disabled={true}
+                  >
+                    User can switch teams (read-only)
+                  </Checkbox>
 
-                <div>
-                  <Typography.SmallStrong>
-                    <span id={"team-list-id"}>Member of team (read-only)</span>
-                  </Typography.SmallStrong>
-                  <ul aria-labelledby={"team-list-id"}>
-                    {user.switchAllowedTeamNames.map((team) => {
-                      return <li key={team}>{team}</li>;
-                    })}
-                  </ul>
-                </div>
-              </Box.Flex>
-            )}
-        </Grid.Item>
-      </Grid>
-      <SubmitButton loading={isLoadingUpdateUser}>Update profile</SubmitButton>
-    </Form>
+                  <div>
+                    <Typography.SmallStrong>
+                      <span id={"team-list-id"}>
+                        Member of team (read-only)
+                      </span>
+                    </Typography.SmallStrong>
+                    <ul aria-labelledby={"team-list-id"}>
+                      {user.switchAllowedTeamNames.map((team) => {
+                        return <li key={team}>{team}</li>;
+                      })}
+                    </ul>
+                  </div>
+                </Box.Flex>
+              )}
+          </Grid.Item>
+        </Grid>
+        <SubmitButton loading={isLoadingUpdateUser}>
+          Update profile
+        </SubmitButton>
+      </Form>
+    </>
   );
 }
 

--- a/coral/src/app/features/user-information/profile/Profile.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.tsx
@@ -54,7 +54,6 @@ function Profile() {
       email: user?.mailid || "",
       team: user?.team || "",
       role: user?.role || "",
-      switchTeams: user?.switchTeams || false,
     },
     schema: profileFormSchema,
   });
@@ -67,7 +66,7 @@ function Profile() {
       )
     ) {
       toast({
-        message: "No changes were made to the topic.",
+        message: "No changes were made to the profile.",
         position: "bottom-left",
         variant: "default",
       });

--- a/coral/src/app/features/user-information/profile/Profile.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.tsx
@@ -1,11 +1,10 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { getUser, updateProfile } from "src/domain/user";
-import { Alert, Box, Grid, Typography, useToast } from "@aivenio/aquarium";
+import { Alert, Box, Grid, useToast } from "@aivenio/aquarium";
 import {
   Form,
   SubmitButton,
   TextInput,
-  Checkbox,
   useForm,
 } from "src/app/components/Form";
 import {
@@ -16,6 +15,7 @@ import { SkeletonProfile } from "src/app/features/user-information/profile/compo
 import { parseErrorMsg } from "src/services/mutation-utils";
 import isEqual from "lodash/isEqual";
 import { FieldErrors } from "react-hook-form";
+import { TeamsOverview } from "src/app/features/user-information/profile/components/TeamsOverview";
 
 function Profile() {
   const toast = useToast();
@@ -130,43 +130,18 @@ function Profile() {
               name={"role"}
               readOnly={true}
             />
-
-            {user.switchTeams &&
-              user.switchAllowedTeamNames &&
-              user.switchAllowedTeamNames?.length >= 1 && (
-                <Box.Flex
-                  flexDirection={"column"}
-                  rowGap={"l2"}
-                  paddingBottom={"l2"}
-                >
-                  <Checkbox<ProfileFormSchema>
-                    name={"switchTeams"}
-                    checked={user.switchTeams}
-                    disabled={true}
-                  >
-                    User can switch teams (read-only)
-                  </Checkbox>
-
-                  <div>
-                    <Typography.SmallStrong>
-                      <span id={"team-list-id"}>
-                        Member of team (read-only)
-                      </span>
-                    </Typography.SmallStrong>
-                    <ul aria-labelledby={"team-list-id"}>
-                      {user.switchAllowedTeamNames.map((team) => {
-                        return <li key={team}>{team}</li>;
-                      })}
-                    </ul>
-                  </div>
-                </Box.Flex>
-              )}
           </Grid.Item>
         </Grid>
         <SubmitButton loading={isLoadingUpdateUser}>
           Update profile
         </SubmitButton>
       </Form>
+
+      {user.switchTeams &&
+        user.switchAllowedTeamNames &&
+        user.switchAllowedTeamNames?.length >= 1 && (
+          <TeamsOverview teams={user.switchAllowedTeamNames} />
+        )}
     </>
   );
 }

--- a/coral/src/app/features/user-information/profile/Profile.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getUser } from "src/domain/user";
-import { Alert, Box, Grid, Typography } from "@aivenio/aquarium";
+import { Alert, Box, Grid, Typography, useToast } from "@aivenio/aquarium";
 import {
   Form,
   SubmitButton,
@@ -15,9 +15,11 @@ import {
 import { SkeletonProfile } from "src/app/features/user-information/profile/components/SkeletonProfile";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import isEqual from "lodash/isEqual";
-import { use } from "msw/lib/core/utils/internal/requestHandlerUtils";
+import { FieldErrors } from "react-hook-form";
 
 function Profile() {
+  const toast = useToast();
+
   const {
     data: user,
     isLoading,
@@ -47,14 +49,17 @@ function Profile() {
         [user?.fullname, user?.mailid]
       )
     ) {
-      console.log("NO CHANGES");
-    } else {
-      console.log(userInput);
+      toast({
+        message: "No changes were made to the topic.",
+        position: "bottom-left",
+        variant: "default",
+      });
+      return;
     }
+    console.log(userInput);
   }
 
-  // @ts-ignore
-  function onFormError(error) {
+  function onFormError(error: FieldErrors<ProfileFormSchema>) {
     console.error(error);
   }
 
@@ -76,7 +81,7 @@ function Profile() {
       <Grid>
         <Grid.Item md={6} xs={12}>
           <TextInput<ProfileFormSchema>
-            labelText={"User name"}
+            labelText={"User name (read-only)"}
             name={"userName"}
             readOnly={true}
           />
@@ -93,12 +98,12 @@ function Profile() {
             name={"email"}
           />
           <TextInput<ProfileFormSchema>
-            labelText={"Team (currently logged in)"}
+            labelText={"Team (read-only)"}
             name={"team"}
             readOnly={true}
           />
           <TextInput<ProfileFormSchema>
-            labelText={"Role"}
+            labelText={"Role (read-only)"}
             name={"role"}
             readOnly={true}
           />
@@ -116,12 +121,12 @@ function Profile() {
                   checked={user.switchTeams}
                   disabled={true}
                 >
-                  User can switch teams
+                  User can switch teams (read-only)
                 </Checkbox>
 
                 <div>
                   <Typography.SmallStrong>
-                    <span id={"team-list-id"}>Member of team</span>
+                    <span id={"team-list-id"}>Member of team (read-only)</span>
                   </Typography.SmallStrong>
                   <ul aria-labelledby={"team-list-id"}>
                     {user.switchAllowedTeamNames.map((team) => {

--- a/coral/src/app/features/user-information/profile/Profile.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.tsx
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getUser } from "src/domain/user/user-api";
+
+function Profile() {
+  const { data: user } = useQuery({
+    queryKey: ["getUser"],
+    queryFn: getUser,
+  });
+  return <div>This is profile page of {user?.username}</div>;
+}
+
+export { Profile };

--- a/coral/src/app/features/user-information/profile/components/SkeletonProfile.tsx
+++ b/coral/src/app/features/user-information/profile/components/SkeletonProfile.tsx
@@ -1,0 +1,24 @@
+import { Grid } from "@aivenio/aquarium";
+import { TextInput } from "src/app/components/Form";
+
+function SkeletonProfile() {
+  return (
+    <>
+      <div className={"visually-hidden"}>User profile loading.</div>
+      <div aria-hidden={true}>
+        <Grid>
+          <Grid.Item md={6} xs={12} aria-hidden={true}>
+            <TextInput.Skeleton />
+
+            <TextInput.Skeleton />
+            <TextInput.Skeleton />
+            <TextInput.Skeleton />
+            <TextInput.Skeleton />
+          </Grid.Item>
+        </Grid>
+      </div>
+    </>
+  );
+}
+
+export { SkeletonProfile };

--- a/coral/src/app/features/user-information/profile/components/TeamsOverview.test.tsx
+++ b/coral/src/app/features/user-information/profile/components/TeamsOverview.test.tsx
@@ -1,13 +1,14 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, screen, within } from "@testing-library/react";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { TeamsOverview } from "src/app/features/user-information/profile/components/TeamsOverview";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 const testTeams = ["Discovery", "Enterprise", "Voyager"];
 describe("TeamsOverview.tsx", () => {
   describe("shows a table with all teams", () => {
     beforeAll(() => {
       mockIntersectionObserver();
-      render(<TeamsOverview teams={testTeams} />);
+      customRender(<TeamsOverview teams={testTeams} />, { memoryRouter: true });
     });
 
     afterAll(cleanup);
@@ -57,6 +58,14 @@ describe("TeamsOverview.tsx", () => {
         const row = within(table).getByRole("row", { name: team });
         expect(row).toBeVisible();
       });
+    });
+
+    it("shows a link to the page showing all teams", () => {
+      const link = screen.getByRole("link", {
+        name: "See all teams",
+      });
+
+      expect(link).toBeVisible();
     });
   });
 });

--- a/coral/src/app/features/user-information/profile/components/TeamsOverview.test.tsx
+++ b/coral/src/app/features/user-information/profile/components/TeamsOverview.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { TeamsOverview } from "src/app/features/user-information/profile/components/TeamsOverview";
+
+const testTeams = ["Discovery", "Enterprise", "Voyager"];
+describe("TeamsOverview.tsx", () => {
+  describe("shows a table with all teams", () => {
+    beforeAll(() => {
+      mockIntersectionObserver();
+      render(<TeamsOverview teams={testTeams} />);
+    });
+
+    afterAll(cleanup);
+
+    it("shows a headline", () => {
+      const headline = screen.getByRole("heading", { name: "Teams" });
+
+      expect(headline).toBeVisible();
+    });
+
+    it("shows a table with accessible name", () => {
+      const table = screen.getByRole("table", {
+        name: "Teams user belongs to",
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    it("shows a column header for team name", () => {
+      const table = screen.getByRole("table", {
+        name: "Teams user belongs to",
+      });
+      const columnHeader = within(table).getByRole("columnheader", {
+        name: "Team name",
+      });
+
+      expect(columnHeader).toBeVisible();
+    });
+
+    it("shows a for for each team", () => {
+      const table = screen.getByRole("table", {
+        name: "Teams user belongs to",
+      });
+      const rows = within(table).getAllByRole("row");
+
+      // one row is the header row
+      const rowLength = testTeams.length + 1;
+      expect(rows).toHaveLength(rowLength);
+    });
+
+    testTeams.forEach((team) => {
+      it(`shows a row for ${team}`, () => {
+        const table = screen.getByRole("table", {
+          name: "Teams user belongs to",
+        });
+
+        const row = within(table).getByRole("row", { name: team });
+        expect(row).toBeVisible();
+      });
+    });
+  });
+});

--- a/coral/src/app/features/user-information/profile/components/TeamsOverview.tsx
+++ b/coral/src/app/features/user-information/profile/components/TeamsOverview.tsx
@@ -7,6 +7,8 @@ import {
   Typography,
 } from "@aivenio/aquarium";
 import uniqueId from "lodash/uniqueId";
+import { Link } from "react-router-dom";
+import { Routes } from "src/app/router_utils";
 
 type TeamsOverviewProps = {
   teams: string[];
@@ -65,6 +67,8 @@ const TeamsOverview = ({ teams }: TeamsOverviewProps) => {
         rows={rows}
         noWrap={false}
       />
+
+      <Link to={Routes.TEAMS}>See all teams</Link>
     </Box.Flex>
   );
 };

--- a/coral/src/app/features/user-information/profile/components/TeamsOverview.tsx
+++ b/coral/src/app/features/user-information/profile/components/TeamsOverview.tsx
@@ -1,0 +1,72 @@
+import {
+  Box,
+  Checkbox,
+  DataTable,
+  DataTableColumn,
+  EmptyState,
+  Typography,
+} from "@aivenio/aquarium";
+import uniqueId from "lodash/uniqueId";
+
+type TeamsOverviewProps = {
+  teams: string[];
+};
+
+interface TeamsOverviewRow {
+  id: string;
+  teamName: string;
+}
+
+const TeamsOverview = ({ teams }: TeamsOverviewProps) => {
+  const columns: Array<DataTableColumn<TeamsOverviewRow>> = [
+    {
+      type: "text",
+      field: "teamName",
+      headerName: "Team name",
+    },
+  ];
+
+  const rows: TeamsOverviewRow[] = teams.map((team) => {
+    return {
+      id: uniqueId(),
+      teamName: team,
+    };
+  });
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState title="No teams">
+        There are no team data available.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Box.Flex
+      flexDirection={"column"}
+      rowGap={"l2"}
+      paddingBottom={"l2"}
+      paddingTop={"l4"}
+    >
+      <Typography.Large htmlTag={"h2"}>Teams</Typography.Large>
+      <Checkbox
+        checked={true}
+        disabled={true}
+        caption={
+          "Enable team switching for users with multiple teams in Klaw interface."
+        }
+      >
+        Switch between Teams
+      </Checkbox>
+
+      <DataTable
+        ariaLabel={"Teams user belongs to"}
+        columns={columns}
+        rows={rows}
+        noWrap={false}
+      />
+    </Box.Flex>
+  );
+};
+
+export { TeamsOverview };

--- a/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
+++ b/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
@@ -1,8 +1,17 @@
 import { z } from "zod";
 
+const fullNameRegex = /^[A-Za-zÀ-ÖØ-öø-ÿ' ]*$/;
+
 const profileFormSchema = z.object({
   userName: z.string(),
-  fullName: z.string().min(3),
+  fullName: z
+    .string()
+    .min(4, { message: "Full name must contain at least 4 characters." })
+    .regex(fullNameRegex, {
+      message:
+        "Invalid input. Full name can only include uppercase and lowercase letters, accented characters (including" +
+        " umlauts), apostrophes, and spaces.",
+    }),
   email: z.coerce.string().email().min(5),
   team: z.string(),
   role: z.string(),

--- a/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
+++ b/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+const profileFormSchema = z.object({
+  userName: z.string(),
+  fullName: z.string().min(3),
+  email: z.coerce.string().email().min(5),
+  team: z.string(),
+  role: z.string(),
+  switchTeams: z.boolean(),
+});
+
+type ProfileFormSchema = z.infer<typeof profileFormSchema>;
+
+export { profileFormSchema };
+export type { ProfileFormSchema };

--- a/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
+++ b/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
@@ -12,7 +12,10 @@ const profileFormSchema = z.object({
         "Invalid input. Full name can only include uppercase and lowercase letters, accented characters (including" +
         " umlauts), apostrophes, and spaces.",
     }),
-  email: z.coerce.string().email().min(5),
+  email: z.coerce
+    .string()
+    .min(1, { message: "Email address can not be empty." })
+    .email({ message: "Email address is invalid." }),
   team: z.string(),
   role: z.string(),
   switchTeams: z.boolean().optional(),

--- a/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
+++ b/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
@@ -15,7 +15,7 @@ const profileFormSchema = z.object({
   email: z.coerce.string().email().min(5),
   team: z.string(),
   role: z.string(),
-  switchTeams: z.boolean(),
+  switchTeams: z.boolean().optional(),
 });
 
 type ProfileFormSchema = z.infer<typeof profileFormSchema>;

--- a/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
+++ b/coral/src/app/features/user-information/profile/form-schema/profile-form.ts
@@ -18,7 +18,6 @@ const profileFormSchema = z.object({
     .email({ message: "Email address is invalid." }),
   team: z.string(),
   role: z.string(),
-  switchTeams: z.boolean().optional(),
 });
 
 type ProfileFormSchema = z.infer<typeof profileFormSchema>;

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -179,7 +179,7 @@ describe("MainNavigation.tsx", () => {
         name: "User information submenu",
       });
 
-      const link = within(list).getByRole("link", { name: "Profile" });
+      const link = within(list).getByRole("link", { name: "User profile" });
       expect(link).toBeVisible();
       expect(link).toHaveAttribute("href", "/myProfile");
     });
@@ -199,7 +199,7 @@ describe("MainNavigation.tsx", () => {
         name: "User information submenu",
       });
 
-      const link = within(list).getByRole("link", { name: "Profile" });
+      const link = within(list).getByRole("link", { name: "User profile" });
       expect(link).toBeVisible();
       expect(link).toHaveAttribute("href", "/user/profile");
     });

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -179,7 +179,7 @@ describe("MainNavigation.tsx", () => {
         name: "User information submenu",
       });
 
-      const link = within(list).getByRole("link", { name: "User profile" });
+      const link = within(list).getByRole("link", { name: "Profile" });
       expect(link).toBeVisible();
       expect(link).toHaveAttribute("href", "/myProfile");
     });
@@ -199,7 +199,7 @@ describe("MainNavigation.tsx", () => {
         name: "User information submenu",
       });
 
-      const link = within(list).getByRole("link", { name: "User profile" });
+      const link = within(list).getByRole("link", { name: "Profile" });
       expect(link).toBeVisible();
       expect(link).toHaveAttribute("href", "/user/profile");
     });

--- a/coral/src/app/pages/user-information/profile/index.tsx
+++ b/coral/src/app/pages/user-information/profile/index.tsx
@@ -1,12 +1,13 @@
 import { PageHeader } from "@aivenio/aquarium";
 import PreviewBanner from "src/app/components/PreviewBanner";
+import { Profile } from "src/app/features/user-information/profile/Profile";
 
 function UserProfile() {
   return (
     <>
       <PreviewBanner linkTarget={"/myProfile"} />
       <PageHeader title={"User profile"} />
-      <div>here is a user profile!</div>
+      <Profile />
     </>
   );
 }

--- a/coral/src/app/pages/user-information/profile/index.tsx
+++ b/coral/src/app/pages/user-information/profile/index.tsx
@@ -1,12 +1,15 @@
-import { PageHeader } from "@aivenio/aquarium";
 import PreviewBanner from "src/app/components/PreviewBanner";
 import { Profile } from "src/app/features/user-information/profile/Profile";
+import { PageHeader } from "@aivenio/aquarium";
 
 function UserProfile() {
   return (
     <>
       <PreviewBanner linkTarget={"/myProfile"} />
-      <PageHeader title={"User profile"} />
+      <PageHeader
+        title={"User profile"}
+        subtitle={"Manage your user profile information and settings."}
+      />
       <Profile />
     </>
   );

--- a/coral/src/domain/user/index.ts
+++ b/coral/src/domain/user/index.ts
@@ -1,5 +1,5 @@
-import { getUserList, getUser } from "src/domain/user/user-api";
+import { getUserList, getUser, updateProfile } from "src/domain/user/user-api";
 import { User } from "src/domain/user/user-types";
 
-export { getUserList, getUser };
+export { getUserList, getUser, updateProfile };
 export type { User };

--- a/coral/src/domain/user/index.ts
+++ b/coral/src/domain/user/index.ts
@@ -1,5 +1,5 @@
-import { getUserList } from "src/domain/user/user-api";
+import { getUserList, getUser } from "src/domain/user/user-api";
 import { User } from "src/domain/user/user-types";
 
-export { getUserList };
+export { getUserList, getUser };
 export type { User };

--- a/coral/src/domain/user/user-api.ts
+++ b/coral/src/domain/user/user-api.ts
@@ -1,5 +1,5 @@
 import { transformUserListApiResponse } from "src/domain/user/user-transformer";
-import { UserListApiResponse } from "src/domain/user/user-types";
+import { User, UserListApiResponse } from "src/domain/user/user-types";
 import api, { API_PATHS } from "src/services/api";
 import { convertQueryValuesToString } from "src/services/api-helper";
 import {
@@ -30,6 +30,13 @@ async function getUserList(
     );
 }
 
+async function getUser(): Promise<User> {
+  return api.get<KlawApiResponse<"getMyProfileInfo">>(
+    API_PATHS.getMyProfileInfo
+  );
+}
+
+
 async function changePassword(
   payload: KlawApiRequest<"changePwd">
 ): Promise<KlawApiResponse<"changePwd">> {
@@ -40,4 +47,4 @@ async function getMyTenantInfo(): Promise<KlawApiResponse<"getMyTenantInfo">> {
   return api.get(API_PATHS.getMyTenantInfo);
 }
 
-export { changePassword, getUserList, getMyTenantInfo };
+export { changePassword, getUserList, getMyTenantInfo, getUser };

--- a/coral/src/domain/user/user-api.ts
+++ b/coral/src/domain/user/user-api.ts
@@ -9,7 +9,6 @@ import { transformUserListApiResponse } from "src/domain/user/user-transformer";
 import { User, UserListApiResponse } from "src/domain/user/user-types";
 import { convertQueryValuesToString } from "src/services/api-helper";
 
-
 async function getUserList(
   params: KlawApiRequestQueryParameters<"showUsers">
 ): Promise<UserListApiResponse> {
@@ -38,13 +37,11 @@ async function getUser(): Promise<User> {
   );
 }
 
-
 async function changePassword(
   payload: KlawApiRequest<"changePwd">
 ): Promise<KlawApiResponse<"changePwd">> {
   return api.post(API_PATHS.changePwd, payload);
 }
-
 
 async function updateProfile(profile: KlawApiModel<"ProfileModel">) {
   return api.post<

--- a/coral/src/domain/user/user-api.ts
+++ b/coral/src/domain/user/user-api.ts
@@ -1,12 +1,14 @@
-import { transformUserListApiResponse } from "src/domain/user/user-transformer";
-import { User, UserListApiResponse } from "src/domain/user/user-types";
-import api, { API_PATHS } from "src/services/api";
-import { convertQueryValuesToString } from "src/services/api-helper";
 import {
+  KlawApiModel,
   KlawApiRequest,
   KlawApiRequestQueryParameters,
   KlawApiResponse,
 } from "types/utils";
+import api, { API_PATHS } from "src/services/api";
+import { transformUserListApiResponse } from "src/domain/user/user-transformer";
+import { User, UserListApiResponse } from "src/domain/user/user-types";
+import { convertQueryValuesToString } from "src/services/api-helper";
+
 
 async function getUserList(
   params: KlawApiRequestQueryParameters<"showUsers">
@@ -43,8 +45,16 @@ async function changePassword(
   return api.post(API_PATHS.changePwd, payload);
 }
 
+
+async function updateProfile(profile: KlawApiModel<"ProfileModel">) {
+  return api.post<
+    KlawApiResponse<"updateProfile">,
+    KlawApiRequest<"updateProfile">
+  >(API_PATHS.updateProfile, profile);
+}
+
 async function getMyTenantInfo(): Promise<KlawApiResponse<"getMyTenantInfo">> {
   return api.get(API_PATHS.getMyTenantInfo);
 }
 
-export { changePassword, getUserList, getMyTenantInfo, getUser };
+export { changePassword, getUserList, updateProfile, getMyTenantInfo, getUser };


### PR DESCRIPTION
# Linked issue

Resolves: #2019 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

## This PR:

- adds `Profile` component to view and edit profile


## Screenshots
NOTE: I sneaked in a link to the teams page after making the recording and screenshots

### Default / view state

https://github.com/Aiven-Open/klaw/assets/943800/67bb3583-f321-430b-917e-2343d9a5cc18



### Error states
<img width="544" alt="Screenshot 2023-11-29 at 13 32 38" src="https://github.com/Aiven-Open/klaw/assets/943800/97e5dbcb-6629-4c5f-a127-7a8e5afba0ce">
<img width="578" alt="Screenshot 2023-11-29 at 13 32 27" src="https://github.com/Aiven-Open/klaw/assets/943800/6252fdcc-7c94-4125-b761-d1e1a9b84f2a">



### Error when updating profile
(message mocked by me)

<img width="880" alt="Screenshot 2023-11-29 at 13 33 22" src="https://github.com/Aiven-Open/klaw/assets/943800/9598af01-eb18-42b9-a15b-9ba57d903d11">





# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
