### PR TITLE
Add topic owner team to topic overview

### DIFF
--- a/coral/src/app/features/topics/details/overview/TopicOverview.tsx
+++ b/coral/src/app/features/topics/details/overview/TopicOverview.tsx
@@ -31,6 +31,7 @@ function TopicOverview() {
       hasOpenTopicRequest,
       hasOpenClaimRequest,
       clusterId,
+      teamname,
     },
     topicPromotionDetails,
   } = topicOverview;
@@ -64,6 +65,11 @@ function TopicOverview() {
               entity={"Partitions"}
             />
           </Box.Flex>
+        </Card>
+      </Grid.Item>
+      <Grid.Item xs={2}>
+        <Card title="Topic owner" fullWidth>
+          <Typography htmlTag={"div"}>{teamname}</Typography>
         </Card>
       </Grid.Item>
 

--- a/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
+++ b/coral/src/app/features/topics/details/overview/__snapshots__/TopicOverview.test.tsx.snap
@@ -62,6 +62,32 @@ exports[`TopicOverview with promotion banner renders correct DOM according to da
       style="grid-column: [object Object];"
     >
       <div
+        class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+      >
+        <div
+          class="flex flex-col gap-4"
+        >
+          <div
+            class="typography-default-strong text-black"
+          >
+            Topic owner
+          </div>
+          <div
+            class="typography-caption text-grey-70"
+          >
+            <div
+              class="typography-default text-grey-70"
+            >
+              Ospo
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style="grid-column: [object Object];"
+    >
+      <div
         data-testid="topic-promotion-banner"
       >
         <div
@@ -510,6 +536,32 @@ exports[`TopicOverview without promotion banner renders correct DOM according to
                   Partitions
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style="grid-column: [object Object];"
+    >
+      <div
+        class="border-grey-5 border-[1px] rounded-[2px] relative p-5 flex flex-col gap-5 w-full Aquarium-Card"
+      >
+        <div
+          class="flex flex-col gap-4"
+        >
+          <div
+            class="typography-default-strong text-black"
+          >
+            Topic owner
+          </div>
+          <div
+            class="typography-caption text-grey-70"
+          >
+            <div
+              class="typography-default text-grey-70"
+            >
+              Ospo
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Linked issue

Resolves: #1682 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# Description

Adds the topic owner team to the topic overview page. 

![Screenshot 2023-12-28 at 17 42 31](https://github.com/Aiven-Open/klaw/assets/943800/0b1eb59b-138b-40cc-ad43-0e6aa8d62368)


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
