### PR TITLE
fix(coral): Update state for open submenu correctly

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigationSubmenuList.tsx
@@ -1,7 +1,7 @@
 import { Box, Icon } from "@aivenio/aquarium";
 import data from "@aivenio/aquarium/dist/src/icons/console";
 import classes from "src/app/layout/main-navigation/MainNavigationSubmenuList.module.css";
-import { ReactElement, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import caretDown from "@aivenio/aquarium/dist/src/icons/caretDown";
 import caretUp from "@aivenio/aquarium/dist/src/icons/caretUp";
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
@@ -20,6 +20,10 @@ function MainNavigationSubmenuList(props: MainNavigationSubmenuItemProps) {
   const buttonText = open
     ? `${text} submenu, open. Click to close.`
     : `${text} submenu, closed. Click to open.`;
+
+  useEffect(() => {
+    setOpen(defaultExpanded);
+  }, [defaultExpanded]);
 
   return (
     <>


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The expandable menu items are not opening when user access a submenu in them from a link. For example: When "user information" is closed and I open the Profile dropdown, click on "User profile", then the "User information" stays close, even so "User profile" is active. 

Technically:
While the  initial value of `open` is set correctly (based on the property `defaultExpanded`, changes in `defaultExpanded` are not updating this state. 

# What is the new behavior?

Works ^^

We're updating the state when the prop updates now. 

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
