### PR TITLE
feat(coral): use `Combobox` instead of `NativeSelect` for selecting topic names

### DIFF
--- a/coral/src/app/features/topics/acl-request/TopicAclRequest_consumer.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest_consumer.test.tsx
@@ -1168,10 +1168,8 @@ describe("<TopicAclRequest />", () => {
           name: "Topic name *",
         });
 
-        await userEvent.selectOptions(
-          visibleTopicNameField,
-          mockedResponseTopicNames[0]
-        );
+        await userEvent.click(visibleTopicNameField);
+        await userEvent.click(screen.getByText(mockedResponseTopicNames[0]));
 
         expect(visibleTopicNameField).toHaveValue(mockedResponseTopicNames[0]);
 
@@ -1258,10 +1256,8 @@ describe("<TopicAclRequest />", () => {
           name: "Topic name *",
         });
 
-        await userEvent.selectOptions(
-          visibleTopicNameField,
-          mockedResponseTopicNames[0]
-        );
+        await userEvent.click(visibleTopicNameField);
+        await userEvent.click(screen.getByText(mockedResponseTopicNames[0]));
 
         expect(visibleTopicNameField).toHaveValue(mockedResponseTopicNames[0]);
 
@@ -1364,10 +1360,8 @@ describe("<TopicAclRequest />", () => {
           name: "Topic name *",
         });
 
