### PR TITLE
Configure object mapper during init rather than each time during method invokation

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
@@ -72,7 +72,11 @@ public class ExportImportDataService {
   @Value("${klaw.version}")
   private String klawVersion;
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper()
+          .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true)
+          .configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+  ;
   private static final String FILE_EXT = ".json";
   private static final String FILE_PREFIX = "kwmetadata";
   private static final String ADMIN_CONFIG_PREFIX = "admin_config";
@@ -91,7 +95,6 @@ public class ExportImportDataService {
   void importData() {
     try {
       if (importMetadata) {
-        OBJECT_MAPPER.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
         HandleDbRequests handleDbRequests = manageDatabase.getHandleDbRequests();
         importKlawAdminConfig(handleDbRequests);
         importKwData(handleDbRequests);
@@ -158,7 +161,6 @@ public class ExportImportDataService {
     if (!exportMetadata) {
       return;
     }
-    OBJECT_MAPPER.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
 
     exportKwMetadata();
   }

--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -57,7 +57,8 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class ServerConfigService {
 
-  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   public static final ObjectWriter WRITER_WITH_DEFAULT_PRETTY_PRINTER =
       OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
   @Autowired private Environment env;
@@ -154,7 +155,6 @@ public class ServerConfigService {
       if (KwConstants.TENANT_CONFIG_PROPERTY.equals(kwKey)) {
         TenantConfig dynamicObj;
         try {
-          OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
           dynamicObj = OBJECT_MAPPER.readValue(kwVal, TenantConfig.class);
           updateEnvNameValues(dynamicObj, tenantId);
           kwVal = WRITER_WITH_DEFAULT_PRETTY_PRINTER.writeValueAsString(dynamicObj);


### PR DESCRIPTION
Currently there are places where `OBJECT_MAPPER` is going to be configured each time during method invokation.
Actually it could be done only once during init and all useless calls could be removed then