### PR TITLE
Version Number in Klaw from buildProperties instead of external configuration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -393,13 +393,18 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <goals>
                             <goal>start</goal>
                             <goal>stop</goal>
                         </goals>
                         <configuration>
                             <maxAttempts>${spring.integration.test.timeout}</maxAttempts>
-
                         </configuration>
                     </execution>
                 </executions>

--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -43,6 +43,7 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -123,9 +124,6 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
   @Value("${klaw.superadmin.default.password}")
   private String superAdminDefaultPwd;
 
-  @Value("${klaw.version}")
-  private String kwVersion;
-
   @Value("${klaw.jasypt.encryptor.secretkey}")
   private String encryptorSecretKey;
 
@@ -135,6 +133,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
   @Value("${klaw.superadmin.default.username}")
   private String superAdminDefaultUserName;
 
+  @Autowired BuildProperties buildProperties;
   private ApplicationContext contextApp;
 
   @Override
@@ -250,13 +249,13 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
     String productName = "Klaw";
     Optional<ProductDetails> productDetails = handleDbRequests.getProductDetails(productName);
     if (productDetails.isPresent()) {
-      if (!Objects.equals(productDetails.get().getVersion(), kwVersion)) {
+      if (!Objects.equals(productDetails.get().getVersion(), buildProperties.getVersion())) {
         handleDbRequests.insertProductDetails(
-            defaultDataService.getProductDetails(productName, kwVersion));
+            defaultDataService.getProductDetails(productName, buildProperties.getVersion()));
       }
     } else {
       handleDbRequests.insertProductDetails(
-          defaultDataService.getProductDetails(productName, kwVersion));
+          defaultDataService.getProductDetails(productName, buildProperties.getVersion()));
     }
   }
 

