### PR TITLE
refactor(coral): Add native select wrapper to handle  async option data

### DIFF
--- a/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
@@ -121,6 +121,15 @@ describe("AsyncNativeSelectWrapper", () => {
       expect(select).toBeDisabled();
     });
 
+    it("shows the label text given to the child NativeSelect", () => {
+      const labelElement = screen.getByLabelText(
+        testNativeSelect.props.labelText
+      );
+      const select = screen.getByRole("combobox");
+
+      expect(select).toBe(labelElement);
+    });
+
     it("marks the select element as invalid", () => {
       const select = screen.getByRole("combobox", { name: "No test-select" });
 

--- a/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
@@ -1,0 +1,175 @@
+import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
+import { NativeSelect, Option, Typography } from "@aivenio/aquarium";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { AsyncNativeSelectWrapper } from "src/app/components/AsyncNativeSelectWrapper";
+import { KlawApiError } from "src/services/api";
+const mockedUseToast = jest.fn();
+jest.mock("@aivenio/aquarium", () => ({
+  ...jest.requireActual("@aivenio/aquarium"),
+  useToast: () => mockedUseToast,
+}));
+
+const testSelectLabel = "My test select";
+const testNativeSelect = (
+  <NativeSelect labelText={testSelectLabel}>
+    <Option>Option one</Option>
+    <Option>Option two</Option>
+  </NativeSelect>
+);
+
+const testProps = {
+  entity: "test-select",
+  isLoading: false,
+  isError: false,
+  error: "",
+};
+
+describe("AsyncNativeSelectWrapper", () => {
+  beforeAll(mockIntersectionObserver);
+
+  describe("only accepts a <NativeSelect> from design-system as child", () => {
+    const originalConsoleError = console.error;
+    beforeEach(() => {
+      console.error = jest.fn();
+    });
+
+    afterEach(() => {
+      console.error = originalConsoleError;
+      cleanup();
+    });
+
+    it("throws an error when child element is a html element", () => {
+      expect(() =>
+        render(
+          <AsyncNativeSelectWrapper {...testProps}>
+            <p>not correct</p>
+          </AsyncNativeSelectWrapper>
+        )
+      ).toThrow(
+        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` as a child."
+      );
+    });
+
+    it("throws an error when child element is a different DS component", () => {
+      expect(() =>
+        render(
+          <AsyncNativeSelectWrapper {...testProps}>
+            <Typography>not correct</Typography>
+          </AsyncNativeSelectWrapper>
+        )
+      ).toThrow(
+        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` as a child."
+      );
+    });
+
+    it("does not throw an error when child element is a DS NativeSelect", () => {
+      expect(() =>
+        render(
+          <AsyncNativeSelectWrapper {...testProps}>
+            {testNativeSelect}
+          </AsyncNativeSelectWrapper>
+        )
+      ).not.toThrow();
+    });
+  });
+
+  describe("shows a select element in loading state", () => {
+    beforeAll(() => {
+      render(
+        <AsyncNativeSelectWrapper {...testProps} isLoading={true}>
+          {testNativeSelect}
+        </AsyncNativeSelectWrapper>
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("shows a loading information and animation", () => {
+      const loadingInfo = screen.getByTestId("async-select-loading");
+      expect(loadingInfo).toBeVisible();
+    });
+
+    it("does not render the select element", () => {
+      const select = screen.queryByRole("combobox", { name: testSelectLabel });
+      expect(select).not.toBeInTheDocument();
+    });
+  });
+
+  describe("handles errors when loading of content went wrong", () => {
+    const testError: KlawApiError = {
+      success: false,
+      message: "Oh nooooo",
+    };
+
+    beforeAll(() => {
+      render(
+        <AsyncNativeSelectWrapper
+          {...testProps}
+          isError={true}
+          error={testError}
+        >
+          {testNativeSelect}
+        </AsyncNativeSelectWrapper>
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("renders a disabled select element with information about missing data", () => {
+      const select = screen.getByRole("combobox", { name: "No test-select" });
+
+      expect(select).toBeDisabled();
+    });
+
+    it("marks the select element as invalid", () => {
+      const select = screen.getByRole("combobox", { name: "No test-select" });
+
+      expect(select).toBeInvalid();
+    });
+
+    it("shows an error information beneath the select element", () => {
+      const errorText = screen.getByText("test-select could not be loaded.");
+      expect(errorText).toBeVisible();
+    });
+
+    it("notifies user about the error", () => {
+      expect(mockedUseToast).toHaveBeenCalledWith({
+        message: "Error loading test-select: Oh nooooo",
+        position: "bottom-left",
+        variant: "default",
+      });
+    });
+  });
+
+  describe("shows the correct select element when content is loaded successfully", () => {
+    beforeAll(() => {
+      render(
+        <AsyncNativeSelectWrapper {...testProps}>
+          {testNativeSelect}
+        </AsyncNativeSelectWrapper>
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("renders the given select element", () => {
+      const select = screen.getByRole("combobox", { name: testSelectLabel });
+      expect(select).toBeEnabled();
+    });
+
+    it("renders the given select element", () => {
+      const select = screen.getByRole("combobox", { name: testSelectLabel });
+      expect(select).toBeEnabled();
+      expect(select).toBeValid();
+    });
+
+    it("renders the correct children of the select element", () => {
+      const select = screen.getByRole("combobox", { name: testSelectLabel });
+      const options = within(select).getAllByRole("option");
+
+      expect(options).toHaveLength(2);
+      expect(options[0]).toHaveValue("Option one");
+      expect(options[1]).toHaveValue("Option two");
+    });
+  });
+});

--- a/coral/src/app/components/AsyncNativeSelectWrapper.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.tsx
@@ -60,7 +60,7 @@ function AsyncNativeSelectWrapper(props: AsyncNativeSelectWrapperProps) {
       <NativeSelect
         valid={false}
         disabled={true}
-        labelText={`Filter by ${entity}`}
+        labelText={children.props.labelText}
         aria-label={`No ${entity}`}
         placeholder={`No ${entity}`}
         helperText={`${entity} could not be loaded.`}

--- a/coral/src/app/components/AsyncNativeSelectWrapper.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.tsx
@@ -1,0 +1,82 @@
+import { NativeSelect, NativeSelectProps, useToast } from "@aivenio/aquarium";
+import { isValidElement, ReactElement, ReactNode, useEffect } from "react";
+import { parseErrorMsg } from "src/services/mutation-utils";
+
+function isNativeSelectComponent(
+  child: ReactNode
+): child is ReactElement<NativeSelectProps> {
+  return (
+    isValidElement(child) &&
+    /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
+    (child.type as any)?.render?.displayName === NativeSelect.displayName
+  );
+}
+
+type AsyncNativeSelectWrapperProps = {
+  /**
+   * `entity` is the entity which user filters by, e.g. "Team" or "Topic"
+   * It is used in e.g. placeholder and toast notification for error cases,
+   * like "Error loading <ENTITY>"
+   */
+  entity: string;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  children: ReactElement<NativeSelectProps>;
+};
+
+/** <AsyncNativeSelectWrapper> handles loading
+ * and error states for a <NativeSelect> that uses
+ * data that is fetched async (e.g. from API)
+ * only takes one <NativeSelect /> as a child.
+ */
+function AsyncNativeSelectWrapper(props: AsyncNativeSelectWrapperProps) {
+  const { entity, isLoading, isError, error, children } = props;
+
+  const toast = useToast();
+
+  // Type-guard to make sure we're only passing
+  // <NativeSelect> as a child component
+  useEffect(() => {
+    if (!isNativeSelectComponent(children)) {
+      throw new Error(
+        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` as a child."
+      );
+    }
+  }, [children]);
+
+  useEffect(() => {
+    if (isError) {
+      toast({
+        message: `Error loading ${entity}: ${parseErrorMsg(error)}`,
+        position: "bottom-left",
+        variant: "default",
+      });
+    }
+  }, [isError]);
+
+  if (isError) {
+    return (
+      <NativeSelect
+        valid={false}
+        disabled={true}
+        labelText={`Filter by ${entity}`}
+        aria-label={`No ${entity}`}
+        placeholder={`No ${entity}`}
+        helperText={`${entity} could not be loaded.`}
+      />
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div data-testid={"async-select-loading"}>
+        <NativeSelect.Skeleton />
+      </div>
+    );
+  }
+
+  return children;
+}
+
+export { AsyncNativeSelectWrapper };


### PR DESCRIPTION
# Linked issue

Resolves: #xxxxx

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# Description

This PR introduces `AsyncNativeSelectWrapper`. The component can be used whenever we need a `NativeSelect` where options are based on data fetched from an API. 

`AsyncNativeSelectWrapper` then handles showing the correct loading state as well as showing an error state and notifying the user about errors.

## Screenshots

all three states - screenshots are a bit static 😅  I'll use the new component in https://github.com/Aiven-Open/klaw/pull/2144 when it's merged.

<img width="906" alt="Screenshot 2024-01-09 at 16 08 59" src="https://github.com/Aiven-Open/klaw/assets/943800/1edd0296-0283-464f-960a-c17158e833ae">

<img width="917" alt="Screenshot 2024-01-09 at 16 09 45" src="https://github.com/Aiven-Open/klaw/assets/943800/cc9571c6-66dd-49b4-9860-41a43da4b5d0">

<img width="927" alt="Screenshot 2024-01-09 at 16 09 23" src="https://github.com/Aiven-Open/klaw/assets/943800/b16927d1-3bf1-4ce9-b5bc-8c6a38ca5124">



# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
