### PR TITLE
Add promotion persmission

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x8x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x8x0.java
@@ -1,0 +1,55 @@
+package io.aiven.klaw.dao.migration;
+
+import static io.aiven.klaw.helpers.KwConstants.KLAW_EXTRA_PERMISSION_TOPIC_PROMOTION_KEY;
+
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.KwProperties;
+import io.aiven.klaw.dao.UserInfo;
+import io.aiven.klaw.helpers.db.rdbms.InsertDataJdbc;
+import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@DataMigration(version = "2.8.0", order = 4)
+@Slf4j
+@Configuration // Spring will automatically scan and instantiate this class for retrieval.
+public class MigrateData2x8x0 {
+
+  @Autowired private InsertDataJdbc insertDataJdbc;
+  @Autowired private SelectDataJdbc selectDataJdbc;
+
+  @Autowired private ManageDatabase manageDatabase;
+
+  public MigrateData2x8x0() {}
+
+  @MigrationRunner()
+  public boolean migrate() {
+    log.info(
+        "Start to migrate 2.8.0 data. Add new server property klaw.extra.permission.topic.promote.");
+
+    List<UserInfo> allUserInfo = selectDataJdbc.selectAllUsersAllTenants();
+    Set<Integer> tenantIds =
+        allUserInfo.stream().map(UserInfo::getTenantId).collect(Collectors.toSet());
+
+    for (int tenantId : tenantIds) {
+      List<KwProperties> kwPropertiesList = selectDataJdbc.selectAllKwPropertiesPerTenant(tenantId);
+      KwProperties kwProperties38 =
+          new KwProperties(
+              KLAW_EXTRA_PERMISSION_TOPIC_PROMOTION_KEY,
+              tenantId,
+              "false",
+              "Need of an extra permission APPROVE_TOPICS_PROMOTION to promote topics");
+      kwPropertiesList.add(kwProperties38);
+
+      insertDataJdbc.insertDefaultKwProperties(List.of(kwProperties38));
+      manageDatabase.loadEnvMapForOneTenant(tenantId);
+      manageDatabase.loadKwPropsPerOneTenant(null, tenantId);
+    }
+
+    return true;
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -23,6 +23,9 @@ public class KwConstants {
   public static final String CLUSTER_CONN_URL_KEY = "klaw.clusterapi.url";
   public static final String EMAIL_NOTIFICATIONS_ENABLED_KEY = "klaw.mail.notifications.enable";
 
+  public static final String KLAW_EXTRA_PERMISSION_TOPIC_PROMOTION_KEY =
+      "klaw.extra.permission.topic.promote";
+
   public static final String USER_ROLE = "USER";
 
   public static final String REQUESTOR_SUBSCRIPTIONS = "requestor_subscriptions";

--- a/core/src/main/java/io/aiven/klaw/model/enums/PermissionType.java
+++ b/core/src/main/java/io/aiven/klaw/model/enums/PermissionType.java
@@ -13,6 +13,7 @@ public enum PermissionType {
 
   REQUEST_CREATE_OPERATIONAL_CHANGES("To request for Operational changes"),
   APPROVE_TOPICS("To approve topics requests"),
+  APPROVE_TOPICS_PROMOTION("To approve topic promotion requests"),
   APPROVE_SUBSCRIPTIONS("To approve producer or consumer subscriptions"),
   APPROVE_SCHEMAS("To approve schemas"),
   APPROVE_CONNECTORS("To approve kafka connectors"),

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -1,5 +1,7 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.helpers.KwConstants.KLAW_EXTRA_PERMISSION_TOPIC_PROMOTION_KEY;
+
 import io.aiven.klaw.dao.*;
 import io.aiven.klaw.helpers.KwConstants;
 import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
@@ -46,6 +48,8 @@ public class DefaultDataService {
 
   @Value("${klaw.clusterapi.url:http://localhost:9343}")
   private String clusterApiUrl;
+
+  private boolean extraPermissionForTopicsPromotion;
 
   public UserInfo getUser(
       int tenantId,
@@ -302,6 +306,14 @@ public class DefaultDataService {
             KwConstants.MAIL_TOPICUPDATEREQUEST_CONTENT,
             "Email notification body for a new Topic Update Request");
     kwPropertiesList.add(kwProperties37);
+
+    KwProperties kwProperties38 =
+        new KwProperties(
+            KLAW_EXTRA_PERMISSION_TOPIC_PROMOTION_KEY,
+            tenantId,
+            "false",
+            "Need of an extra permission APPROVE_TOPICS_PROMOTION to promote topics");
+    kwPropertiesList.add(kwProperties38);
     return kwPropertiesList;
   }
 

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -17,6 +17,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_ERR_113;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_ERR_114;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_ERR_115;
 import static io.aiven.klaw.error.KlawErrorMessages.TOPICS_VLD_ERR_121;
+import static io.aiven.klaw.helpers.KwConstants.KLAW_EXTRA_PERMISSION_TOPIC_PROMOTION_KEY;
 import static io.aiven.klaw.helpers.KwConstants.ORDER_OF_TOPIC_ENVS;
 import static io.aiven.klaw.helpers.UtilMethods.updateEnvStatus;
 import static io.aiven.klaw.model.enums.MailType.*;
@@ -707,6 +708,16 @@ public class TopicControllerService {
     String userName = getUserName();
     int tenantId = commonUtilsService.getTenantId(userName);
     TopicRequest topicRequest = getTopicRequestFromTopicId(Integer.parseInt(topicId), tenantId);
+
+    String needOfExtraPermissionForPromote =
+        manageDatabase.getKwPropertyValue(KLAW_EXTRA_PERMISSION_TOPIC_PROMOTION_KEY, tenantId);
+    if (topicRequest.getRequestOperationType().equals(RequestOperationType.PROMOTE.value)
+        && Boolean.parseBoolean(needOfExtraPermissionForPromote)) {
+      if (commonUtilsService.isNotAuthorizedUser(
+          getPrincipal(), PermissionType.APPROVE_TOPICS_PROMOTION)) {
+        return ApiResponse.NOT_AUTHORIZED;
+      }
+    }
 
     ApiResponse validationResponse = validateTopicRequest(topicRequest, userName);
     if (!validationResponse.isSuccess()) {

--- a/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
+++ b/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
@@ -125,7 +125,7 @@ class MigrationUtilityTest {
     Reflections reflections = new Reflections(PROD_PACKAGE_TO_SCAN);
     Set<Class<?>> classes = reflections.getTypesAnnotatedWith(DataMigration.class);
     // When adding a new package you will need to increment this by 1.
-    assertThat(classes.size()).isEqualTo(4);
+    assertThat(classes.size()).isEqualTo(5);
     Set<Integer> uniqueOrder = new HashSet<>();
     // Check Order Numbers are correctly assigned
     classes.forEach(


### PR DESCRIPTION
# Linked issue

Resolves: #2121 

# What kind of change does this PR introduce?

New permission when topics are promoted
- a config is added if new permission is required to promote topics
- a new permission is added and this should be manually assigned to role by users
- on topic promotion, apart from APPROVE_TOPICS, a check is added to look for permission APPROVE_TOPICS_PROMOTION if server config for extra permission is set to true. by default it is false.

- [ ] Bug fix
- [ ] New feature
- [ X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._
there is no extra permission to promote topics

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._
a new permission is added to check if the user has promote topics permission

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
