### PR TITLE
refactor(coral): Prevent action for submit and cancel buttons in form while mutation is ongoing

### DIFF
--- a/coral/src/app/features/connectors/request/ConnectorEditRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorEditRequest.tsx
@@ -281,6 +281,7 @@ function ConnectorEditRequest() {
               Submit update request
             </SubmitButton>
             <Button
+              disabled={editIsLoading}
               type="button"
               kind={"secondary"}
               onClick={

--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -190,6 +190,7 @@ function ConnectorRequest() {
               Submit request
             </SubmitButton>
             <Button
+              disabled={connectorRequestMutation.isLoading}
               type="button"
               kind={"secondary"}
               onClick={

--- a/coral/src/app/features/topics/request/TopicEditRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicEditRequest.tsx
@@ -326,7 +326,9 @@ function TopicEditRequest() {
         </Box.Flex>
 
         <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
-          <SubmitButton>Submit update request</SubmitButton>
+          <SubmitButton loading={editIsLoading}>
+            Submit update request
+          </SubmitButton>
           <Button
             type="button"
             kind={"secondary"}

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
@@ -291,6 +291,7 @@ function TopicPromotionRequest() {
             Submit promotion request
           </SubmitButton>
           <Button
+            disabled={promoteIsLoading}
             type="button"
             kind={"secondary"}
             onClick={

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -203,6 +203,7 @@ function TopicRequest() {
           <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
             <SubmitButton loading={isLoading}>Submit request</SubmitButton>
             <Button
+              disabled={isLoading}
               type="button"
               kind={"secondary"}
               onClick={

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.tsx
@@ -266,13 +266,17 @@ function TopicSchemaRequest(props: TopicSchemaRequestProps) {
           )}
           <Box display={"flex"} colGap={"l1"} marginTop={"3"}>
             <SubmitButton
-              disabled={isValidationError && !form.watch("forceRegister")}
+              disabled={
+                (isValidationError && !form.watch("forceRegister")) ||
+                schemaRequestMutation.isLoading
+              }
             >
               {isValidationError
                 ? "Submit request to force register"
                 : "Submit request"}
             </SubmitButton>
             <Button
+              disabled={schemaRequestMutation.isLoading}
               type="button"
               kind={"secondary"}
               onClick={

--- a/coral/src/app/features/user-information/change-password/ChangePasswordForm.tsx
+++ b/coral/src/app/features/user-information/change-password/ChangePasswordForm.tsx
@@ -98,7 +98,7 @@ function ChangePasswordForm() {
             labelText="Confirm new password"
             name="confirmPassword"
           />
-          <SubmitButton>Update password</SubmitButton>
+          <SubmitButton loading={isLoading}>Update password</SubmitButton>
         </Form>
       </Box>
     </>


### PR DESCRIPTION
# Linked issue

Resolves: #1749 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# Description
Prevents user from submitting / canceling all forms while a request is in progress. 

Note:
I tried to find a good way to test this, but since it's a async process, the tests are either brittle or we need to work with a timeout, which slows all tests down. I felt that is unnecessary for this functionality, I tested all forms manually. 

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
