### PR TITLE
Use set rather than scan list

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
@@ -14,15 +14,15 @@ public class KlawResourceUtils {
   private static final LinkedHashSet<String> EMPTY_LINKED_HASH_SET = new LinkedHashSet<>(0);
 
   public static List<EnvIdInfo> getConvertedEnvs(List<Env> allEnvs, Set<String> selectedEnvs) {
-    Set<EnvIdInfo> newEnvList = new LinkedHashSet<>();
+    Set<EnvIdInfo> newEnvSet = new LinkedHashSet<>();
     for (Env env1 : allEnvs) {
       if (selectedEnvs.contains(env1.getId())) {
-        newEnvList.add(new EnvIdInfo(env1.getId(), env1.getName()));
+        newEnvSet.add(new EnvIdInfo(env1.getId(), env1.getName()));
         break;
       }
     }
 
-    return new ArrayList<>(newEnvList);
+    return new ArrayList<>(newEnvSet);
   }
 
   public static LinkedHashSet<String> getOrderedEnvsSet(String orderOfEnvs) {

--- a/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
@@ -3,10 +3,9 @@ package io.aiven.klaw.helpers;
 import io.aiven.klaw.dao.Env;
 import io.aiven.klaw.model.response.EnvIdInfo;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -14,19 +13,16 @@ public class KlawResourceUtils {
 
   private static final LinkedHashSet<String> EMPTY_LINKED_HASH_SET = new LinkedHashSet<>(0);
 
-  public static List<EnvIdInfo> getConvertedEnvs(
-      List<Env> allEnvs, Collection<String> selectedEnvs) {
-    List<EnvIdInfo> newEnvList = new ArrayList<>();
-    for (String env : selectedEnvs) {
-      for (Env env1 : allEnvs) {
-        if (Objects.equals(env, env1.getId())) {
-          newEnvList.add(new EnvIdInfo(env1.getId(), env1.getName()));
-          break;
-        }
+  public static List<EnvIdInfo> getConvertedEnvs(List<Env> allEnvs, Set<String> selectedEnvs) {
+    Set<EnvIdInfo> newEnvList = new LinkedHashSet<>();
+    for (Env env1 : allEnvs) {
+      if (selectedEnvs.contains(env1.getId())) {
+        newEnvList.add(new EnvIdInfo(env1.getId(), env1.getName()));
+        break;
       }
     }
 
-    return newEnvList;
+    return new ArrayList<>(newEnvList);
   }
 
   public static LinkedHashSet<String> getOrderedEnvsSet(String orderOfEnvs) {

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -366,13 +367,12 @@ public class KafkaConnectControllerService {
                   new KafkaConnectorModelResponse();
               kafkaConnectorModelResponse.setSequence(counterInc);
 
-              List<String> envList = connectorSOT.getEnvironmentsList();
-              envList.sort(Comparator.comparingInt(orderOfEnvs::indexOf));
+              Set<String> set = new HashSet<>(connectorSOT.getEnvironmentsList());
 
               kafkaConnectorModelResponse.setConnectorId(connectorSOT.getConnectorId());
               kafkaConnectorModelResponse.setEnvironmentId(connectorSOT.getEnvironment());
               kafkaConnectorModelResponse.setEnvironmentsList(
-                  KlawResourceUtils.getConvertedEnvs(listAllEnvs, envList));
+                  KlawResourceUtils.getConvertedEnvs(listAllEnvs, set));
               kafkaConnectorModelResponse.setConnectorName(connectorSOT.getConnectorName());
               kafkaConnectorModelResponse.setTeamName(
                   manageDatabase.getTeamNameFromTeamId(tenantId, connectorSOT.getTeamId()));

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -367,12 +367,12 @@ public class KafkaConnectControllerService {
                   new KafkaConnectorModelResponse();
               kafkaConnectorModelResponse.setSequence(counterInc);
 
-              Set<String> set = new HashSet<>(connectorSOT.getEnvironmentsList());
+              Set<String> envSet = new HashSet<>(connectorSOT.getEnvironmentsList());
 
               kafkaConnectorModelResponse.setConnectorId(connectorSOT.getConnectorId());
               kafkaConnectorModelResponse.setEnvironmentId(connectorSOT.getEnvironment());
               kafkaConnectorModelResponse.setEnvironmentsList(
-                  KlawResourceUtils.getConvertedEnvs(listAllEnvs, set));
+                  KlawResourceUtils.getConvertedEnvs(listAllEnvs, envSet));
               kafkaConnectorModelResponse.setConnectorName(connectorSOT.getConnectorName());
               kafkaConnectorModelResponse.setTeamName(
                   manageDatabase.getTeamNameFromTeamId(tenantId, connectorSOT.getTeamId()));


### PR DESCRIPTION
The idea is to use sets to speed up `getConvertedEnvs`