### PR TITLE
refactor(coral): Update modal with topic request details for CLAIM requests

### DIFF
--- a/coral/src/app/features/components/TopicDetailsModalContent.test.tsx
+++ b/coral/src/app/features/components/TopicDetailsModalContent.test.tsx
@@ -89,45 +89,61 @@ describe("TopicDetailsModalContent", () => {
       expect(findTerm("Environment")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.environment)).toBeVisible();
     });
+
     it("renders Request type", () => {
       expect(findTerm("Request type")).toBeVisible();
       expect(
         findDefinition(noAdvancedConfigRequest.requestOperationType)
       ).toBeVisible();
     });
+
     it("renders Topic", () => {
       expect(findTerm("Topic")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.topicname)).toBeVisible();
     });
+
     it("renders Topic description", () => {
       expect(findTerm("Topic description")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.description)).toBeVisible();
     });
+
     it("renders Topic partition", () => {
       expect(findTerm("Topic partition")).toBeVisible();
       expect(
         findDefinition(String(noAdvancedConfigRequest.topicpartitions))
       ).toBeVisible();
     });
+
     it("renders Topic replication factor", () => {
       expect(findTerm("Topic replication factor")).toBeVisible();
       expect(
         findDefinition(noAdvancedConfigRequest.replicationfactor)
       ).toBeVisible();
     });
+
     it("renders Message for approval", () => {
       expect(findTerm("Message for approval")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.remarks)).toBeVisible();
     });
+
     it("renders Requested by", () => {
       expect(findTerm("Requested by")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.requestor)).toBeVisible();
     });
+
     it("renders Requested on", () => {
       expect(findTerm("Requested on")).toBeVisible();
       expect(
         findDefinition(`${noAdvancedConfigRequest.requesttimestring} UTC`)
       ).toBeVisible();
+    });
+
+    it("does not render team information", () => {
+      const term = screen.queryByText("Team");
+      const definition = screen.queryByText(noAdvancedConfigRequest.teamname);
+
+      expect(term).not.toBeInTheDocument();
+      expect(definition).not.toBeInTheDocument();
     });
   });
 
@@ -143,51 +159,68 @@ describe("TopicDetailsModalContent", () => {
       expect(findTerm("Environment")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.environment)).toBeVisible();
     });
+
     it("renders Request type", () => {
       expect(findTerm("Request type")).toBeVisible();
       expect(
         findDefinition(noAdvancedConfigRequest.requestOperationType)
       ).toBeVisible();
     });
+
     it("renders Topic", () => {
       expect(findTerm("Topic")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.topicname)).toBeVisible();
     });
+
     it("renders Topic description", () => {
       expect(findTerm("Topic description")).toBeVisible();
       expect(
         findDefinition("This topic description is mandatory!")
       ).toBeVisible();
     });
+
     it("renders Topic partition", () => {
       expect(findTerm("Topic partition")).toBeVisible();
       expect(
         findDefinition(String(noAdvancedConfigRequest.topicpartitions))
       ).toBeVisible();
     });
+
     it("renders Topic replication factor", () => {
       expect(findTerm("Topic replication factor")).toBeVisible();
       expect(
         findDefinition(noAdvancedConfigRequest.replicationfactor)
       ).toBeVisible();
     });
+
     it("renders Message for approval", () => {
       expect(findTerm("Message for approval")).toBeVisible();
       expect(findDefinition("No message")).toBeVisible();
     });
+
     it("renders Requested by", () => {
       expect(findTerm("Requested by")).toBeVisible();
       expect(findDefinition(noAdvancedConfigRequest.requestor)).toBeVisible();
     });
+
     it("renders Requested on", () => {
       expect(findTerm("Requested on")).toBeVisible();
       expect(
         findDefinition(`${noAdvancedConfigRequest.requesttimestring} UTC`)
       ).toBeVisible();
     });
+
     it("renders Advanced configuration", () => {
       expect(findTerm("Advanced configuration")).toBeVisible();
       expect(screen.getByTestId("topic-advanced-config")).toBeVisible();
+    });
+
+    it("does not render team information", () => {
+      const term = screen.queryByText("Team");
+      const definition = screen.queryByText(withAdvancedConfigRequest.teamname);
+
+      expect(term).not.toBeInTheDocument();
+      expect(definition).not.toBeInTheDocument();
     });
   });
 
@@ -224,7 +257,7 @@ describe("TopicDetailsModalContent", () => {
       expect(definition).not.toBeInTheDocument();
     });
 
-    it("renders Topic replication factor", () => {
+    it("does not render Topic replication factor", () => {
       const term = screen.queryByText("Topic replication factor");
       const definition = screen.queryByText(
         noAdvancedConfigRequest.replicationfactor
@@ -232,6 +265,11 @@ describe("TopicDetailsModalContent", () => {
 
       expect(term).not.toBeInTheDocument();
       expect(definition).not.toBeInTheDocument();
+    });
+
+    it("renders team that started CLAIM request", () => {
+      expect(findTerm("Team")).toBeVisible();
+      expect(findDefinition(noAdvancedConfigRequest.teamname)).toBeVisible();
     });
   });
 });

--- a/coral/src/app/features/components/TopicDetailsModalContent.test.tsx
+++ b/coral/src/app/features/components/TopicDetailsModalContent.test.tsx
@@ -131,7 +131,7 @@ describe("TopicDetailsModalContent", () => {
     });
   });
 
