### PR TITLE
fix(coral): Use disabled instead of false for the value of the Switch teams column in Users page

### DIFF
--- a/coral/src/app/features/configuration/users/components/UsersTable.test.tsx
+++ b/coral/src/app/features/configuration/users/components/UsersTable.test.tsx
@@ -144,7 +144,7 @@ describe("UsersTable.tsx", () => {
 
         const positionOfSwitchTeamRow = tableRowHeader.indexOf("Switch teams");
         expect(cell[positionOfSwitchTeamRow]).toHaveTextContent(
-          user.switchTeams ? "enabled" : "false"
+          user.switchTeams ? "Enabled" : "Disabled"
         );
       });
 

--- a/coral/src/app/features/configuration/users/components/UsersTable.tsx
+++ b/coral/src/app/features/configuration/users/components/UsersTable.tsx
@@ -53,7 +53,7 @@ const UsersTable = ({ users, ariaLabel }: UsersProps) => {
       headerName: "Switch teams",
       status: ({ switchTeams }) => ({
         status: switchTeams ? "success" : "neutral",
-        text: switchTeams ? "enabled" : "false",
+        text: switchTeams ? "Enabled" : "Disabled",
       }),
     },
     {


### PR DESCRIPTION
fix: Fix values in Switch teams column (Users page)

# Linked issue

Resolves: #2157 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The Switch teams column in Users page can have two values: enabled and false.

![image](https://github.com/Aiven-Open/klaw/assets/15722914/3c8c235c-1be0-4d24-9663-12073e6e150a)

# What is the new behavior?

The values now can only be Enabled and Disabled

![Screenshot 2024-01-05 165013](https://github.com/Aiven-Open/klaw/assets/15722914/989786ae-c229-4498-b5ba-794a566844f2)


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