--- a/core/src/main/java/io/aiven/klaw/config/MigrationUtility.java
+++ b/core/src/main/java/io/aiven/klaw/config/MigrationUtility.java
@@ -27,6 +27,7 @@ import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 
@@ -42,7 +43,6 @@ public class MigrationUtility {
   @Value("${klaw.data.migration.packageToScan:io.aiven.klaw.dao.migration}")
   private String packageToScan;
 
-  @Value("${klaw.version}")
   private String currentKlawVersion;
 
   @Value("${klaw.db.hoursFor.tableCreation:1}")
@@ -54,12 +54,16 @@ public class MigrationUtility {
 
   @Autowired private SpringLiquibase liquibase;
 
+  @Autowired BuildProperties buildProperties;
+
   @SchedulerLock(
       name = "TaskScheduler_MigrationUtility",
       lockAtLeastFor = "${klaw.shedlock.lockAtLeastFor:PT30M}",
       lockAtMostFor = "${klaw.shedlock.lockAtMostFor:PT60M}")
   public void startMigration() throws Exception {
-
+    // Set the Klaw version from the build properties.
+    currentKlawVersion = buildProperties.getVersion();
+    log.debug("Klaw build version {}", currentKlawVersion);
     // Find the latest version in DB
     DataVersion currentDataVersion = getLatestDataVersion();
 

--- a/core/src/main/java/io/aiven/klaw/config/OpenApiConfig.java
+++ b/core/src/main/java/io/aiven/klaw/config/OpenApiConfig.java
@@ -5,18 +5,19 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
 
-  @Value("${klaw.version}")
-  private String kwVersion;
+  @Autowired BuildProperties buildProperties;
 
   @Bean
   public OpenAPI klawOpenAPI() {
+
     return new OpenAPI()
         .info(
             new Info()
@@ -25,7 +26,7 @@ public class OpenApiConfig {
                 .description(
                     "This specification is still a work in progress and is not yet implemented in any API."
                         + " The purpose of this specification is to facilitate developers discussions.")
-                .version(kwVersion)
+                .version(buildProperties.getVersion())
                 .license(
                     new License()
                         .name("Apache 2.0")

--- a/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ExportImportDataService.java
@@ -24,6 +24,7 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.jasypt.util.text.BasicTextEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -69,8 +70,7 @@ public class ExportImportDataService {
   @Value("${klaw.import.kwrequestsdata.file.path:path}")
   private String klawImportKwRequestsDataFilePath;
 
-  @Value("${klaw.version}")
-  private String klawVersion;
+  @Autowired BuildProperties buildProperties;
 
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper()
@@ -206,7 +206,7 @@ public class ExportImportDataService {
             .users(userList)
             .properties(handleDbRequests.getKwProperties())
             .productDetails(handleDbRequests.getProductDetails("Klaw").orElse(new ProductDetails()))
-            .klawVersion(klawVersion)
+            .klawVersion(buildProperties.getVersion())
             .createdTime(timeStamp)
             .build();
     log.info("Selecting Kw Admin Config --- ENDED");
@@ -231,7 +231,7 @@ public class ExportImportDataService {
             .subscriptions(handleDbRequests.getAllSubscriptions())
             .schemas(handleDbRequests.getAllSchemas())
             .kafkaConnectors(handleDbRequests.getAllConnectors())
-            .klawVersion(klawVersion)
+            .klawVersion(buildProperties.getVersion())
             .createdTime(timeStamp)
             .build();
     log.info("Selecting Kw Data --- STARTED");
@@ -248,7 +248,7 @@ public class ExportImportDataService {
             .subscriptionRequests(handleDbRequests.getAllAclRequests())
             .schemaRequests(handleDbRequests.getAllSchemaRequests())
             .connectorRequests(handleDbRequests.getAllConnectorRequests())
-            .klawVersion(klawVersion)
+            .klawVersion(buildProperties.getVersion())
             .createdTime(timeStamp)
             .build();
     log.info("Selecting Kw Requests Data --- ENDED");

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.core.Authentication;
@@ -65,8 +66,7 @@ public class UtilControllerService implements InitializingBean {
 
   @Autowired private CommonUtilsService commonUtilsService;
 
-  @Value("${klaw.version}")
-  private String klawVersion;
+  @Autowired BuildProperties buildProperties;
 
   @Value("${klaw.login.authentication.type}")
   private String authenticationType;
@@ -613,7 +613,7 @@ public class UtilControllerService implements InitializingBean {
       authenticationInfo.setTenantName(getTenantNameFromUser(userName, userInfo));
       authenticationInfo.setUserrole(authority);
       authenticationInfo.setCompanyinfo(companyInfo);
-      authenticationInfo.setKlawversion(klawVersion);
+      authenticationInfo.setKlawversion(buildProperties.getVersion());
       authenticationInfo.setNotifications(outstandingTopicReqs);
       authenticationInfo.setNotificationsAcls(outstandingAclReqs);
       authenticationInfo.setNotificationsSchemas(outstandingSchemasReqs);

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -148,9 +148,6 @@ klaw.db.storetype=rdbms
 # klaw application is either "saas" or "onpremise"
 klaw.installation.type=onpremise
 
-# current version of klaw
-klaw.version=@project.version@
-
 #Sensitive fields in a kafka connector request, which will be encrypted. Comma separated. Users cannot view the content.
 klaw.connect.sensitive.fields=password,secret,username
 

--- a/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
+++ b/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
@@ -32,6 +32,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.reflections.Reflections;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -45,6 +46,8 @@ class MigrationUtilityTest {
   MigrationUtility utility;
 
   @Mock private DataVersionRepo versionRepo;
+
+  @Mock BuildProperties buildProperties;
 
   @Mock private SpringLiquibase liquibase;
 
@@ -77,6 +80,8 @@ class MigrationUtilityTest {
     ReflectionTestUtils.setField(utility, "packageToScan", PACKAGE_TO_SCAN);
     ReflectionTestUtils.setField(utility, "liquibase", liquibase);
     ReflectionTestUtils.setField(utility, "allowedTimeBetweenTableInstall", 1);
+    ReflectionTestUtils.setField(utility, "buildProperties", buildProperties);
+    when(buildProperties.getVersion()).thenReturn(KLAW_VERSION);
   }
 
   @Test

--- a/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ExportImportDataServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -31,6 +32,10 @@ public class ExportImportDataServiceTest {
   @Mock private HandleDbRequestsJdbc handleDbRequests;
   private ExportImportDataService exportImportDataService;
 
+  @Mock BuildProperties buildProperties;
+
+  private static final String KLAW_VERSION = "2.7.0";
+
   @BeforeEach
   public void setUp() throws Exception {
     exportImportDataService = new ExportImportDataService();
@@ -38,6 +43,8 @@ public class ExportImportDataServiceTest {
     ReflectionTestUtils.setField(exportImportDataService, "manageDatabase", manageDatabase);
     ReflectionTestUtils.setField(exportImportDataService, "encryptorSecretKey", "testkey");
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
+    ReflectionTestUtils.setField(exportImportDataService, "buildProperties", buildProperties);
+    when(buildProperties.getVersion()).thenReturn(KLAW_VERSION);
   }
 
   @Test

--- a/core/src/test/resources/test-application-rdbms-ad-authorization.properties
+++ b/core/src/test/resources/test-application-rdbms-ad-authorization.properties
@@ -23,8 +23,6 @@ klaw.login.authentication.type=ad
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=@project.version@
-
 # Spring JPA properties mysql
 # Spring JPA properties filedb
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1

--- a/core/src/test/resources/test-application-rdbms-sso-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-sso-ad.properties
@@ -23,8 +23,6 @@ klaw.login.authentication.type=ad
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=@project.version@
-
 # Spring JPA properties mysql
 # Spring JPA properties filedb
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1

--- a/core/src/test/resources/test-application-rdbms-windows-ad.properties
+++ b/core/src/test/resources/test-application-rdbms-windows-ad.properties
@@ -126,9 +126,6 @@ klaw.db.storetype=rdbms
 # klaw application is either "saas" or "onpremise"
 klaw.installation.type=onpremise
 
-# current version of klaw
-klaw.version=@project.version@
-
 # Database settings
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml

--- a/core/src/test/resources/test-application-rdbms.properties
+++ b/core/src/test/resources/test-application-rdbms.properties
@@ -23,8 +23,6 @@ klaw.login.authentication.type=db
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=@project.version@
-
 # Spring JPA properties mysql
 # Spring JPA properties filedb
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1

--- a/core/src/test/resources/test-application-rdbms1.properties
+++ b/core/src/test/resources/test-application-rdbms1.properties
@@ -23,8 +23,6 @@ klaw.login.authentication.type=db
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml
 
-klaw.version=@project.version@
-
 # Spring JPA properties mysql
 # Spring JPA properties filedb
 spring.datasource.url=jdbc:h2:mem:testdb1;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
Update to use the build info properties to determine the build version of Klaw. This will prevent accidental incorrect configuration in the application.properties files

# Linked issue

Resolves: #xxxxx

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?
Currently if an external application.properties file is not updated with the correct build info then the migration Utility does not execute appropriately. As the klaw-version and the properties version are incorrect.

# What is the new behavior?

Now the klaw version will be taken from the build properties (from the pom when building) and used internally to ensure the correct version is being used.

# Other information

This also prevents any issue where the klaw.version in the application.properties file is left with the placeholder that is normally replaced as part of the build.

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
