### PR TITLE
Remove deprecated calls in web security

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/ConfigUtils.java
+++ b/core/src/main/java/io/aiven/klaw/config/ConfigUtils.java
@@ -5,6 +5,7 @@ import io.aiven.klaw.auth.KwAuthenticationSuccessHandler;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.authentication.logout.HeaderWriterLogoutHandler;
 import org.springframework.security.web.header.writers.ClearSiteDataHeaderWriter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -66,30 +67,32 @@ public class ConfigUtils {
       KwAuthenticationSuccessHandler kwAuthenticationSuccessHandler,
       KwAuthenticationFailureHandler kwAuthenticationFailureHandler)
       throws Exception {
-    http.csrf()
-        .disable()
-        .authorizeHttpRequests()
-        .requestMatchers(getStaticResources(coralEnabled))
-        .permitAll()
-        .anyRequest()
-        .authenticated()
-        .and()
-        .oauth2Login()
-        .successHandler(kwAuthenticationSuccessHandler)
-        .failureHandler(kwAuthenticationFailureHandler)
-        .failureUrl("/login?error")
-        .loginPage("/login")
-        .permitAll()
-        .and()
-        .logout()
-        .invalidateHttpSession(true)
-        .logoutUrl("/logout")
-        .logoutSuccessUrl("/login")
-        .addLogoutHandler(
-            new HeaderWriterLogoutHandler(
-                new ClearSiteDataHeaderWriter(
-                    ClearSiteDataHeaderWriter.Directive.CACHE,
-                    ClearSiteDataHeaderWriter.Directive.COOKIES,
-                    ClearSiteDataHeaderWriter.Directive.STORAGE)));
+    http.csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(getStaticResources(coralEnabled))
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .oauth2Login(
+            oauthLogin ->
+                oauthLogin
+                    .successHandler(kwAuthenticationSuccessHandler)
+                    .failureHandler(kwAuthenticationFailureHandler)
+                    .failureUrl("/login?error")
+                    .loginPage("/login")
+                    .permitAll())
+        .logout(
+            logout ->
+                logout
+                    .invalidateHttpSession(true)
+                    .logoutUrl("/logout")
+                    .logoutSuccessUrl("/login")
+                    .addLogoutHandler(
+                        new HeaderWriterLogoutHandler(
+                            new ClearSiteDataHeaderWriter(
+                                ClearSiteDataHeaderWriter.Directive.CACHE,
+                                ClearSiteDataHeaderWriter.Directive.COOKIES,
+                                ClearSiteDataHeaderWriter.Directive.STORAGE))));
   }
 }

--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
@@ -26,6 +26,7 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
@@ -75,24 +76,23 @@ public class SecurityConfigNoSSO {
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf()
-        .disable()
-        .authorizeHttpRequests()
-        .requestMatchers(ConfigUtils.getStaticResources(coralEnabled))
-        .permitAll()
-        .anyRequest()
-        .fullyAuthenticated()
-        .and()
-        .formLogin()
-        .successHandler(kwAuthenticationSuccessHandler)
-        .failureHandler(kwAuthenticationFailureHandler)
-        .failureForwardUrl("/login?error")
-        .failureUrl("/login?error")
-        .loginPage("/login")
-        .permitAll()
-        .and()
-        .logout()
-        .logoutSuccessUrl("/login");
+    http.csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(ConfigUtils.getStaticResources(coralEnabled))
+                    .permitAll()
+                    .anyRequest()
+                    .fullyAuthenticated())
+        .formLogin(
+            formLogin ->
+                formLogin
+                    .successHandler(kwAuthenticationSuccessHandler)
+                    .failureHandler(kwAuthenticationFailureHandler)
+                    .failureForwardUrl("/login?error")
+                    .failureUrl("/login?error")
+                    .loginPage("/login")
+                    .permitAll())
+        .logout(logout -> logout.logoutSuccessUrl("/login"));
 
     return http.build();
   }


### PR DESCRIPTION
# Linked issue

Resolves: #xxxxx
Removes deprecated calls in web security config

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._
Certain calls like csrf, oauth2Login, login, formLogin are deprecated

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._
Update code 

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