-  describe("renders correct content for Topic request (no description,  no remarks, with config)", () => {
+  describe("renders correct content for Topic request (no description, no remarks, with config)", () => {
     beforeAll(() => {
       render(
         <TopicDetailsModalContent topicRequest={withAdvancedConfigRequest} />
@@ -188,6 +188,50 @@ describe("TopicDetailsModalContent", () => {
     it("renders Advanced configuration", () => {
       expect(findTerm("Advanced configuration")).toBeVisible();
       expect(screen.getByTestId("topic-advanced-config")).toBeVisible();
+    });
+  });
+
+  describe("renders correct content for Topic CLAIM request (no description, partition, replication)", () => {
+    beforeAll(() => {
+      render(
+        <TopicDetailsModalContent
+          topicRequest={{
+            ...noAdvancedConfigRequest,
+            requestOperationType: "CLAIM",
+          }}
+        />
+      );
+    });
+    afterAll(cleanup);
+
+    it("does not renders Topic description", () => {
+      const term = screen.queryByText("Topic description");
+      const definition = screen.queryByText(
+        noAdvancedConfigRequest.description
+      );
+
+      expect(term).not.toBeInTheDocument();
+      expect(definition).not.toBeInTheDocument();
+    });
+
+    it("does not renders Topic partition", () => {
+      const term = screen.queryByText("Topic partition");
+      const definition = screen.queryByText(
+        String(noAdvancedConfigRequest.topicpartitions)
+      );
+
+      expect(term).not.toBeInTheDocument();
+      expect(definition).not.toBeInTheDocument();
+    });
+
+    it("renders Topic replication factor", () => {
+      const term = screen.queryByText("Topic replication factor");
+      const definition = screen.queryByText(
+        noAdvancedConfigRequest.replicationfactor
+      );
+
+      expect(term).not.toBeInTheDocument();
+      expect(definition).not.toBeInTheDocument();
     });
   });
 });

--- a/coral/src/app/features/components/TopicDetailsModalContent.tsx
+++ b/coral/src/app/features/components/TopicDetailsModalContent.tsx
@@ -47,6 +47,7 @@ const TopicDetailsModalContent = ({
     remarks,
     requestor,
     requesttimestring,
+    teamname,
   } = topicRequest;
 
   const hasAdvancedConfig =
@@ -133,6 +134,12 @@ const TopicDetailsModalContent = ({
         <Label>Requested by</Label>
         <dd>{requestor}</dd>
       </Box.Flex>
+      {requestOperationType === "CLAIM" && (
+        <Box.Flex flexDirection={"column"}>
+          <Label>Team</Label>
+          <dd>{teamname}</dd>
+        </Box.Flex>
+      )}
       <Box.Flex flexDirection={"column"}>
         <Label>Requested on</Label>
         <dd>{requesttimestring} UTC</dd>

--- a/coral/src/app/features/components/TopicDetailsModalContent.tsx
+++ b/coral/src/app/features/components/TopicDetailsModalContent.tsx
@@ -73,20 +73,30 @@ const TopicDetailsModalContent = ({
           <dd>{topicname}</dd>
         </Box.Flex>
       </Grid.Item>
-      <Grid.Item xs={2}>
-        <Box.Flex flexDirection={"column"}>
-          <Label>Topic description</Label>
-          <dd>{description}</dd>
-        </Box.Flex>
-      </Grid.Item>
-      <Box.Flex flexDirection={"column"}>
-        <Label>Topic partition</Label>
-        <dd>{topicpartitions}</dd>
-      </Box.Flex>
-      <Box.Flex flexDirection={"column"}>
-        <Label>Topic replication factor</Label>
-        <dd>{replicationfactor}</dd>
-      </Box.Flex>
+      {/*getTopicRequestsForApprover for a CLAIM request*/}
+      {/*does not contain topicpartitions, replicationfactor and description*/}
+      {/*even though the openapi definition implies it*/}
+      {/*In case it's a CLAIM request we don't want to show those options.*/}
+      {requestOperationType !== "CLAIM" && (
+        <>
+          <Grid.Item xs={2}>
+            <Box.Flex flexDirection={"column"}>
+              <Label>Topic description</Label>
+              <dd>{description}</dd>
+            </Box.Flex>
+          </Grid.Item>
+
+          <Box.Flex flexDirection={"column"}>
+            <Label>Topic partition</Label>
+            <dd>{topicpartitions}</dd>
+          </Box.Flex>
+
+          <Box.Flex flexDirection={"column"}>
+            <Label>Topic replication factor</Label>
+            <dd>{replicationfactor}</dd>
+          </Box.Flex>
+        </>
+      )}
       {hasAdvancedConfig && (
         <Grid.Item xs={2}>
           <Box.Flex flexDirection={"column"}>


### PR DESCRIPTION
# Linked issue

Resolves: #1679 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The details modal show values for topic partition, topic description and topic replication factor for `CLAIM` requests, but the endpoint does not return them. 


#### Update request

<img width="900" alt="Screenshot 2023-12-27 at 16 19 48" src="https://github.com/Aiven-Open/klaw/assets/943800/e306dc4d-d851-42ef-8ff8-b9705aeed005">


#### CLAIM request (before change)

<img width="945" alt="Screenshot 2023-12-27 at 16 20 46" src="https://github.com/Aiven-Open/klaw/assets/943800/2a8ff516-febc-4f06-b6b3-9677eedebbff">



# What is the new behavior?

If it's a claim request, the headlines are not shown.

<img width="940" alt="Screenshot 2023-12-27 at 16 20 29" src="https://github.com/Aiven-Open/klaw/assets/943800/af242f9b-3f3f-4976-8c33-c196b646132a">


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
