### PR TITLE
refactor: Use id instead of name for querying teams

### DIFF
--- a/coral/src/app/features/configuration/users/Users.test.tsx
+++ b/coral/src/app/features/configuration/users/Users.test.tsx
@@ -377,9 +377,10 @@ describe("Users.tsx", () => {
       await user.selectOptions(select, option);
 
       //first call on load
-      expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
+      expect(mockGetUsers).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        teamName: "NCC-1701-D",
+        searchUserParam: undefined,
+        teamId: undefined,
       });
     });
 
@@ -395,9 +396,10 @@ describe("Users.tsx", () => {
       await user.selectOptions(select, optionOne);
 
       //first call on load
-      expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
+      expect(mockGetUsers).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
-        teamName: "NCC-1701-D",
+        searchUserParam: undefined,
+        teamId: undefined,
       });
 
       const optionTwo = within(select).getByRole("option", {
@@ -407,8 +409,10 @@ describe("Users.tsx", () => {
       await user.selectOptions(select, optionTwo);
 
       //first call on load, second for the first filter
-      expect(mockGetUsers).toHaveBeenNthCalledWith(3, {
+      expect(mockGetUsers).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
+        searchUserParam: undefined,
+        teamId: undefined,
       });
     });
   });

--- a/coral/src/app/features/configuration/users/Users.test.tsx
+++ b/coral/src/app/features/configuration/users/Users.test.tsx
@@ -361,8 +361,8 @@ describe("Users.tsx", () => {
       // one option for "All teams"
       expect(options).toHaveLength(mockedTeams.length + 1);
       expect(options[0]).toHaveValue("ALL");
-      expect(options[1]).toHaveValue(mockedTeams[0].teamname);
-      expect(options[2]).toHaveValue(mockedTeams[1].teamname);
+      expect(options[1]).toHaveValue(mockedTeams[0].teamId.toString());
+      expect(options[2]).toHaveValue(mockedTeams[1].teamId.toString());
     });
 
     it("fetches new data when user filters by a team", async () => {
@@ -377,10 +377,10 @@ describe("Users.tsx", () => {
       await user.selectOptions(select, option);
 
       //first call on load
-      expect(mockGetUsers).toHaveBeenNthCalledWith(1, {
+      expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
         pageNo: "1",
         searchUserParam: undefined,
-        teamId: undefined,
+        teamId: mockedTeams[0].teamId,
       });
     });
 
@@ -396,10 +396,10 @@ describe("Users.tsx", () => {
       await user.selectOptions(select, optionOne);
 
       //first call on load
-      expect(mockGetUsers).toHaveBeenNthCalledWith(1, {
+      expect(mockGetUsers).toHaveBeenNthCalledWith(2, {
         pageNo: "1",
         searchUserParam: undefined,
-        teamId: undefined,
+        teamId: mockedTeams[0].teamId,
       });
 
       const optionTwo = within(select).getByRole("option", {
@@ -409,10 +409,8 @@ describe("Users.tsx", () => {
       await user.selectOptions(select, optionTwo);
 
       //first call on load, second for the first filter
-      expect(mockGetUsers).toHaveBeenNthCalledWith(1, {
+      expect(mockGetUsers).toHaveBeenNthCalledWith(3, {
         pageNo: "1",
-        searchUserParam: undefined,
-        teamId: undefined,
       });
     });
   });

--- a/coral/src/app/features/configuration/users/Users.tsx
+++ b/coral/src/app/features/configuration/users/Users.tsx
@@ -13,7 +13,7 @@ import { SearchFilter } from "src/app/features/components/filters/SearchFilter";
 
 function UsersWithoutFilterContext() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { teamName, search } = useFiltersContext();
+  const { teamId, search } = useFiltersContext();
 
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
@@ -24,11 +24,11 @@ function UsersWithoutFilterContext() {
     isLoading,
     isError,
     error,
-  } = useQuery(["getUserList", currentPage, teamName, search], {
+  } = useQuery(["getUserList", currentPage, teamId, search], {
     queryFn: () =>
       getUserList({
         pageNo: String(currentPage),
-        teamName: teamName === "ALL" ? undefined : teamName,
+        teamId: teamId === "ALL" ? undefined : Number(teamId),
         searchUserParam: search.length === 0 ? undefined : search,
       }),
     keepPreviousData: true,

--- a/coral/src/app/features/configuration/users/Users.tsx
+++ b/coral/src/app/features/configuration/users/Users.tsx
@@ -61,7 +61,7 @@ function UsersWithoutFilterContext() {
   return (
     <TableLayout
       filters={[
-        <TeamFilter useTeamName key={"team"} />,
+        <TeamFilter key={"team"} />,
         <SearchFilter
           key="search"
           label="Search username"

--- a/coral/src/domain/user/user-api.ts
+++ b/coral/src/domain/user/user-api.ts
@@ -14,7 +14,7 @@ async function getUserList(
 ): Promise<UserListApiResponse> {
   const queryParams = convertQueryValuesToString({
     ...params,
-    ...(params?.teamName && { teamName: params.teamName }),
+    ...(params?.teamId && { teamId: params.teamId }),
     ...(params?.searchUserParam && { searchUserParam: params.searchUserParam }),
   });
 

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -3100,7 +3100,7 @@ export type operations = {
   showUsers: {
     parameters: {
       query?: {
-        teamName?: string;
+        teamId?: number;
         pageNo?: string;
         searchUserParam?: string;
       };

--- a/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
@@ -212,11 +212,11 @@ public class UsersTeamsController {
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<List<UserInfoModelResponse>> showUsers(
-      @RequestParam(value = "teamName", defaultValue = "") String teamName,
+      @RequestParam(value = "teamId", defaultValue = "") Integer teamId,
       @RequestParam(value = "pageNo", defaultValue = "1") String pageNo,
       @RequestParam(value = "searchUserParam", defaultValue = "") String searchUserParam) {
     return new ResponseEntity<>(
-        usersTeamsControllerService.showUsers(teamName, searchUserParam, pageNo), HttpStatus.OK);
+        usersTeamsControllerService.showUsers(teamId, searchUserParam, pageNo), HttpStatus.OK);
   }
 
   @RequestMapping(

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -752,7 +752,7 @@ public class UsersTeamsControllerService {
   }
 
   public List<UserInfoModelResponse> showUsers(
-      String teamName, String userSearchStr, String pageNo) {
+      Integer teamId, String userSearchStr, String pageNo) {
 
     List<UserInfoModelResponse> userInfoModels = new ArrayList<>();
     int tenantId = commonUtilsService.getTenantId(getUserName());
@@ -770,10 +770,8 @@ public class UsersTeamsControllerService {
           UserInfoModelResponse userInfoModel = new UserInfoModelResponse();
           copyProperties(userListItem, userInfoModel);
           updateSwitchTeamsList(userInfoModel, userListItem, tenantId, true);
-          if (teamName != null && !teamName.equals("")) {
-            if (Objects.equals(
-                manageDatabase.getTeamNameFromTeamId(tenantId, userInfoModel.getTeamId()),
-                teamName)) {
+          if (teamId != null) {
+            if (Objects.equals(userInfoModel.getTeamId(), teamId)) {
               userInfoModels.add(userInfoModel);
             }
           } else {

--- a/core/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/UiConfigControllerTest.java
@@ -365,7 +365,7 @@ public class UiConfigControllerTest {
     mvcUserTeams
         .perform(
             MockMvcRequestBuilders.get("/showUserList")
-                .param("teamName", "")
+                .param("teamId", "101")
                 .param("pageNo", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2388,12 +2388,12 @@
         "tags" : [ "users-teams-controller" ],
         "operationId" : "showUsers",
         "parameters" : [ {
-          "name" : "teamName",
+          "name" : "teamId",
           "in" : "query",
           "required" : false,
           "schema" : {
-            "type" : "string",
-            "default" : ""
+            "type" : "integer",
+            "format" : "int32"
           }
         }, {
           "name" : "pageNo",
@@ -7445,10 +7445,10 @@
               "type" : "string"
             }
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -7679,10 +7679,10 @@
           "schemaversion" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -7844,10 +7844,10 @@
               "type" : "string"
             }
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -8323,13 +8323,13 @@
       },
       "Scales" : {
         "properties" : {
-          "yaxes" : {
+          "xaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"
             }
           },
-          "xaxes" : {
+          "yaxes" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/YAx"
@@ -8535,10 +8535,10 @@
           "validatedTopic" : {
             "type" : "boolean"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -9034,10 +9034,10 @@
           "approvingTeamId" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },
@@ -9592,10 +9592,10 @@
           "aclResourceType" : {
             "type" : "string"
           },
-          "deletable" : {
+          "editable" : {
             "type" : "boolean"
           },
-          "editable" : {
+          "deletable" : {
             "type" : "boolean"
           }
         },


### PR DESCRIPTION
# Linked issue

Resolves: #2001 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The endpoint /_showUsers_ takes the _teamName_ parameter to filter by _team_. It uses _teamName_ as a string, but other endpoints where we use _team_ as a parameter use _teamId_.

# What is the new behavior?

The endpoint /_showUsers_ takes the _teamId_ parameter to filter by team.

Screenshots of Klaw Core refactored:
![Screenshot 2024-01-10 120413](https://github.com/Aiven-Open/klaw/assets/15722914/cd9655e3-6a08-4969-9ae3-1b7654e4eacc)
![Screenshot 2024-01-10 120402](https://github.com/Aiven-Open/klaw/assets/15722914/45ba70b5-8f71-4d01-ba46-eae8e662f88c)
![Screenshot 2024-01-10 120353](https://github.com/Aiven-Open/klaw/assets/15722914/d0d6315d-dcf3-463c-988d-7e833729adcc)

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
