### PR TITLE
feat(coral): Remove feature flag for cluster view

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -61,9 +61,7 @@ const submenuItems = [
       },
       {
         name: "Clusters",
-        linkTo: isFeatureFlagActiveMock()
-          ? "/configuration/clusters"
-          : "/clusters",
+        linkTo: "/configuration/clusters",
       },
     ],
   },
@@ -173,53 +171,6 @@ describe("MainNavigation.tsx", () => {
 
       const icons = within(nav).getAllByTestId("ds-icon");
       expect(icons).toHaveLength(iconAmount);
-    });
-  });
-
-  describe("renders links to cluster behind feature flag", () => {
-    afterEach(() => {
-      cleanup();
-      jest.resetAllMocks();
-    });
-
-    it("renders a link to the old UI when feature flag is false", async () => {
-      isFeatureFlagActiveMock.mockReturnValue(false);
-      customRender(<MainNavigation />, {
-        memoryRouter: true,
-        queryClient: true,
-      });
-
-      const button = screen.getByRole("button", {
-        name: new RegExp("Configuration overview", "i"),
-      });
-      await userEvent.click(button);
-      const list = screen.getByRole("list", {
-        name: "Configuration overview submenu",
-      });
-
-      const link = within(list).getByRole("link", { name: "Clusters" });
-      expect(link).toBeVisible();
-      expect(link).toHaveAttribute("href", "/clusters");
-    });
-
-    it("renders a link to the profile page when feature flag is true", async () => {
-      isFeatureFlagActiveMock.mockReturnValue(true);
-      customRender(<MainNavigation />, {
-        memoryRouter: true,
-        queryClient: true,
-      });
-
-      const button = screen.getByRole("button", {
-        name: new RegExp("Configuration overview", "i"),
-      });
-      await userEvent.click(button);
-      const list = screen.getByRole("list", {
-        name: "Configuration overview submenu",
-      });
-
-      const link = within(list).getByRole("link", { name: "Clusters" });
-      expect(link).toBeVisible();
-      expect(link).toHaveAttribute("href", "/configuration/clusters");
     });
   });
 

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -13,15 +13,9 @@ import { usePendingRequests } from "src/app/hooks/usePendingRequests";
 import MainNavigationLink from "src/app/layout/main-navigation/MainNavigationLink";
 import MainNavigationSubmenuList from "src/app/layout/main-navigation/MainNavigationSubmenuList";
 import { Routes } from "src/app/router_utils";
-import useFeatureFlag from "src/services/feature-flags/hook/useFeatureFlag";
-import { FeatureFlag } from "src/services/feature-flags/types";
 
 function MainNavigation() {
   const { pathname } = useLocation();
-
-  const clusterViewFeatureFlagIsEnabled = useFeatureFlag(
-    FeatureFlag.FEATURE_FLAG_VIEW_CLUSTER
-  );
 
   const { TOTAL_NOTIFICATIONS } = usePendingRequests();
 
@@ -119,9 +113,7 @@ function MainNavigation() {
               active={pathname.startsWith(Routes.ENVIRONMENTS)}
             />
             <MainNavigationLink
-              to={
-                clusterViewFeatureFlagIsEnabled ? Routes.CLUSTERS : "/clusters"
-              }
+              to={Routes.CLUSTERS}
               linkText={"Clusters"}
               active={pathname.startsWith(Routes.CLUSTERS)}
             />

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -59,8 +59,6 @@ import {
   TopicOverviewTabEnum,
 } from "src/app/router_utils";
 import { getRouterBasename } from "src/config";
-import { createRouteBehindFeatureFlag } from "src/services/feature-flags/route-utils";
-import { FeatureFlag } from "src/services/feature-flags/types";
 
 const routes: Array<RouteObject> = [
   {
@@ -246,12 +244,10 @@ const routes: Array<RouteObject> = [
             path: Routes.USERS,
             element: <UsersPage />,
           },
-          createRouteBehindFeatureFlag({
+          {
             path: Routes.CLUSTERS,
-            featureFlag: FeatureFlag.FEATURE_FLAG_VIEW_CLUSTER,
-            redirectRouteWithoutFeatureFlag: Routes.TOPICS,
             element: <ClustersPage />,
-          }),
+          },
         ],
       },
       {

--- a/coral/src/services/feature-flags/types.ts
+++ b/coral/src/services/feature-flags/types.ts
@@ -1,5 +1,3 @@
-enum FeatureFlag {
-  FEATURE_FLAG_VIEW_CLUSTER = "FEATURE_FLAG_VIEW_CLUSTER",
-}
+enum FeatureFlag {}
 
 export { FeatureFlag };

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -138,9 +138,6 @@ export default defineConfig(({ mode }) => {
       "process.env": {
         ROUTER_BASENAME: getRouterBasename(environment),
         API_BASE_URL: getApiBaseUrl(environment),
-        FEATURE_FLAG_VIEW_CLUSTER: ["development", "remote-api"]
-          .includes(mode)
-          .toString(),
       },
     },
     css: {


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Clusters view is behind a feature flag because it was waiting on this fix: https://github.com/Aiven-Open/klaw/pull/2071

# What is the new behavior?

Remove feature flag

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
