### PR TITLE
Add Tenant level topics count, null constraints

### DIFF
--- a/coral/src/domain/requests/requests-transformers.test.ts
+++ b/coral/src/domain/requests/requests-transformers.test.ts
@@ -23,16 +23,6 @@ const mockedRequestsWaitingForApprovalMissingAcl: RequestsWaitingForApprovalWith
     TOTAL_NOTIFICATIONS: 8,
   };
 
-const defaultRecord = {
-  TOPIC: 0,
-  ACL: 0,
-  SCHEMA: 0,
-  CONNECTOR: 0,
-  USER: 0,
-  OPERATIONAL: 0,
-  TOTAL_NOTIFICATIONS: 0,
-};
-
 const mockApiResponse: KlawApiResponse<"getRequestStatistics"> = {
   requestEntityStatistics: [
     {
@@ -379,14 +369,6 @@ describe("request-transformers.ts", () => {
         getRequestsWaitingForApprovalTransformer(mockApiResponse);
 
       expect(response).toEqual(mockedRequestsWaitingForApproval);
-    });
-
-    it("should return record with default data if API response is undefined", () => {
-      const response = getRequestsWaitingForApprovalTransformer({
-        requestEntityStatistics: undefined,
-      });
-
-      expect(response).toEqual(defaultRecord);
     });
 
     it("should return record with default data for single entity type if API response misses that data", () => {

--- a/coral/src/domain/requests/requests-transformers.ts
+++ b/coral/src/domain/requests/requests-transformers.ts
@@ -16,19 +16,8 @@ const getRequestsWaitingForApprovalTransformer = (
     TOTAL_NOTIFICATIONS: 0,
   };
 
-  if (requestEntityStatistics === undefined) {
-    return requestsWaitingForApproval;
-  }
-
   requestEntityStatistics.forEach((statistics) => {
     const { requestEntityType, requestStatusCountSet } = statistics;
-
-    if (
-      requestEntityType === undefined ||
-      requestStatusCountSet === undefined
-    ) {
-      return;
-    }
 
     const amountOfRequestsForEntity =
       requestStatusCountSet.find(

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -1161,18 +1161,18 @@ export type components = {
     };
     RequestEntityStatusCount: {
       /** @enum {string} */
-      requestEntityType?: "TOPIC" | "ACL" | "SCHEMA" | "CONNECTOR" | "OPERATIONAL" | "USER";
-      requestStatusCountSet?: components["schemas"]["RequestStatusCount"][];
-      requestsOperationTypeCountSet?: components["schemas"]["RequestsOperationTypeCount"][];
+      requestEntityType: "TOPIC" | "ACL" | "SCHEMA" | "CONNECTOR" | "OPERATIONAL" | "USER";
+      requestStatusCountSet: components["schemas"]["RequestStatusCount"][];
+      requestsOperationTypeCountSet: components["schemas"]["RequestsOperationTypeCount"][];
     };
     RequestStatusCount: {
       /** @enum {string} */
-      requestStatus?: "CREATED" | "DELETED" | "DECLINED" | "APPROVED" | "ALL";
+      requestStatus: "CREATED" | "DELETED" | "DECLINED" | "APPROVED" | "ALL";
       /** Format: int64 */
-      count?: number;
+      count: number;
     };
     RequestsCountOverview: {
-      requestEntityStatistics?: components["schemas"]["RequestEntityStatusCount"][];
+      requestEntityStatistics: components["schemas"]["RequestEntityStatusCount"][];
     };
     RequestsOperationTypeCount: {
       /** @enum {string} */
@@ -1744,6 +1744,7 @@ export type components = {
       adAuthRoleEnabled: string;
       supportlink: string;
       myteamtopics: string;
+      myOrgTopics: string;
       googleFeedbackFormLink: string;
     };
     KwPropertiesResponse: {

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -3167,8 +3167,8 @@ export type operations = {
       };
     };
     responses: {
-      /** @description default response */
-      default: {
+      /** @description OK */
+      200: {
         content: {
           "application/json": components["schemas"]["RequestsCountOverview"];
         };

--- a/core/src/main/java/io/aiven/klaw/controller/UtilController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UtilController.java
@@ -95,6 +95,8 @@ public class UtilController {
       summary = "Get counts of all request entity types for different status,operation types",
       responses = {
         @ApiResponse(
+            description = "OK",
+            responseCode = "200",
             content = @Content(schema = @Schema(implementation = RequestsCountOverview.class)))
       })
   @RequestMapping(

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -1031,7 +1031,9 @@ public class SelectDataJdbc {
     log.debug("getDashboardInfo {}", teamId);
     Map<String, String> dashboardInfo = new HashMap<>();
     Integer topicListSize = topicRepo.findDistinctCountTopicnameByTeamId(teamId, tenantId);
+    int topicListSizeForOrg = topicRepo.countByTenantId(tenantId);
     dashboardInfo.put("myteamtopics", "" + topicListSize);
+    dashboardInfo.put("myOrgTopics", "" + topicListSizeForOrg);
 
     return dashboardInfo;
   }

--- a/core/src/main/java/io/aiven/klaw/model/response/AuthenticationInfo.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/AuthenticationInfo.java
@@ -59,5 +59,6 @@ public class AuthenticationInfo {
   @NotNull private String adAuthRoleEnabled;
   @NotNull private String supportlink;
   @NotNull private String myteamtopics;
+  @NotNull private String myOrgTopics;
   @NotNull private String googleFeedbackFormLink;
 }

--- a/core/src/main/java/io/aiven/klaw/model/response/RequestEntityStatusCount.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/RequestEntityStatusCount.java
@@ -1,12 +1,16 @@
 package io.aiven.klaw.model.response;
 
 import io.aiven.klaw.model.enums.RequestEntityType;
+import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import lombok.Data;
 
 @Data
 public class RequestEntityStatusCount {
-  RequestEntityType requestEntityType; // TOPIC,ACL,SCHEMA,CONNECTOR
-  Set<RequestStatusCount> requestStatusCountSet; // created/approved/deleted/declined
+  @NotNull RequestEntityType requestEntityType; // TOPIC,ACL,SCHEMA,CONNECTOR
+
+  @NotNull Set<RequestStatusCount> requestStatusCountSet; // created/approved/deleted/declined
+
+  @NotNull
   Set<RequestsOperationTypeCount> requestsOperationTypeCountSet; // Create/Delete/Update/Claim
 }

--- a/core/src/main/java/io/aiven/klaw/model/response/RequestStatusCount.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/RequestStatusCount.java
@@ -1,12 +1,14 @@
 package io.aiven.klaw.model.response;
 
 import io.aiven.klaw.model.enums.RequestStatus;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
 public class RequestStatusCount {
-  RequestStatus requestStatus; // CREATED,DELETED,APPROVED,DECLINED
-  long count;
+  @NotNull RequestStatus requestStatus; // CREATED,DELETED,APPROVED,DECLINED
+
+  @NotNull long count;
 }

--- a/core/src/main/java/io/aiven/klaw/model/response/RequestsCountOverview.java
+++ b/core/src/main/java/io/aiven/klaw/model/response/RequestsCountOverview.java
@@ -1,9 +1,10 @@
 package io.aiven.klaw.model.response;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import lombok.Data;
 
 @Data
 public class RequestsCountOverview {
-  Set<RequestEntityStatusCount> requestEntityStatistics;
+  @NotNull Set<RequestEntityStatusCount> requestEntityStatistics;
 }

--- a/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/TopicRepo.java
@@ -38,6 +38,8 @@ public interface TopicRepo extends CrudRepository<Topic, TopicID> {
       nativeQuery = true)
   List<Object[]> findAllTopicsGroupByTeamId(@Param("tenantId") Integer tenantId);
 
+  int countByTenantId(int tenantId);
+
   @Query(value = "select count(*) from kwtopics", nativeQuery = true)
   int findAllTopicsCount();
 

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -313,6 +313,7 @@ public class UtilControllerService implements InitializingBean {
       Map<String, String> teamTopics =
           reqsHandle.getDashboardInfo(commonUtilsService.getTeamId(userName), tenantId);
       authenticationInfo.setMyteamtopics(teamTopics.get("myteamtopics"));
+      authenticationInfo.setMyOrgTopics(teamTopics.get("myOrgTopics"));
       authenticationInfo.setContextPath(kwContextPath);
       authenticationInfo.setTeamsize("" + manageDatabase.getTeamsForTenant(tenantId).size());
       authenticationInfo.setSchema_clusters_count(

--- a/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicIntegrationTest.java
+++ b/core/src/test/java/io/aiven/klaw/helpers/db/rdbms/TopicIntegrationTest.java
@@ -217,8 +217,8 @@ public class TopicIntegrationTest {
     Map<String, String> res1 = selectDataJdbc.getDashboardInfo(101, 101);
     Map<String, String> res2 = selectDataJdbc.getDashboardInfo(103, 103);
 
-    assertThat(res1.size()).isEqualTo(1);
-    assertThat(res2.size()).isEqualTo(1);
+    assertThat(res1.size()).isEqualTo(2); // team topics and tenant topics
+    assertThat(res2.size()).isEqualTo(2); // team topics and tenant topics
   }
 
   @Test

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7708,7 +7708,8 @@
             },
             "uniqueItems" : true
           }
-        }
+        },
+        "required" : [ "requestEntityType", "requestStatusCountSet", "requestsOperationTypeCountSet" ]
       },
       "RequestStatusCount" : {
         "properties" : {
@@ -7720,7 +7721,8 @@
             "type" : "integer",
             "format" : "int64"
           }
-        }
+        },
+        "required" : [ "count", "requestStatus" ]
       },
       "RequestsCountOverview" : {
         "properties" : {
@@ -7731,7 +7733,8 @@
             },
             "uniqueItems" : true
           }
-        }
+        },
+        "required" : [ "requestEntityStatistics" ]
       },
       "RequestsOperationTypeCount" : {
         "properties" : {
@@ -9355,11 +9358,14 @@
           "myteamtopics" : {
             "type" : "string"
           },
+          "myOrgTopics" : {
+            "type" : "string"
+          },
           "googleFeedbackFormLink" : {
             "type" : "string"
           }
         },
-        "required" : [ "adAuthRoleEnabled", "addDeleteEditClusters", "addDeleteEditEnvs", "addEditRoles", "addTeams", "addUser", "approveAtleastOneRequest", "approveDeclineConnectors", "approveDeclineOperationalReqs", "approveDeclineSchemas", "approveDeclineSubscriptions", "approveDeclineTopics", "authenticationType", "broadcastText", "canShutdownKw", "canSwitchTeams", "canUpdatePermissions", "companyinfo", "contextPath", "coralAvailableForUser", "coralEnabled", "googleFeedbackFormLink", "kafka_clusters_count", "kafkaconnect_clusters_count", "klawversion", "manageConnectors", "myteamtopics", "notifications", "notificationsAcls", "notificationsConnectors", "notificationsSchemas", "notificationsUsers", "pendingApprovalsRedirectionPage", "requestItems", "saasEnabled", "schema_clusters_count", "showAddDeleteTenants", "showServerConfigEnvProperties", "supportlink", "syncBackAcls", "syncBackSchemas", "syncBackTopics", "syncConnectors", "syncSchemas", "syncTopicsAcls", "teamId", "teamname", "teamsize", "tenantActiveStatus", "tenantName", "updateServerConfig", "username", "userrole", "viewKafkaConnect", "viewTopics" ]
+        "required" : [ "adAuthRoleEnabled", "addDeleteEditClusters", "addDeleteEditEnvs", "addEditRoles", "addTeams", "addUser", "approveAtleastOneRequest", "approveDeclineConnectors", "approveDeclineOperationalReqs", "approveDeclineSchemas", "approveDeclineSubscriptions", "approveDeclineTopics", "authenticationType", "broadcastText", "canShutdownKw", "canSwitchTeams", "canUpdatePermissions", "companyinfo", "contextPath", "coralAvailableForUser", "coralEnabled", "googleFeedbackFormLink", "kafka_clusters_count", "kafkaconnect_clusters_count", "klawversion", "manageConnectors", "myOrgTopics", "myteamtopics", "notifications", "notificationsAcls", "notificationsConnectors", "notificationsSchemas", "notificationsUsers", "pendingApprovalsRedirectionPage", "requestItems", "saasEnabled", "schema_clusters_count", "showAddDeleteTenants", "showServerConfigEnvProperties", "supportlink", "syncBackAcls", "syncBackSchemas", "syncBackTopics", "syncConnectors", "syncSchemas", "syncTopicsAcls", "teamId", "teamname", "teamsize", "tenantActiveStatus", "tenantName", "updateServerConfig", "username", "userrole", "viewKafkaConnect", "viewTopics" ]
       },
       "KwPropertiesResponse" : {
         "properties" : {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2540,8 +2540,8 @@
           }
         } ],
         "responses" : {
-          "default" : {
-            "description" : "default response",
+          "200" : {
+            "description" : "OK",
             "content" : {
               "application/json" : {
                 "schema" : {


### PR DESCRIPTION
# Linked issue

Resolves: #2173 

# What kind of change does this PR introduce?

- Updates getAuth endpoint to fetch topics count at tenant level
- Adds notnull constraints to /topics/statistics endpoint

- [ ] Bug fix
- [ ] New feature
- [ X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._
Topics count at tenant level doesn't exist

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._
Adding topics count at tenant level in getAuth endpoint

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