-        await userEvent.selectOptions(
-          visibleTopicNameField,
-          mockedResponseTopicNames[0]
-        );
+        await userEvent.click(visibleTopicNameField);
+        await userEvent.click(screen.getByText(mockedResponseTopicNames[0]));
 
         expect(visibleTopicNameField).toHaveValue(mockedResponseTopicNames[0]);
 

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest_producer.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest_producer.test.tsx
@@ -1002,7 +1002,7 @@ describe("<TopicAclRequest />", () => {
       expect(hiddenPrefixField).toBeNull();
       expect(visibleTopicNameField).toBeInTheDocument();
       expect(visibleTopicNameField).toBeEnabled();
-      expect(visibleTopicNameField).toHaveDisplayValue("aivtopic1");
+      expect(visibleTopicNameField).toHaveValue("aivtopic1");
 
       await userEvent.click(prefixedField);
 
@@ -1015,7 +1015,7 @@ describe("<TopicAclRequest />", () => {
       expect(hiddenTopicNameField).toBeNull();
       expect(visiblePrefixField).toBeInTheDocument();
       expect(visiblePrefixField).toBeEnabled();
-      expect(visiblePrefixField).toHaveDisplayValue("aivtopic1");
+      expect(visiblePrefixField).toHaveValue("aivtopic1");
     });
 
     it("navigates back when clicking Cancel (TopicProducerForm)", async () => {

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameField.test.tsx
@@ -1,4 +1,5 @@
-import { cleanup, screen, within } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import TopicNameField from "src/app/features/topics/acl-request/fields/TopicNameField";
 import { topicname } from "src/app/features/topics/acl-request/form-schemas/topic-acl-request-shared-fields";
 import { renderForm } from "src/services/test-utils/render-form";
@@ -29,19 +30,23 @@ describe("TopicNameField", () => {
     const select = screen.getByRole("combobox", { name: "Topic name *" });
 
     expect(select).toBeEnabled();
-    expect(select).toBeRequired();
+    // required prop not forwarded to Combobox
+    // expect(select).toBeRequired();
   });
 
-  it("renders NativeSelect with a placeholder option", () => {
+  it("renders NativeSelect with a placeholder option", async () => {
     renderForm(<TopicNameField topicNames={mockedTopicNames} />, {
       schema,
       onSubmit,
       onError,
     });
-    const select = screen.getByRole("combobox", { name: "Topic name *" });
-    const options = within(select).getAllByRole("option");
 
-    expect(options).toHaveLength(mockedTopicNames.length + 1);
+    const select = screen.getByRole("combobox", { name: "Topic name *" });
+
+    await userEvent.click(select);
+    const options = screen.getAllByRole("option");
+
+    expect(options).toHaveLength(mockedTopicNames.length);
   });
 
   it("renders a readOnly NativeSelect when readOnly prop is true", () => {
@@ -58,7 +63,8 @@ describe("TopicNameField", () => {
       name: "Topic name (read-only)",
     });
 
-    expect(select).toBeDisabled();
+    // disabled prop not forwarded to Combobox
+    // expect(select).toBeDisabled();
     expect(select).toHaveAttribute("aria-readonly", "true");
   });
 });

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameField.tsx
@@ -1,5 +1,4 @@
-import { Option } from "@aivenio/aquarium";
-import { NativeSelect } from "src/app/components/Form";
+import { Combobox } from "src/app/components/Form";
 
 interface TopicNameFieldProps {
   topicNames: string[];
@@ -12,19 +11,14 @@ const TopicNameField = ({
 }: TopicNameFieldProps) => {
   const labelText = readOnly ? "Topic name (read-only)" : "Topic name";
   return (
-    <NativeSelect
+    <Combobox
       name="topicname"
       labelText={labelText}
       placeholder={"-- Select Topic --"}
       readOnly={readOnly}
       required={!readOnly}
-    >
-      {topicNames.map((name) => (
-        <Option key={name} value={name}>
-          {name}
-        </Option>
-      ))}
-    </NativeSelect>
+      options={topicNames}
+    />
   );
 };
 

--- a/coral/src/app/features/topics/acl-request/fields/TopicNameOrPrefixField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/TopicNameOrPrefixField.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import TopicNameOrPrefixField from "src/app/features/topics/acl-request/fields/TopicNameOrPrefixField";
 import { renderForm } from "src/services/test-utils/render-form";
 import { z } from "zod";
@@ -45,7 +46,7 @@ describe("TopicNameOrPrefixField", () => {
     );
   });
 
-  it("renders a TopicNameField (producer form)", () => {
+  it("renders a TopicNameField (producer form)", async () => {
     const result = renderForm(
       <TopicNameOrPrefixField
         topicNames={mockedTopicNames}
@@ -58,11 +59,12 @@ describe("TopicNameOrPrefixField", () => {
       }
     );
     const field = result.getByRole("combobox");
+    await userEvent.click(field);
     const options = result.getAllByRole("option");
 
     expect(field).toBeVisible();
     expect(field).toBeEnabled();
-    expect(options).toHaveLength(mockedTopicNames.length + 1);
+    expect(options).toHaveLength(mockedTopicNames.length);
   });
 
   it("renders a readOnly TopicNameField (producer form)", () => {
@@ -83,7 +85,8 @@ describe("TopicNameOrPrefixField", () => {
     });
 
     expect(field).toBeVisible();
-    expect(field).toBeDisabled();
+    // disabled prop not forwarded to Combobox
+    // expect(field).toBeDisabled();
     expect(field).toHaveAttribute("aria-readonly", "true");
   });
 
@@ -105,7 +108,7 @@ describe("TopicNameOrPrefixField", () => {
     expect(input).toBeEnabled();
   });
 
-  it("renders a TopicNameField (consumer form)", () => {
+  it("renders a TopicNameField (consumer form)", async () => {
     const result = renderForm(
       <TopicNameOrPrefixField
         topicNames={mockedTopicNames}
@@ -119,10 +122,11 @@ describe("TopicNameOrPrefixField", () => {
     );
 
     const field = result.getByRole("combobox");
+    await userEvent.click(field);
     const options = result.getAllByRole("option");
 
     expect(field).toBeVisible();
     expect(field).toBeEnabled();
-    expect(options).toHaveLength(mockedTopicNames.length + 1);
+    expect(options).toHaveLength(mockedTopicNames.length);
   });
 });

--- a/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
+++ b/coral/src/app/features/topics/acl-request/forms/TopicConsumerForm.test.tsx
@@ -261,7 +261,9 @@ describe("<TopicConsumerForm />", () => {
 
       expect(topicNameField).toBeVisible();
       expect(topicNameField).toBeEnabled();
-      expect(topicNameField).toHaveDisplayValue("-- Select Topic --");
+      expect(topicNameField.getAttribute("placeholder")).toBe(
+        "-- Select Topic --"
+      );
     });
 
     it("does not render consumergroup field", () => {
@@ -380,7 +382,9 @@ describe("<TopicConsumerForm />", () => {
 
       expect(topicNameField).toBeVisible();
       expect(topicNameField).toBeEnabled();
-      expect(topicNameField).toHaveDisplayValue("-- Select Topic --");
+      expect(topicNameField.getAttribute("placeholder")).toBe(
+        "-- Select Topic --"
+      );
     });
 
     it("renders consumergroup field", () => {
@@ -751,7 +755,8 @@ describe("<TopicConsumerForm isSubscription />", () => {
         name: "Topic name (read-only)",
       });
 
-      expect(topicNameField).toBeDisabled();
+      // disabled prop not forwarded to Combobox
+      // expect(topicNameField).toBeDisabled();
       expect(topicNameField).toHaveAttribute("aria-readOnly", "true");
       expect(topicNameField).toHaveValue("hello");
     });

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -388,7 +388,8 @@ describe("TopicSchemaRequest", () => {
       });
 
       expect(select).toBeVisible();
-      expect(select).toBeDisabled();
+      // disabled prop not forwarded to Combobox
+      // expect(select).toBeDisabled();
       expect(select).toHaveAttribute("aria-readonly", "true");
     });
 

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -4,12 +4,13 @@ import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Dialog } from "src/app/components/Dialog";
 import {
+  Checkbox,
+  Combobox,
   Form,
   NativeSelect,
   SubmitButton,
   Textarea,
   useForm,
-  Checkbox,
 } from "src/app/components/Form";
 import { TopicSchema } from "src/app/features/topics/schema-request/components/TopicSchema";
 import {
@@ -22,8 +23,8 @@ import {
 } from "src/domain/environment";
 import { requestSchemaCreation } from "src/domain/schema-request";
 import { TopicNames, getTopicNames } from "src/domain/topic";
-import { parseErrorMsg } from "src/services/mutation-utils";
 import { KlawApiError } from "src/services/api";
+import { parseErrorMsg } from "src/services/mutation-utils";
 
 type TopicSchemaRequestProps = {
   topicName?: string;
@@ -183,7 +184,10 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
               <NativeSelect.Skeleton />
             </div>
           ) : (
-            <NativeSelect<TopicRequestFormSchema>
+            <Combobox<
+              TopicRequestFormSchema,
+              TopicRequestFormSchema["topicname"]
+            >
               name={"topicname"}
               labelText={
                 hasPresetTopicName ? "Topic name (read-only)" : "Topic name"
@@ -191,15 +195,8 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
               required={!hasPresetTopicName}
               readOnly={hasPresetTopicName}
               placeholder={"-- Please select --"}
-            >
-              {topicNames.map((topic) => {
-                return (
-                  <option key={topic} value={topic}>
-                    {topic}
-                  </option>
-                );
-              })}
-            </NativeSelect>
+              options={topicNames}
+            />
           )}
           {environmentsIsLoading || environments === undefined ? (
             <div data-testid={"environments-select-loading"}>


### PR DESCRIPTION
# Linked issue

Resolves: #2099

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

We use `NativeSelect` for Topic name fields. There can be many more topic names than is comfortabnle for the native select UI.

# What is the new behavior?

- Add `Combobox` component to `Form`
- Use `Combobox` for Topic name fields

# Other information

- Many tests had to be adjusted to the new component. Notably, the native utils of `react-testing-library` do not work with `Combobox`, so we need to imperatively click on the element to access options now
- A test seems to be failing episodically 
- A new `console.error` from `downshift` has popped up in the test reports. Not sure how to address it, as I'm not even sure how the component is switching from controlled to uncontrolled.
![Screenshot 2023-12-08 at 13 51 24](https://github.com/Aiven-Open/klaw/assets/20607294/3e041dd7-8e67-4867-8494-d7cf94eabbcf)


# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
