### PR TITLE
fix(coral): Add UI error handling in shared filters

### DIFF
--- a/coral/src/app/features/activity-log/ActivityLog.test.tsx
+++ b/coral/src/app/features/activity-log/ActivityLog.test.tsx
@@ -75,6 +75,7 @@ describe("ActivityLog", () => {
     customRender(<ActivityLog />, {
       queryClient: true,
       memoryRouter: true,
+      aquariumContext: true,
     });
     expect(mockGetActivityLog).toHaveBeenCalledTimes(1);
   });
@@ -104,6 +105,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -120,6 +122,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -152,6 +155,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -166,6 +170,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -184,6 +189,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -204,6 +210,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -224,6 +231,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -247,6 +255,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -287,6 +296,7 @@ describe("ActivityLog", () => {
       customRender(<ActivityLog />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?environment=TEST_ENV_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -154,6 +154,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
       const skeleton = screen.getByTestId("skeleton-table");
 
@@ -168,6 +169,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const skeleton = screen.getByTestId("skeleton-table");
@@ -194,6 +196,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -265,6 +268,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -449,6 +453,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?requestType=DELETE",
       });
 
@@ -489,6 +494,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -581,6 +587,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -700,6 +707,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -862,6 +870,7 @@ describe("AclApprovals", () => {
       customRender(<AclApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
@@ -152,6 +152,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -168,6 +169,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -193,6 +195,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -260,6 +263,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -275,6 +279,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -294,6 +299,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -314,6 +320,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -334,6 +341,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -358,6 +366,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -408,6 +417,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -577,6 +587,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -673,6 +684,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -769,6 +781,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -892,6 +905,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -1060,6 +1074,7 @@ describe("ConnectorApprovals", () => {
       customRender(<ConnectorApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -146,6 +146,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -162,6 +163,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -187,6 +189,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -252,6 +255,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -267,6 +271,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -286,6 +291,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -306,6 +312,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -326,6 +333,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -350,6 +358,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -396,6 +405,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -518,6 +528,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -630,6 +641,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -728,6 +740,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -853,6 +866,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -1023,6 +1037,7 @@ describe("SchemaApprovals", () => {
       customRender(<SchemaApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -171,6 +171,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -189,6 +190,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const skeleton = screen.getByTestId("skeleton-table");
@@ -217,6 +219,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -289,6 +292,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -304,6 +308,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -323,6 +328,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -343,6 +349,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -363,6 +370,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -387,6 +395,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -434,6 +443,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -529,6 +539,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -685,6 +696,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -779,6 +791,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -900,6 +913,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -1066,6 +1080,7 @@ describe("TopicApprovals", () => {
       customRender(<TopicApprovals />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "src/domain/environment";
 import { createMockEnvironmentDTO } from "src/domain/environment/environment-test-helper";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { KlawApiError } from "src/services/api";
 import { getAllEnvironments } from "src/domain/environment/environment-api";
 
 jest.mock("src/domain/environment/environment-api.ts");
@@ -38,6 +39,12 @@ const mockEnvironments = [
   }),
 ];
 
+const mockedUseToast = jest.fn();
+jest.mock("@aivenio/aquarium", () => ({
+  ...jest.requireActual("@aivenio/aquarium"),
+  useToast: () => mockedUseToast,
+}));
+
 const filterLabel = "Filter by Environment";
 
 const WrappedEnvironmentFilter = withFiltersContext({
@@ -63,6 +70,7 @@ describe("EnvironmentFilter.tsx", () => {
       customRender(<WrappedEnvironmentFilter />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
 
       expect(mockGetEnvironments).toHaveBeenCalled();
@@ -76,6 +84,7 @@ describe("EnvironmentFilter.tsx", () => {
       customRender(<WrappedEnvironmentFilter />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
 
       expect(mockGetEnvironments).toHaveBeenCalled();
@@ -90,6 +99,7 @@ describe("EnvironmentFilter.tsx", () => {
       customRender(<WrappedEnvironmentFilter />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
 
       expect(mockGetSyncConnectorsEnvironments).toHaveBeenCalled();
@@ -121,9 +131,10 @@ describe("EnvironmentFilter.tsx", () => {
       customRender(<WrappedEnvironmentFilter />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-environment-loading")
+        screen.getByTestId("async-select-loading")
       );
     });
 
@@ -202,9 +213,10 @@ describe("EnvironmentFilter.tsx", () => {
       customRender(<WrappedEnvironmentFilter />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-environment-loading")
+        screen.getByTestId("async-select-loading")
       );
     });
 
@@ -273,10 +285,11 @@ describe("EnvironmentFilter.tsx", () => {
       customRender(<WrappedEnvironmentFilter />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-environment-loading")
+        screen.getByTestId("async-select-loading")
       );
     });
 
@@ -303,10 +316,11 @@ describe("EnvironmentFilter.tsx", () => {
 
       customRender(<WrappedEnvironmentFilter />, {
         queryClient: true,
+        aquariumContext: true,
         memoryRouter: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-environment-loading")
+        screen.getByTestId("async-select-loading")
       );
     });
 
@@ -337,10 +351,11 @@ describe("EnvironmentFilter.tsx", () => {
 
       customRender(<WrappedEnvironmentFilter />, {
         queryClient: true,
+        aquariumContext: true,
         browserRouter: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-environment-loading")
+        screen.getByTestId("async-select-loading")
       );
     });
 
@@ -385,6 +400,59 @@ describe("EnvironmentFilter.tsx", () => {
       await waitFor(() => {
         expect(window.location.search).toEqual("?page=1");
       });
+    });
+  });
+
+  describe("gives user information if fetching environments failed", () => {
+    const testError: KlawApiError = {
+      message: "Oh no, this did not work",
+      success: false,
+    };
+
+    const originalConsoleError = jest.fn();
+
+    beforeEach(async () => {
+      console.error = jest.fn();
+      mockGetEnvironments.mockRejectedValue(testError);
+      mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
+
+      customRender(<WrappedEnvironmentFilter />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
+      await waitForElementToBeRemoved(
+        screen.getByTestId("async-select-loading")
+      );
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("shows a disabled select with No Environments", () => {
+      const select = screen.getByRole("combobox", {
+        name: "No Environments",
+      });
+
+      expect(select).toBeDisabled();
+    });
+
+    it("shows an error message below the select element", () => {
+      const errorText = screen.getByText("Environments could not be loaded.");
+
+      expect(errorText).toBeVisible();
+    });
+
+    it("shows a toast notification with error", () => {
+      expect(mockedUseToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `Error loading Environments: ${testError.message}`,
+        })
+      );
+      expect(console.error).toHaveBeenCalledWith(testError);
     });
   });
 });

--- a/coral/src/app/features/components/filters/EnvironmentFilter.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.tsx
@@ -8,6 +8,7 @@ import {
 } from "src/domain/environment";
 import { getAllEnvironments } from "src/domain/environment/environment-api";
 import { HTTPError } from "src/services/api";
+import { AsyncNativeSelectWrapper } from "src/app/components/AsyncNativeSelectWrapper";
 
 type EnvironmentFor = "TOPIC_AND_ACL" | "SCHEMA" | "CONNECTOR" | "ALL";
 interface EnvironmentFilterProps {
@@ -59,7 +60,12 @@ function filterEnvironmentsForSchema(
 function EnvironmentFilter({ environmentsFor }: EnvironmentFilterProps) {
   const { environment, setFilterValue } = useFiltersContext();
 
-  const { data: environments } = useQuery<Environment[], HTTPError>(
+  const {
+    data: environments,
+    isError,
+    isLoading,
+    error,
+  } = useQuery<Environment[], HTTPError>(
     [environmentEndpointMap[environmentsFor].queryFn],
     {
       queryFn: environmentEndpointMap[environmentsFor].apiEndpoint,
@@ -72,14 +78,13 @@ function EnvironmentFilter({ environmentsFor }: EnvironmentFilterProps) {
     }
   );
 
-  if (!environments) {
-    return (
-      <div data-testid={"select-environment-loading"}>
-        <NativeSelect.Skeleton />
-      </div>
-    );
-  } else {
-    return (
+  return (
+    <AsyncNativeSelectWrapper
+      entity={"Environments"}
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+    >
       <NativeSelect
         labelText="Filter by Environment"
         value={environment}
@@ -91,14 +96,14 @@ function EnvironmentFilter({ environmentsFor }: EnvironmentFilterProps) {
           All Environments
         </Option>
 
-        {environments.map((env: Environment) => (
+        {environments?.map((env: Environment) => (
           <Option key={env.id} value={env.id}>
             {env.name}
           </Option>
         ))}
       </NativeSelect>
-    );
-  }
+    </AsyncNativeSelectWrapper>
+  );
 }
 
 export default EnvironmentFilter;

--- a/coral/src/app/features/components/filters/TeamFilter.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.tsx
@@ -2,25 +2,30 @@ import { NativeSelect, Option } from "@aivenio/aquarium";
 import { useQuery } from "@tanstack/react-query";
 import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
 import { getTeams } from "src/domain/team/team-api";
+import { AsyncNativeSelectWrapper } from "src/app/components/AsyncNativeSelectWrapper";
 
 type TeamFilterProps = {
   useTeamName?: boolean;
 };
 function TeamFilter({ useTeamName }: TeamFilterProps) {
-  const { data: teams } = useQuery(["get-teams"], {
+  const {
+    data: teams,
+    isLoading,
+    isError,
+    error,
+  } = useQuery(["get-teams"], {
     queryFn: () => getTeams(),
   });
 
   const { teamId, teamName, setFilterValue } = useFiltersContext();
 
-  if (!teams) {
-    return (
-      <div data-testid={"select-team-loading"}>
-        <NativeSelect.Skeleton />
-      </div>
-    );
-  } else {
-    return (
+  return (
+    <AsyncNativeSelectWrapper
+      entity={"Teams"}
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+    >
       <NativeSelect
         labelText="Filter by team"
         value={useTeamName ? teamName : teamId}
@@ -34,7 +39,7 @@ function TeamFilter({ useTeamName }: TeamFilterProps) {
         <Option key={"ALL"} value={"ALL"}>
           All teams
         </Option>
-        {teams.map((team) => (
+        {teams?.map((team) => (
           <Option
             key={team.teamId}
             value={useTeamName ? team.teamname : team.teamId}
@@ -43,8 +48,8 @@ function TeamFilter({ useTeamName }: TeamFilterProps) {
           </Option>
         ))}
       </NativeSelect>
-    );
-  }
+    </AsyncNativeSelectWrapper>
+  );
 }
 
 export default TeamFilter;

--- a/coral/src/app/features/configuration/users/Users.test.tsx
+++ b/coral/src/app/features/configuration/users/Users.test.tsx
@@ -81,7 +81,11 @@ describe("Users.tsx", () => {
         totalPages: 1,
         entries: [],
       });
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
     });
 
     afterAll(() => {
@@ -103,7 +107,11 @@ describe("Users.tsx", () => {
         totalPages: 1,
         entries: [],
       });
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -135,7 +143,11 @@ describe("Users.tsx", () => {
       console.error = jest.fn();
       mockGetTeams.mockResolvedValue([]);
       mockGetUsers.mockRejectedValue(testError);
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -170,7 +182,11 @@ describe("Users.tsx", () => {
         totalPages: 1,
         entries: mockUsers,
       });
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -225,7 +241,11 @@ describe("Users.tsx", () => {
         totalPages: 4,
         entries: mockUsers,
       });
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -273,7 +293,11 @@ describe("Users.tsx", () => {
         totalPages: 5,
         entries: mockUsers,
       });
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -314,7 +338,11 @@ describe("Users.tsx", () => {
         totalPages: 5,
         entries: mockUsers,
       });
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -394,7 +422,11 @@ describe("Users.tsx", () => {
         totalPages: 5,
         entries: mockUsers,
       });
-      customRender(<Users />, { queryClient: true, memoryRouter: true });
+      customRender(<Users />, {
+        queryClient: true,
+        aquariumContext: true,
+        memoryRouter: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 

--- a/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
+++ b/coral/src/app/features/connectors/browse/BrowseConnectors.test.tsx
@@ -167,6 +167,7 @@ describe("BrowseConnectors.tsx", () => {
       customRender(<BrowseConnectors />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -218,6 +219,7 @@ describe("BrowseConnectors.tsx", () => {
       customRender(<BrowseConnectors />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -258,6 +260,7 @@ describe("BrowseConnectors.tsx", () => {
       customRender(<BrowseConnectors />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
@@ -302,6 +305,7 @@ describe("BrowseConnectors.tsx", () => {
       customRender(<BrowseConnectors />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
@@ -363,6 +367,7 @@ describe("BrowseConnectors.tsx", () => {
       customRender(<BrowseConnectors />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
@@ -422,6 +427,7 @@ describe("BrowseConnectors.tsx", () => {
       customRender(<BrowseConnectors />, {
         memoryRouter: true,
         queryClient: true,
+        aquariumContext: true,
       });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -124,6 +124,7 @@ describe("AclRequests", () => {
     customRender(<AclRequests />, {
       queryClient: true,
       memoryRouter: true,
+      aquariumContext: true,
     });
     expect(getAclRequests).toBeCalledTimes(1);
   });
@@ -146,6 +147,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -166,6 +168,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -190,6 +193,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -210,6 +214,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -230,6 +235,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -252,6 +258,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -301,6 +308,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?search=abc",
       });
       expect(getAclRequests).toHaveBeenNthCalledWith(1, {
@@ -318,6 +326,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
       const search = screen.getByRole("search", { name: "Search Topic" });
       expect(search).toBeEnabled();
@@ -346,11 +355,12 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?environment=1",
       });
 
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-environment-loading")
+        screen.getByTestId("async-select-loading")
       );
 
       const envFilter = screen.getByRole("combobox", {
@@ -374,10 +384,11 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-environment-loading")
+        screen.getByTestId("async-select-loading")
       );
 
       const envFilter = screen.getByRole("combobox", {
@@ -409,6 +420,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?aclType=CONSUMER",
       });
 
@@ -434,6 +446,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const envFilter = screen.getByRole("combobox", {
@@ -465,6 +478,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?status=APPROVED",
       });
 
@@ -489,6 +503,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const envFilter = screen.getByRole("combobox", {
@@ -521,6 +536,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?showOnlyMyRequests=true",
       });
 
@@ -545,6 +561,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const toggle = screen.getByRole("checkbox", {
@@ -580,6 +597,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?requestType=DELETE",
       });
 
@@ -604,6 +622,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const requestTypeFilter = screen.getByRole("combobox", {
@@ -636,6 +655,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -717,6 +737,7 @@ describe("AclRequests", () => {
       customRender(<AclRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
@@ -101,6 +101,7 @@ describe("ConnectorRequests", () => {
     customRender(<ConnectorRequests />, {
       queryClient: true,
       memoryRouter: true,
+      aquariumContext: true,
     });
     expect(getConnectorRequests).toBeCalledTimes(1);
   });
@@ -132,6 +133,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -148,6 +150,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -182,6 +185,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -201,6 +205,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -224,6 +229,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -244,6 +250,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -264,6 +271,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -289,6 +297,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -337,6 +346,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?search=",
       });
       expect(getConnectorRequests).toHaveBeenNthCalledWith(1, {
@@ -353,6 +363,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const search = screen.getByRole("search", {
@@ -386,6 +397,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?environment=TEST_ENV_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
@@ -439,6 +451,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?showOnlyMyRequests=true",
       });
       expect(getConnectorRequests).toHaveBeenNthCalledWith(1, {
@@ -455,6 +468,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
       const isMyRequestSwitch = screen.getByRole("checkbox", {
         name: "Show only my requests",
@@ -476,6 +490,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?showOnlyMyRequests=true",
       });
       const isMyRequestSwitch = screen.getByRole("checkbox", {
@@ -507,6 +522,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?status=TEST_STATUS_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
@@ -565,6 +581,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?requestType=DELETE",
       });
 
@@ -624,6 +641,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -787,6 +805,7 @@ describe("ConnectorRequests", () => {
       customRender(<ConnectorRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -80,6 +80,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -96,6 +97,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       const table = screen.queryByRole("table");
@@ -119,6 +121,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -203,6 +206,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -218,6 +222,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -237,6 +242,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -257,6 +263,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -277,6 +284,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -302,6 +310,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -346,6 +355,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?environment=TEST_ENV_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
@@ -398,6 +408,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?requestType=TEST_TYPE_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
@@ -445,6 +456,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?status=TEST_STATUS_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
@@ -492,6 +504,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?search=TEST_SEARCH_VALUE",
       });
 
@@ -537,6 +550,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?showOnlyMyRequests=true",
       });
 
@@ -582,6 +596,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -678,6 +693,7 @@ describe("SchemaRequest", () => {
       customRender(<SchemaRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -87,6 +87,7 @@ describe("TopicRequests", () => {
     customRender(<TopicRequests />, {
       queryClient: true,
       memoryRouter: true,
+      aquariumContext: true,
     });
     expect(getTopicRequests).toBeCalledTimes(1);
   });
@@ -101,6 +102,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?search=",
       });
       expect(getTopicRequests).toHaveBeenNthCalledWith(1, {
@@ -117,6 +119,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
       const search = screen.getByRole("search", { name: "Search Topic" });
       expect(search).toBeVisible();
@@ -145,6 +148,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?showOnlyMyRequests=true",
       });
       expect(getTopicRequests).toHaveBeenNthCalledWith(1, {
@@ -161,6 +165,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
       const isMyRequestSwitch = screen.getByRole("checkbox", {
         name: "Show only my requests",
@@ -182,6 +187,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?showOnlyMyRequests=true",
       });
       const isMyRequestSwitch = screen.getByRole("checkbox", {
@@ -222,6 +228,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: routePath,
       });
 
@@ -241,6 +248,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -264,6 +272,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -284,6 +293,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -304,6 +314,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -329,6 +340,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -376,6 +388,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?environment=TEST_ENV_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
@@ -429,6 +442,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath:
           "/?status=TEST_STATUS_THAT_CANNOT_BE_PART_OF_ANY_API_MOCK",
       });
@@ -484,6 +498,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -573,6 +588,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
       });
 
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
@@ -735,6 +751,7 @@ describe("TopicRequests", () => {
       customRender(<TopicRequests />, {
         queryClient: true,
         memoryRouter: true,
+        aquariumContext: true,
         customRoutePath: "/?requestType=DELETE",
       });
 

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -95,7 +95,7 @@ describe("BrowseTopics.tsx", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-team-loading")
+        screen.getAllByTestId("async-select-loading")
       );
     });
 
@@ -291,7 +291,7 @@ describe("BrowseTopics.tsx", () => {
       });
 
       await waitForElementToBeRemoved(
-        screen.getByTestId("select-team-loading")
+        screen.getAllByTestId("async-select-loading")
       );
     });
 

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -89,7 +89,11 @@ describe("BrowseTopics.tsx", () => {
       mockGetEnvironments.mockResolvedValue(mockGetEnvironmentResponse);
       mockGetTopics.mockResolvedValue(mockedGetTopicsResponseSinglePage);
 
-      customRender(<BrowseTopics />, { memoryRouter: true, queryClient: true });
+      customRender(<BrowseTopics />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
       await waitForElementToBeRemoved(
         screen.getByTestId("select-team-loading")
       );
@@ -150,7 +154,11 @@ describe("BrowseTopics.tsx", () => {
       mockGetEnvironments.mockResolvedValue([]);
       mockGetTopics.mockResolvedValue(mockedGetTopicsResponseMultiplePages);
 
-      customRender(<BrowseTopics />, { memoryRouter: true, queryClient: true });
+      customRender(<BrowseTopics />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -174,7 +182,11 @@ describe("BrowseTopics.tsx", () => {
       mockGetEnvironments.mockResolvedValue([]);
       mockGetTopics.mockResolvedValue(mockedGetTopicsResponseMultiplePages);
 
-      customRender(<BrowseTopics />, { memoryRouter: true, queryClient: true });
+      customRender(<BrowseTopics />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -213,7 +225,11 @@ describe("BrowseTopics.tsx", () => {
       mockGetEnvironments.mockResolvedValue(mockGetEnvironmentResponse);
       mockGetTopics.mockResolvedValue(mockedResponseTransformed);
 
-      customRender(<BrowseTopics />, { memoryRouter: true, queryClient: true });
+      customRender(<BrowseTopics />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 
@@ -268,7 +284,11 @@ describe("BrowseTopics.tsx", () => {
       mockGetEnvironments.mockResolvedValue([]);
       mockGetTopics.mockResolvedValue(mockedResponseTransformed);
 
-      customRender(<BrowseTopics />, { memoryRouter: true, queryClient: true });
+      customRender(<BrowseTopics />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
 
       await waitForElementToBeRemoved(
         screen.getByTestId("select-team-loading")
@@ -328,7 +348,11 @@ describe("BrowseTopics.tsx", () => {
       mockGetTeams.mockResolvedValue([]);
       mockGetEnvironments.mockResolvedValue([]);
       mockGetTopics.mockResolvedValue(mockedResponseTransformed);
-      customRender(<BrowseTopics />, { memoryRouter: true, queryClient: true });
+      customRender(<BrowseTopics />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -246,7 +246,7 @@ describe("TopicSubscriptions.tsx", () => {
       queryClient: true,
       aquariumContext: true,
     });
-    await waitForElementToBeRemoved(screen.getByTestId("select-team-loading"));
+    await waitForElementToBeRemoved(screen.getByTestId("async-select-loading"));
   });
 
   afterEach(() => {

--- a/coral/src/app/pages/requests/acls/index.test.tsx
+++ b/coral/src/app/pages/requests/acls/index.test.tsx
@@ -27,6 +27,7 @@ describe("AclRequestsPage", () => {
 
     customRender(<AclRequestsPage />, {
       queryClient: true,
+      aquariumContext: true,
       memoryRouter: true,
     });
     await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/pages/requests/connectors/index.test.tsx
+++ b/coral/src/app/pages/requests/connectors/index.test.tsx
@@ -32,6 +32,7 @@ describe("ConnectorRequestsPage", () => {
     customRender(<ConnectorRequestsPage />, {
       queryClient: true,
       memoryRouter: true,
+      aquariumContext: true,
     });
     await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
   });

--- a/coral/src/app/pages/requests/schemas/index.test.tsx
+++ b/coral/src/app/pages/requests/schemas/index.test.tsx
@@ -27,6 +27,7 @@ describe("SchemaRequestPage", () => {
 
     customRender(<SchemaRequestsPage />, {
       queryClient: true,
+      aquariumContext: true,
       memoryRouter: true,
     });
     await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));

--- a/coral/src/app/pages/requests/topics/index.test.tsx
+++ b/coral/src/app/pages/requests/topics/index.test.tsx
@@ -28,6 +28,7 @@ describe("TopicRequestsPage", () => {
     customRender(<TopicRequestsPage />, {
       queryClient: true,
       memoryRouter: true,
+      aquariumContext: true,
     });
     await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
   });

--- a/coral/src/app/pages/topics/index.test.tsx
+++ b/coral/src/app/pages/topics/index.test.tsx
@@ -45,7 +45,11 @@ describe("Topics", () => {
       mockGetEnvironments.mockResolvedValue([]);
       mockGetTopics.mockResolvedValue(mockGetTopicsResponse);
 
-      customRender(<Topics />, { memoryRouter: true, queryClient: true });
+      customRender(<Topics />, {
+        memoryRouter: true,
+        queryClient: true,
+        aquariumContext: true,
+      });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
     });
 


### PR DESCRIPTION
# Linked issue

⚠️ This PR had 2 commits from PR  https://github.com/Aiven-Open/klaw/pull/2143 cherry-picked, so that one would need to be merged first! 


Resolves: #1084 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

When the shared Environment or Team filter is used, there is no error handling. In case there is an error in the backend for those endpoints, the filter stays in Loading state and shows no information whatsoever. 

# What is the new behavior?

An error in one of the used endpoints will show up as toast and the filter element will have an error information, too:

<img width="1110" alt="Screenshot 2023-12-29 at 10 19 12" src="https://github.com/Aiven-Open/klaw/assets/943800/e9d4f5ca-75d2-4083-8c74-839bf87e9e65">

<img width="1075" alt="filter-error-state" src="https://github.com/Aiven-Open/klaw/assets/943800/79fccc06-1c9b-4c1d-a487-57ff1b43dbee">


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
