### PR TITLE
fix(core): Count claim requests correctly with `getRequestsStatistics`

### DIFF
--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -77,7 +77,7 @@ public interface KwKafkaConnectorRequestsRepo
   @Query(
       value =
           "select count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
-              + " and (teamid = :teamId or approvingteamid = :approvingTeamid) and requestor != :requestor and connectorstatus = :connectorStatus group by connectorstatus",
+              + " and (((teamid = :teamId or approvingteamid = :approvingTeamid) and connectortype != 'Claim') or (teamId != :approvingTeamid and connectortype = 'Claim')) and requestor != :requestor and connectorstatus = :connectorStatus group by connectorstatus",
       nativeQuery = true)
   Long countRequestorsConnectorRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -93,8 +93,7 @@ public interface TopicRequestsRepo
   @Query(
       value =
           "select count(*) from kwtopicrequests where tenantid = :tenantId"
-              + " and (teamid = :teamId or approvingteamid = :approvingTeamId) and requestor != :requestor "
-              + "and topicstatus = :topicStatus  group by topicstatus",
+              + " and (((teamid = :teamId or approvingteamid = :approvingTeamId) and topictype != 'Claim') or (teamId != :approvingTeamId and topictype = 'Claim')) and requestor != :requestor and topicstatus = :topicStatus group by topicstatus",
       nativeQuery = true)
   Long countRequestorsTopicRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/KafkaConnectorsIntegrationTest.java
@@ -634,7 +634,7 @@ public class KafkaConnectorsIntegrationTest {
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
     assertThat(results).hasSize(2);
-    assertThat(statsCount).containsEntry(RequestStatus.CREATED.value, 21L);
+    assertThat(statsCount).containsEntry(RequestStatus.CREATED.value, 11L);
     assertThat(operationTypeCount)
         .containsEntry(RequestOperationType.CREATE.value, 10L)
         .containsEntry(RequestOperationType.CLAIM.value, 10L);

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicRequestsIntegrationTest.java
@@ -799,7 +799,7 @@ public class TopicRequestsIntegrationTest {
     Map<String, Long> operationTypeCount = results.get("OPERATION_TYPE_COUNTS");
 
     assertThat(results).hasSize(2);
-    assertThat(statsCount).containsEntry(RequestStatus.CREATED.value, 4L);
+    assertThat(statsCount).containsEntry(RequestStatus.CREATED.value, 0L);
     assertThat(operationTypeCount.getOrDefault(RequestOperationType.CREATE.value, 0L)).isZero();
     assertThat(operationTypeCount).containsEntry(RequestOperationType.CLAIM.value, 7L);
     assertThat(statsCount.getOrDefault(RequestStatus.APPROVED.value, 0L)).isZero();


### PR DESCRIPTION
# Linked issue

Resolves: #2090

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

`getRequestsStatistics` will count Claim requests as available for approval, when they are not.

# What is the new behavior?

Do not count Claim requests if:
- they are created by the team of the user

Count the Claim requests if:
- they are not created by the team of the user

# Other information

Some tests had to be changed so the build could complete, but I am not sure if it's only because of the change in behaviour, or if the changes introduced a bug. 

Naively looking at the app, I could only ascertained that the fix *seemed* to now return accurate count for requests available for approval.


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
