### PR TITLE
Use String#replace whenever possible

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/EmailService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EmailService.java
@@ -107,7 +107,7 @@ public class EmailService {
       message.setReplyTo(new Address[] {address});
       message.setFrom(new InternetAddress(fromMailId, noReplyMailIdDisplay));
 
-      text = text.replace("\\\\n", "<br>");
+      text = text.replace("\\n", "<br>");
 
       text =
           text

--- a/core/src/main/java/io/aiven/klaw/service/EmailService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EmailService.java
@@ -107,7 +107,7 @@ public class EmailService {
       message.setReplyTo(new Address[] {address});
       message.setFrom(new InternetAddress(fromMailId, noReplyMailIdDisplay));
 
-      text = text.replace("\n", "<br>");
+      text = text.replace("\\n", "<br>");
 
       text =
           text

--- a/core/src/main/java/io/aiven/klaw/service/EmailService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EmailService.java
@@ -107,7 +107,7 @@ public class EmailService {
       message.setReplyTo(new Address[] {address});
       message.setFrom(new InternetAddress(fromMailId, noReplyMailIdDisplay));
 
-      text = text.replace("\\n", "<br>");
+      text = text.replace("\n", "<br>");
 
       text =
           text

--- a/core/src/main/java/io/aiven/klaw/service/EmailService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EmailService.java
@@ -107,7 +107,7 @@ public class EmailService {
       message.setReplyTo(new Address[] {address});
       message.setFrom(new InternetAddress(fromMailId, noReplyMailIdDisplay));
 
-      text = text.replaceAll("\\\\n", "<br>");
+      text = text.replace("\\\\n", "<br>");
 
       text =
           text

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -1227,8 +1227,7 @@ public class TopicControllerService {
           String prefixVar = "--";
           if (tmpTopicFull.endsWith(
               prefixVar + AclPatternType.PREFIXED + prefixVar)) { // has prefixed acl
-            tmpTopicSub =
-                tmpTopicFull.replaceAll(prefixVar + AclPatternType.PREFIXED + prefixVar, "");
+            tmpTopicSub = tmpTopicFull.replace(prefixVar + AclPatternType.PREFIXED + prefixVar, "");
             if (topicInfo.getTopicname().startsWith(tmpTopicSub)
                 && topicInfo
                     .getEnvironmentsSet()

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -814,7 +814,7 @@ public class TopicSyncControllerService {
           tmpTopicFull = producerConsumerTopic.getTopicname();
 
           if (tmpTopicFull.endsWith("--PREFIXED--")) { // has prefixed acl
-            tmpTopicSub = tmpTopicFull.replaceAll("--PREFIXED--", "");
+            tmpTopicSub = tmpTopicFull.replace("--PREFIXED--", "");
             if (topicInfo.getTopicname().startsWith(tmpTopicSub)
                 && topicInfo
                     .getEnvironmentsSet()

--- a/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UiControllerLoginService.java
@@ -323,7 +323,7 @@ public class UiControllerLoginService {
         registerUserInfoModel.setPwd("");
         if (fullName != null) {
           String fullNameStr =
-              ((String) fullName).replaceAll(",", ""); // Look for other characters in names
+              ((String) fullName).replace(",", ""); // Look for other characters in names
           registerUserInfoModel.setFullname(fullNameStr);
         }
 


### PR DESCRIPTION
If there is no need to replace by regexp then there is String#replace which is much faster than replaceAll, thus it's better to use it instead