### PR TITLE
fix(core): Fix incorrect query annotations for `getRequestStatistics`

### DIFF
--- a/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwKafkaConnectorRequestsRepo.java
@@ -77,7 +77,9 @@ public interface KwKafkaConnectorRequestsRepo
   @Query(
       value =
           "select count(*) from kwkafkaconnectorrequests where tenantid = :tenantId"
-              + " and (((teamid = :teamId or approvingteamid = :approvingTeamid) and connectortype != 'Claim') or (teamId != :approvingTeamid and connectortype = 'Claim')) and requestor != :requestor and connectorstatus = :connectorStatus group by connectorstatus",
+              + " and (((teamid = :teamId or approvingteamid = :approvingTeamid) and connectortype != 'Claim') "
+              + "or (teamid != :teamId and connectortype = 'Claim')) and requestor != :requestor and "
+              + "connectorstatus = :connectorStatus group by connectorstatus",
       nativeQuery = true)
   Long countRequestorsConnectorRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRequestsRepo.java
@@ -93,7 +93,7 @@ public interface TopicRequestsRepo
   @Query(
       value =
           "select count(*) from kwtopicrequests where tenantid = :tenantId"
-              + " and (((teamid = :teamId or approvingteamid = :approvingTeamId) and topictype != 'Claim') or (teamId != :approvingTeamId and topictype = 'Claim')) and requestor != :requestor and topicstatus = :topicStatus group by topicstatus",
+              + " and (((teamid = :teamId or approvingteamid = :approvingTeamId) and topictype != 'Claim') or (teamId != :teamId and topictype = 'Claim')) and requestor != :requestor and topicstatus = :topicStatus group by topicstatus",
       nativeQuery = true)
   Long countRequestorsTopicRequestsGroupByStatusType(
       @Param("teamId") Integer teamId,


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

PR https://github.com/Aiven-Open/klaw/pull/2094 had an error in the queries, forcing a check between varchar and integer which made the endpoint return 500

# What is the new behavior?

Fix the check


# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
