### PR TITLE
Use findAllByTenantIdsOrdered to reduce amount of calls to db

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1326,11 +1326,14 @@ public class SelectDataJdbc {
     Map<String, String> mapProps;
     List<KwTenants> tenants = getTenants();
 
-    for (KwTenants tenant : tenants) {
-      List<KwProperties> kwProps = kwPropertiesRepo.findAllByTenantId(tenant.getTenantId());
-
+    Map<Integer, List<KwProperties>> tenantId2kwPropsMap =
+        kwPropertiesRepo
+            .findAllByTenantIdsOrdered(tenants.stream().map(KwTenants::getTenantId).toList())
+            .stream()
+            .collect(Collectors.groupingBy(KwProperties::getTenantId));
+    for (var entry : tenantId2kwPropsMap.entrySet()) {
       Map<String, Map<String, String>> fullMap = new HashMap<>();
-      for (KwProperties kwProp : kwProps) {
+      for (KwProperties kwProp : entry.getValue()) {
         mapProps = new HashMap<>();
         mapProps.put("kwkey", kwProp.getKwKey());
         mapProps.put("kwvalue", kwProp.getKwValue());
@@ -1339,7 +1342,7 @@ public class SelectDataJdbc {
 
         fullMap.put(kwProp.getKwKey(), mapProps);
       }
-      tenantProps.put(tenant.getTenantId(), fullMap);
+      tenantProps.put(entry.getKey(), fullMap);
     }
 
     return tenantProps;

--- a/core/src/main/java/io/aiven/klaw/repository/KwPropertiesRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/KwPropertiesRepo.java
@@ -2,11 +2,19 @@ package io.aiven.klaw.repository;
 
 import io.aiven.klaw.dao.KwProperties;
 import io.aiven.klaw.dao.KwPropertiesID;
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface KwPropertiesRepo extends CrudRepository<KwProperties, KwPropertiesID> {
   KwProperties findFirstByKwKeyAndTenantIdOrderByTenantId(String kwKey, int tenantId);
+
+  @Query(
+      value = "SELECT * FROM kwproperties WHERE tenantid IN :tenantIds ORDER BY tenantId",
+      nativeQuery = true)
+  List<KwProperties> findAllByTenantIdsOrdered(@Param("tenantIds") Collection<Integer> tenantIds);
 
   List<KwProperties> findAllByTenantId(int tenantId);
 


### PR DESCRIPTION
The PR is about to reduce amount  of calls to db by replacement of `io.aiven.klaw.repository.KwPropertiesRepo#findAllByTenantId` with `io.aiven.klaw.repository.KwPropertiesRepo#findAllByTenantIdsOrdered` and this is allowed to have one call to db instead of call per loop's iteration