### PR TITLE
Enable windows coral build 

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -15,8 +15,8 @@ CORAL_DIST = $(CORAL_ROOT)/dist
 CORAL_ROOT_WIN = ..\coral
 CORAL_DIST_WIN = $(CORAL_ROOT_WIN)\dist
 
-CORAL_ROOT_WIN = ..\coral
-CORAL_DIST_WIN = $(CORAL_ROOT)\dist
+CORAL_ASSETS_OUTPUT_WIN = .\src\main\resources\static\assets\coral
+CORAL_INDEX_OUTPUT_WIN = .\src\main\resources\templates\coral
 
 # Make sure pnpm is pre installed
 PNPM = pnpm
@@ -25,7 +25,9 @@ VERSION = $(shell $(PNPM) -v)
 WIN: ..\coral\index.html $(shell cd $(CORAL_ROOT_WIN)/src && dir /s /b /o:gn)
 	@echo "Windows Coral Build"
 	cd $(CORAL_ROOT_WIN) && $(PNPM) install --frozen-lockfile
-	cd $(CORAL_ROOT_WIN) && $(PNPM) build --assetsDir assets\coral --mode springboot
+	cd $(CORAL_ROOT_WIN) && $(PNPM) build --assetsDir assets/coral --mode springboot
+	xcopy $(CORAL_DIST_WIN)\index.html $(CORAL_INDEX_OUTPUT_WIN)
+	xcopy $(CORAL_DIST_WIN)\assets\coral\* $(CORAL_ASSETS_OUTPUT_WIN)
 
 UNIX: ../coral/index.html $(shell find $(CORAL_ROOT)/src)
 	@echo "Linux Coral Build"

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,9 +1,33 @@
+ifeq ($(OS),Windows_NT)
+    unix_shell := $(shell sh -c uname -s 2>NUL || echo 'false')
+    # If unix shell is 'false' that means uname doesn't exist and so is not a unix shell
+    ifeq ($(unix_shell), 'false')
+      all: WIN
+    else
+      all: UNIX
+    endif
+else
+    all: UNIX
+endif
+
 CORAL_ROOT = ../coral
 CORAL_DIST = $(CORAL_ROOT)/dist
+CORAL_ROOT_WIN = ..\coral
+CORAL_DIST_WIN = $(CORAL_ROOT_WIN)\dist
+
+CORAL_ROOT_WIN = ..\coral
+CORAL_DIST_WIN = $(CORAL_ROOT)\dist
 
 # Make sure pnpm is pre installed
 PNPM = pnpm
+VERSION = $(shell $(PNPM) -v)
+    # is Windows_NT on XP, 2000, 7, Vista, 10...
+WIN: ..\coral\index.html $(shell cd $(CORAL_ROOT_WIN)/src && dir /s /b /o:gn)
+	@echo "Windows Coral Build"
+	cd $(CORAL_ROOT_WIN) && $(PNPM) install --frozen-lockfile
+	cd $(CORAL_ROOT_WIN) && $(PNPM) build --assetsDir assets\coral --mode springboot
 
-$(CORAL_DIST): ../coral/index.html $(shell find $(CORAL_ROOT)/src)
+UNIX: ../coral/index.html $(shell find $(CORAL_ROOT)/src)
+	@echo "Linux Coral Build"
 	cd $(CORAL_ROOT); $(PNPM) install --frozen-lockfile
 	cd $(CORAL_ROOT); $(PNPM) build --assetsDir assets/coral --mode springboot


### PR DESCRIPTION
Enable windows coral build and also continue support for tools like cygwin on windows.



# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Currently the make file in core builds coral, however it uses unix commands to do so which do not translate to windows machines preventing windws build users from being able to avail f the coral UI.
# What is the new behavior?

Now the make file detects if it is a windows OS and if it is , it does a further check to see if it is a unix like shell if not it executes specific dos and powershell compatible command.

In all other cases it will run the existing UNIX commands.

# Other information

N/A

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
