### PR TITLE
refactor(coral): Add UI error handling in async filters 

### DIFF
--- a/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
@@ -18,7 +18,7 @@ const testNativeSelect = (
 );
 
 const testProps = {
-  entity: "test-select",
+  entity: "test stuff",
   isLoading: false,
   isError: false,
   error: "",
@@ -85,9 +85,7 @@ describe("AsyncNativeSelectWrapper", () => {
     afterAll(cleanup);
 
     it("shows a loading information and animation", () => {
-      const loadingInfo = screen.getByTestId(
-        "async-select-loading-test-select"
-      );
+      const loadingInfo = screen.getByTestId("async-select-loading-test-stuff");
       expect(loadingInfo).toBeVisible();
     });
 
@@ -118,7 +116,7 @@ describe("AsyncNativeSelectWrapper", () => {
     afterAll(cleanup);
 
     it("renders a disabled select element with information about missing data", () => {
-      const select = screen.getByRole("combobox", { name: "No test-select" });
+      const select = screen.getByRole("combobox", { name: "No test stuff" });
 
       expect(select).toBeDisabled();
     });
@@ -133,19 +131,19 @@ describe("AsyncNativeSelectWrapper", () => {
     });
 
     it("marks the select element as invalid", () => {
-      const select = screen.getByRole("combobox", { name: "No test-select" });
+      const select = screen.getByRole("combobox", { name: "No test stuff" });
 
       expect(select).toBeInvalid();
     });
 
     it("shows an error information beneath the select element", () => {
-      const errorText = screen.getByText("test-select could not be loaded.");
+      const errorText = screen.getByText("Test stuff could not be loaded.");
       expect(errorText).toBeVisible();
     });
 
     it("notifies user about the error", () => {
       expect(mockedUseToast).toHaveBeenCalledWith({
-        message: "Error loading test-select: Oh nooooo",
+        message: "Error loading test stuff: Oh nooooo",
         position: "bottom-left",
         variant: "default",
       });

--- a/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
@@ -3,7 +3,10 @@ import { NativeSelect, Option, Typography } from "@aivenio/aquarium";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { AsyncNativeSelectWrapper } from "src/app/components/AsyncNativeSelectWrapper";
 import { KlawApiError } from "src/services/api";
+import { ComplexNativeSelect } from "src/app/components/ComplexNativeSelect";
+
 const mockedUseToast = jest.fn();
+
 jest.mock("@aivenio/aquarium", () => ({
   ...jest.requireActual("@aivenio/aquarium"),
   useToast: () => mockedUseToast,
@@ -17,6 +20,16 @@ const testNativeSelect = (
   </NativeSelect>
 );
 
+const testComplexNativeSelect = (
+  <ComplexNativeSelect<{ id: string; name: string }>
+    labelText={testSelectLabel}
+    identifierValue={"id"}
+    identifierName={"name"}
+    options={[]}
+    onBlur={() => null}
+  />
+);
+
 const testProps = {
   entity: "test stuff",
   isLoading: false,
@@ -27,7 +40,7 @@ const testProps = {
 describe("AsyncNativeSelectWrapper", () => {
   beforeAll(mockIntersectionObserver);
 
-  describe("only accepts a <NativeSelect> from design-system as child", () => {
+  describe("only accepts a <NativeSelect> or <ComplexNativeSelect> as child", () => {
     const originalConsoleError = console.error;
     beforeEach(() => {
       console.error = jest.fn();
@@ -46,7 +59,9 @@ describe("AsyncNativeSelectWrapper", () => {
           </AsyncNativeSelectWrapper>
         )
       ).toThrow(
-        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` as a child."
+        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` or `ComplexNativeSelect` as" +
+          " a" +
+          " child."
       );
     });
 
@@ -58,7 +73,9 @@ describe("AsyncNativeSelectWrapper", () => {
           </AsyncNativeSelectWrapper>
         )
       ).toThrow(
-        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` as a child."
+        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` or `ComplexNativeSelect` as" +
+          " a" +
+          " child."
       );
     });
 
@@ -67,6 +84,16 @@ describe("AsyncNativeSelectWrapper", () => {
         render(
           <AsyncNativeSelectWrapper {...testProps}>
             {testNativeSelect}
+          </AsyncNativeSelectWrapper>
+        )
+      ).not.toThrow();
+    });
+
+    it("does not throw an error when child element is a ComplexNativeSelect", () => {
+      expect(() =>
+        render(
+          <AsyncNativeSelectWrapper {...testProps}>
+            {testComplexNativeSelect}
           </AsyncNativeSelectWrapper>
         )
       ).not.toThrow();

--- a/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
@@ -85,7 +85,9 @@ describe("AsyncNativeSelectWrapper", () => {
     afterAll(cleanup);
 
     it("shows a loading information and animation", () => {
-      const loadingInfo = screen.getByTestId("async-select-loading");
+      const loadingInfo = screen.getByTestId(
+        "async-select-loading-test-select"
+      );
       expect(loadingInfo).toBeVisible();
     });
 

--- a/coral/src/app/components/AsyncNativeSelectWrapper.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.tsx
@@ -11,13 +11,25 @@ function isNativeSelectComponent(
   child: ReactNode
 ): //eslint-disable-next-line @typescript-eslint/no-explicit-any
 child is ReactElement<NativeSelectProps | ComplexNativeSelectProps<any>> {
+  const isNativeSelectAquariumImport =
+    isValidElement(child) &&
+    /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
+    (child.type as any)?.render?.displayName === NativeSelect.displayName;
+
+  const isNativeSelectFormImport =
+    isValidElement(child) &&
+    /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
+    (child.type as any)?.name === NativeSelect.displayName;
+
+  const isComplexNativeSelect =
+    isValidElement(child) &&
+    /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
+    (child.type as any)?.name === ComplexNativeSelect.name;
+
   return (
-    (isValidElement(child) &&
-      /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
-      (child.type as any)?.render?.displayName === NativeSelect.displayName) ||
-    (isValidElement(child) &&
-      /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
-      (child.type as any)?.name === ComplexNativeSelect.name)
+    isNativeSelectAquariumImport ||
+    isNativeSelectFormImport ||
+    isComplexNativeSelect
   );
 }
 

--- a/coral/src/app/components/AsyncNativeSelectWrapper.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.tsx
@@ -63,7 +63,7 @@ function AsyncNativeSelectWrapper(props: AsyncNativeSelectWrapperProps) {
     if (!isNativeSelectComponent(children)) {
       const errorMessage =
         "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` or `ComplexNativeSelect` as" +
-          " a child.";
+        " a child.";
 
       if (isDevMode()) {
         throw new Error(errorMessage);

--- a/coral/src/app/components/AsyncNativeSelectWrapper.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.tsx
@@ -2,6 +2,7 @@ import { NativeSelect, NativeSelectProps, useToast } from "@aivenio/aquarium";
 import { isValidElement, ReactElement, ReactNode, useEffect } from "react";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import kebabCase from "lodash/kebabCase";
+import upperFirst from "lodash/upperFirst";
 import { isDevMode } from "src/services/is-dev-mode";
 
 function isNativeSelectComponent(
@@ -16,9 +17,9 @@ function isNativeSelectComponent(
 
 type AsyncNativeSelectWrapperProps = {
   /**
-   * `entity` is the entity which user filters by, e.g. "Team" or "Topic"
+   * `entity` is the entity which user filters by, e.g. "team" or "Environment"
    * It is used in e.g. placeholder and toast notification for error cases,
-   * like "Error loading <ENTITY>"
+   * like "Error loading <ENTITY>".
    */
   entity: string;
   isLoading: boolean;
@@ -70,7 +71,7 @@ function AsyncNativeSelectWrapper(props: AsyncNativeSelectWrapperProps) {
         labelText={children.props.labelText}
         aria-label={`No ${entity}`}
         placeholder={`No ${entity}`}
-        helperText={`${entity} could not be loaded.`}
+        helperText={`${upperFirst(entity)} could not be loaded.`}
       />
     );
   }

--- a/coral/src/app/components/AsyncNativeSelectWrapper.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.tsx
@@ -1,6 +1,7 @@
 import { NativeSelect, NativeSelectProps, useToast } from "@aivenio/aquarium";
 import { isValidElement, ReactElement, ReactNode, useEffect } from "react";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import kebabCase from "lodash/kebabCase";
 import { isDevMode } from "src/services/is-dev-mode";
 
 function isNativeSelectComponent(
@@ -76,7 +77,7 @@ function AsyncNativeSelectWrapper(props: AsyncNativeSelectWrapperProps) {
 
   if (isLoading) {
     return (
-      <div data-testid={"async-select-loading"}>
+      <div data-testid={`async-select-loading-${kebabCase(entity)}`}>
         <NativeSelect.Skeleton />
       </div>
     );

--- a/coral/src/app/components/AsyncNativeSelectWrapper.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.tsx
@@ -3,15 +3,21 @@ import { isValidElement, ReactElement, ReactNode, useEffect } from "react";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import kebabCase from "lodash/kebabCase";
 import upperFirst from "lodash/upperFirst";
+import { ComplexNativeSelectProps } from "src/app/components/ComplexNativeSelect";
+import { ComplexNativeSelect } from "src/app/components/Form";
 import { isDevMode } from "src/services/is-dev-mode";
 
 function isNativeSelectComponent(
   child: ReactNode
-): child is ReactElement<NativeSelectProps> {
+): //eslint-disable-next-line @typescript-eslint/no-explicit-any
+child is ReactElement<NativeSelectProps | ComplexNativeSelectProps<any>> {
   return (
-    isValidElement(child) &&
-    /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
-    (child.type as any)?.render?.displayName === NativeSelect.displayName
+    (isValidElement(child) &&
+      /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
+      (child.type as any)?.render?.displayName === NativeSelect.displayName) ||
+    (isValidElement(child) &&
+      /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
+      (child.type as any)?.name === ComplexNativeSelect.name)
   );
 }
 
@@ -25,7 +31,8 @@ type AsyncNativeSelectWrapperProps = {
   isLoading: boolean;
   isError: boolean;
   error: unknown;
-  children: ReactElement<NativeSelectProps>;
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  children: ReactElement<NativeSelectProps | ComplexNativeSelectProps<any>>;
 };
 
 /** <AsyncNativeSelectWrapper> handles loading
@@ -43,7 +50,8 @@ function AsyncNativeSelectWrapper(props: AsyncNativeSelectWrapperProps) {
   useEffect(() => {
     if (!isNativeSelectComponent(children)) {
       const errorMessage =
-        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` as a child.";
+        "Invalid child component. `AsyncNativeSelectWrapper` only accepts `NativeSelect` or `ComplexNativeSelect` as" +
+          " a child.";
 
       if (isDevMode()) {
         throw new Error(errorMessage);

--- a/coral/src/app/features/activity-log/ActivityLog.test.tsx
+++ b/coral/src/app/features/activity-log/ActivityLog.test.tsx
@@ -64,6 +64,7 @@ describe("ActivityLog", () => {
   beforeEach(() => {
     mockIntersectionObserver();
     mockGetActivityLog.mockResolvedValue(mockGetActivityLogResponse);
+    mockGetAllEnvironments.mockResolvedValue([]);
   });
 
   afterEach(() => {

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -134,7 +134,7 @@ describe("EnvironmentFilter.tsx", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
     });
 
@@ -216,7 +216,7 @@ describe("EnvironmentFilter.tsx", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
     });
 
@@ -289,7 +289,7 @@ describe("EnvironmentFilter.tsx", () => {
         customRoutePath: routePath,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
     });
 
@@ -320,7 +320,7 @@ describe("EnvironmentFilter.tsx", () => {
         memoryRouter: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
     });
 
@@ -355,7 +355,7 @@ describe("EnvironmentFilter.tsx", () => {
         browserRouter: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
     });
 
@@ -422,7 +422,7 @@ describe("EnvironmentFilter.tsx", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
     });
 

--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -65,7 +65,7 @@ describe("TeamFilter.tsx", () => {
           aquariumContext: true,
         });
         await waitForElementToBeRemoved(
-          screen.getByTestId("async-select-loading")
+          screen.getByTestId("async-select-loading-teams")
         );
       });
 
@@ -116,7 +116,7 @@ describe("TeamFilter.tsx", () => {
           customRoutePath: routePath,
         });
         await waitForElementToBeRemoved(
-          screen.getByTestId("async-select-loading")
+          screen.getByTestId("async-select-loading-teams")
         );
       });
 
@@ -147,7 +147,7 @@ describe("TeamFilter.tsx", () => {
           memoryRouter: true,
         });
         await waitForElementToBeRemoved(
-          screen.getByTestId("async-select-loading")
+          screen.getByTestId("async-select-loading-teams")
         );
       });
 
@@ -223,7 +223,7 @@ describe("TeamFilter.tsx", () => {
           aquariumContext: true,
         });
         await waitForElementToBeRemoved(
-          screen.getByTestId("async-select-loading")
+          screen.getByTestId("async-select-loading-teams")
         );
       });
 
@@ -273,7 +273,7 @@ describe("TeamFilter.tsx", () => {
           customRoutePath: routePath,
         });
         await waitForElementToBeRemoved(
-          screen.getByTestId("async-select-loading")
+          screen.getByTestId("async-select-loading-teams")
         );
       });
 
@@ -303,7 +303,7 @@ describe("TeamFilter.tsx", () => {
           memoryRouter: true,
         });
         await waitForElementToBeRemoved(
-          screen.getByTestId("async-select-loading")
+          screen.getByTestId("async-select-loading-teams")
         );
       });
 
@@ -386,7 +386,7 @@ describe("TeamFilter.tsx", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-teams")
       );
     });
 

--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -398,7 +398,7 @@ describe("TeamFilter.tsx", () => {
 
     it("shows a disabled select with No teams", () => {
       const select = screen.getByRole("combobox", {
-        name: "No Teams",
+        name: "No teams",
       });
 
       expect(select).toBeDisabled();
@@ -413,7 +413,7 @@ describe("TeamFilter.tsx", () => {
     it("shows a toast notification with error", () => {
       expect(mockedUseToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: `Error loading Teams: ${testError.message}`,
+          message: `Error loading teams: ${testError.message}`,
         })
       );
       expect(console.error).toHaveBeenCalledWith(testError);

--- a/coral/src/app/features/components/filters/TeamFilter.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.tsx
@@ -21,7 +21,7 @@ function TeamFilter({ useTeamName }: TeamFilterProps) {
 
   return (
     <AsyncNativeSelectWrapper
-      entity={"Teams"}
+      entity={"teams"}
       isLoading={isLoading}
       isError={isError}
       error={error}

--- a/coral/src/app/features/connectors/request/ConnectorRequest.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.tsx
@@ -32,6 +32,7 @@ import {
   getAllEnvironmentsForConnector,
 } from "src/domain/environment";
 import { parseErrorMsg } from "src/services/mutation-utils";
+import { AsyncNativeSelectWrapper } from "src/app/components/AsyncNativeSelectWrapper";
 
 function ConnectorRequest() {
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
@@ -43,10 +44,12 @@ function ConnectorRequest() {
     schema: connectorRequestFormSchema,
   });
 
-  const { data: environments, isLoading: environmentsIsLoading } = useQuery<
-    Environment[],
-    Error
-  >({
+  const {
+    data: environments,
+    isLoading: isLoadingEnvironments,
+    isError: isErrorEnvironments,
+    error: errorEnvironments,
+  } = useQuery<Environment[], Error>({
     queryKey: ["getAllEnvironmentsForConnector"],
     queryFn: () => getAllEnvironmentsForConnector(),
   });
@@ -86,20 +89,19 @@ function ConnectorRequest() {
           ariaLabel={"Request a new connector"}
           onSubmit={onSubmitForm}
         >
-          {environmentsIsLoading && (
-            <div data-testid={"environments-select-loading"}>
-              <NativeSelect.Skeleton />
-            </div>
-          )}
-
-          {environments && (
+          <AsyncNativeSelectWrapper
+            entity={"Environments"}
+            isLoading={isLoadingEnvironments}
+            isError={isErrorEnvironments}
+            error={errorEnvironments}
+          >
             <NativeSelect<ConnectorRequestFormSchema>
               name={"environment"}
               labelText={"Environment"}
               placeholder={"-- Please select --"}
               required
             >
-              {environments.map((env) => {
+              {environments?.map((env) => {
                 return (
                   <option key={env.id} value={env.id}>
                     {env.name}
@@ -107,7 +109,7 @@ function ConnectorRequest() {
                 );
               })}
             </NativeSelect>
-          )}
+          </AsyncNativeSelectWrapper>
 
           <TextInput<ConnectorRequestFormSchema>
             name={"connectorName"}

--- a/coral/src/app/features/requests/acls/AclRequests.test.tsx
+++ b/coral/src/app/features/requests/acls/AclRequests.test.tsx
@@ -360,7 +360,7 @@ describe("AclRequests", () => {
       });
 
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
 
       const envFilter = screen.getByRole("combobox", {
@@ -388,7 +388,7 @@ describe("AclRequests", () => {
       });
 
       await waitForElementToBeRemoved(
-        screen.getByTestId("async-select-loading")
+        screen.getByTestId("async-select-loading-environments")
       );
 
       const envFilter = screen.getByRole("combobox", {

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -95,7 +95,7 @@ describe("BrowseTopics.tsx", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getAllByTestId("async-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 
@@ -291,7 +291,7 @@ describe("BrowseTopics.tsx", () => {
       });
 
       await waitForElementToBeRemoved(
-        screen.getAllByTestId("async-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -690,10 +690,11 @@ describe("TopicDetailsSchema", () => {
       });
 
       it("shows accessible information that versions are loading", () => {
-        const loadingInformation = screen.getByText("Versions loading");
+        const loadingInformation = screen.getByTestId(
+          "async-select-loading-versions"
+        );
 
         expect(loadingInformation).toBeVisible();
-        expect(loadingInformation).toHaveClass("visually-hidden");
       });
 
       it("shows no information about available amount of versions", () => {

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.tsx
@@ -29,6 +29,7 @@ import { InternalLinkButton } from "src/app/components/InternalLinkButton";
 import { SchemaPromotableOnlyAlert } from "src/app/features/topics/details/schema/components/SchemaPromotableOnlyAlert";
 import { NoSchemaBanner } from "src/app/features/topics/details/schema/components/NoSchemaBanner";
 import { OpenSchemaRequestAlert } from "src/app/features/topics/details/schema/components/OpenSchemaRequestAlert";
+import { AsyncNativeSelectWrapper } from "src/app/components/AsyncNativeSelectWrapper";
 
 //@ TODO change to api response value
 // eslint-disable-next-line react/prop-types
@@ -146,32 +147,32 @@ function TopicDetailsSchema() {
       <PageHeader title="Schema" />
       <Box display={"flex"} justifyContent={"space-between"}>
         <Box display={"flex"} colGap={"l1"}>
-          {topicSchemasIsRefetching ? (
-            <>
-              <div className={"visually-hidden"}>Versions loading</div>
-              <NativeSelect.Skeleton />
-            </>
-          ) : (
-            <>
-              <NativeSelect
-                style={{ width: "300px" }}
-                aria-label={"Select version"}
-                onChange={(e) => setSchemaVersion(Number(e.target.value))}
-                defaultValue={schemaDetailsPerEnv.version}
-              >
-                {allSchemaVersions.map((version) => (
-                  <Option key={version} value={version}>
-                    Version {version} {version === latestVersion && "(latest)"}
-                  </Option>
-                ))}
-              </NativeSelect>
-              <Typography.SmallStrong color={"grey-40"}>
-                <Box display={"flex"} marginTop={"3"} colGap={"2"}>
-                  <Icon icon={gitNewBranch} style={{ marginTop: "2px" }} />{" "}
-                  <span>{allSchemaVersions.length} versions</span>
-                </Box>
-              </Typography.SmallStrong>
-            </>
+          <AsyncNativeSelectWrapper
+            entity={"versions"}
+            isLoading={topicSchemasIsRefetching}
+            isError={false}
+            error={""}
+          >
+            <NativeSelect
+              style={{ width: "300px" }}
+              aria-label={"Select version"}
+              onChange={(e) => setSchemaVersion(Number(e.target.value))}
+              defaultValue={schemaDetailsPerEnv.version}
+            >
+              {allSchemaVersions.map((version) => (
+                <Option key={version} value={version}>
+                  Version {version} {version === latestVersion && "(latest)"}
+                </Option>
+              ))}
+            </NativeSelect>
+          </AsyncNativeSelectWrapper>
+          {!topicSchemasIsRefetching && (
+            <Typography.SmallStrong color={"grey-40"}>
+              <Box display={"flex"} marginTop={"3"} colGap={"2"}>
+                <Icon icon={gitNewBranch} style={{ marginTop: "2px" }} />{" "}
+                <span>{allSchemaVersions.length} versions</span>
+              </Box>
+            </Typography.SmallStrong>
           )}
         </Box>
 

--- a/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
+++ b/coral/src/app/features/topics/details/subscriptions/TopicSubscriptions.test.tsx
@@ -246,7 +246,9 @@ describe("TopicSubscriptions.tsx", () => {
       queryClient: true,
       aquariumContext: true,
     });
-    await waitForElementToBeRemoved(screen.getByTestId("async-select-loading"));
+    await waitForElementToBeRemoved(
+      screen.getByTestId("async-select-loading-teams")
+    );
   });
 
   afterEach(() => {

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "src/domain/topic/topic-api";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { objectHasProperty } from "src/services/type-utils";
+import { waitForElementToBeRemoved } from "@testing-library/react/pure";
 
 jest.mock("src/domain/environment/environment-api.ts");
 const mockGetEnvironments =
@@ -42,7 +43,7 @@ describe("<TopicRequest />", () => {
 
   describe("Environment select", () => {
     describe("renders all necessary elements by default", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({ name: "DEV", id: "1" }),
@@ -54,7 +55,12 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
+
       afterAll(() => {
         cleanup();
       });
@@ -97,7 +103,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("when field is clicked", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({ name: "DEV", id: "1" }),
@@ -109,6 +115,9 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterEach(() => {
@@ -157,7 +166,7 @@ describe("<TopicRequest />", () => {
 
   describe("Topic name", () => {
     describe("informs user about valid input with placeholder per default", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({
@@ -174,6 +183,10 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterAll(() => {
@@ -198,7 +211,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("informs user about valid input with placeholder when regex should be applied", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({
@@ -210,10 +223,15 @@ describe("<TopicRequest />", () => {
             },
           }),
         ]);
+
         customRender(<TopicRequest />, {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterAll(() => {
@@ -238,7 +256,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("informs user about valid input with a prefix is needed", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({
@@ -255,6 +273,10 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterAll(() => {
@@ -279,7 +301,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("when topic name does not have enough characters", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({
@@ -292,6 +314,10 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterAll(() => {
@@ -321,7 +347,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("when topic name does not match the default pattern", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({
@@ -334,6 +360,10 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterAll(() => {
@@ -363,7 +393,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("when environment params have topicPrefix defined", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({
@@ -386,6 +416,10 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterEach(() => {
@@ -442,7 +476,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("when environment params have topicSuffix defined", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({
@@ -458,7 +492,12 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
+
       afterAll(() => {
         cleanup();
       });
@@ -488,7 +527,7 @@ describe("<TopicRequest />", () => {
 
   describe("Replication factor", () => {
     describe("renders all necessary elements on default", () => {
-      beforeAll(() => {
+      beforeAll(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({ name: "DEV", id: "1" }),
@@ -521,6 +560,10 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterAll(() => {
@@ -556,7 +599,7 @@ describe("<TopicRequest />", () => {
     });
 
     describe("when environment is changed", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
         mockGetEnvironments.mockResolvedValue([
           createMockEnvironmentDTO({ name: "DEV", id: "1" }),
@@ -589,6 +632,10 @@ describe("<TopicRequest />", () => {
           queryClient: true,
           aquariumContext: true,
         });
+
+        await waitForElementToBeRemoved(
+          screen.getByTestId("async-select-loading-environments")
+        );
       });
 
       afterEach(() => {
@@ -669,7 +716,7 @@ describe("<TopicRequest />", () => {
   });
 
   describe("Topic partitions", () => {
-    beforeAll(() => {
+    beforeAll(async () => {
       mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
       mockGetEnvironments.mockResolvedValue([
         createMockEnvironmentDTO({ name: "DEV", id: "1" }),
@@ -702,7 +749,12 @@ describe("<TopicRequest />", () => {
         queryClient: true,
         aquariumContext: true,
       });
+
+      await waitForElementToBeRemoved(
+        screen.getByTestId("async-select-loading-environments")
+      );
     });
+
     afterAll(cleanup);
 
     describe("input components", () => {
@@ -733,7 +785,7 @@ describe("<TopicRequest />", () => {
   });
 
   describe("when environment is changed", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
       mockGetEnvironments.mockResolvedValue([
         createMockEnvironmentDTO({ name: "DEV", id: "1" }),
@@ -766,7 +818,12 @@ describe("<TopicRequest />", () => {
         queryClient: true,
         aquariumContext: true,
       });
+
+      await waitForElementToBeRemoved(
+        screen.getByTestId("async-select-loading-environments")
+      );
     });
+
     afterEach(cleanup);
 
     it('changes topic partitions value to 4 when environment params have "defaultPartitions"', async () => {
@@ -828,7 +885,7 @@ describe("<TopicRequest />", () => {
   });
 
   describe("AdvancedConfiguration", () => {
-    beforeAll(() => {
+    beforeAll(async () => {
       mockGetTopicAdvancedConfigOptions.mockResolvedValue([]);
       mockGetEnvironments.mockResolvedValue([
         createMockEnvironmentDTO({ name: "DEV", id: "1" }),
@@ -838,7 +895,12 @@ describe("<TopicRequest />", () => {
         queryClient: true,
         aquariumContext: true,
       });
+
+      await waitForElementToBeRemoved(
+        screen.getByTestId("async-select-loading-environments")
+      );
     });
+
     afterAll(cleanup);
 
     it("renders a sub heading", () => {

--- a/coral/src/app/features/topics/request/TopicRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.tsx
@@ -7,7 +7,6 @@ import {
   Textarea,
   TextInput,
   useForm,
-  NativeSelect,
   ComplexNativeSelect,
 } from "src/app/components/Form";
 import formSchema, {
@@ -25,6 +24,7 @@ import { Dialog } from "src/app/components/Dialog";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import isString from "lodash/isString";
+import { AsyncNativeSelectWrapper } from "src/app/components/AsyncNativeSelectWrapper";
 
 function parseNumberOrUndefined(value: string | undefined): number | undefined {
   return isString(value) ? parseInt(value, 10) : undefined;
@@ -36,14 +36,16 @@ function TopicRequest() {
 
   const [cancelDialogVisible, setCancelDialogVisible] = useState(false);
 
-  const { data: environments } = useQuery<EnvironmentForTopicForm[], Error>(
-    ["environments-for-team"],
-    {
-      queryFn: getEnvironmentsForTopicRequest,
-      select: (data) =>
-        data.map(({ name, id, params }) => ({ name, id, params })),
-    }
-  );
+  const {
+    data: environments,
+    isLoading: isLoadingEnvironments,
+    isError: isErrorEnvironments,
+    error: errorEnvironments,
+  } = useQuery<EnvironmentForTopicForm[], Error>(["environments-for-team"], {
+    queryFn: getEnvironmentsForTopicRequest,
+    select: (data) =>
+      data.map(({ name, id, params }) => ({ name, id, params })),
+  });
 
   const defaultValues = Array.isArray(environments)
     ? {
@@ -119,19 +121,22 @@ function TopicRequest() {
           onError={onError}
         >
           <Box width={"full"}>
-            {Array.isArray(environments) ? (
+            <AsyncNativeSelectWrapper
+              entity={"Environments"}
+              isLoading={isLoadingEnvironments}
+              isError={isErrorEnvironments}
+              error={errorEnvironments}
+            >
               <ComplexNativeSelect<Schema, EnvironmentForTopicForm>
                 name="environment"
                 labelText={"Environment"}
                 placeholder={"-- Please select --"}
-                options={environments}
+                options={Array.isArray(environments) ? environments : []}
                 identifierValue={"id"}
                 identifierName={"name"}
                 required
               />
-            ) : (
-              <NativeSelect.Skeleton></NativeSelect.Skeleton>
-            )}
+            </AsyncNativeSelectWrapper>
           </Box>
           <Box>
             <Box paddingY={"l1"}>

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -153,7 +153,7 @@ describe("TopicSchemaRequest", () => {
       expect(form).toBeVisible();
 
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
 
       const select = within(form).getByRole("combobox", {
@@ -188,7 +188,7 @@ describe("TopicSchemaRequest", () => {
       expect(form).toBeVisible();
 
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
 
       const select = within(form).getByRole("combobox", {
@@ -272,7 +272,7 @@ describe("TopicSchemaRequest", () => {
     it("shows a loading element while Environments are being fetched", () => {
       const form = getForm();
       const loadingEnvironments = within(form).getByTestId(
-        "environments-select-loading"
+        "async-select-loading-environments"
       );
 
       expect(loadingEnvironments).toBeVisible();
@@ -293,7 +293,7 @@ describe("TopicSchemaRequest", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 
@@ -429,7 +429,7 @@ describe("TopicSchemaRequest", () => {
         aquariumContext: true,
       });
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 
@@ -509,7 +509,7 @@ describe("TopicSchemaRequest", () => {
         }
       );
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 
@@ -629,7 +629,7 @@ describe("TopicSchemaRequest", () => {
         }
       );
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 
@@ -735,7 +735,7 @@ describe("TopicSchemaRequest", () => {
         }
       );
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 
@@ -923,7 +923,7 @@ describe("TopicSchemaRequest", () => {
         }
       );
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 
@@ -1003,7 +1003,7 @@ describe("TopicSchemaRequest", () => {
         }
       );
       await waitForElementToBeRemoved(
-        screen.getByTestId("environments-select-loading")
+        screen.getAllByTestId(/async-select-loading/)
       );
     });
 


### PR DESCRIPTION
# Linked issue

Resolves: #2183

✅  tested on local build as well as dev-mode

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

(not sure if it's more a fix or a new feature 

# Descri**p**tion 

- update `AsyncNativeSelectWrapper` to be able to handle all cases / general improvements
-> `entity` now is formatted in error message, so that the upper/lower case letter are correct in all cases
-> test-id now has the entity as part of the id, so we can query for specific selects if needed
-> `ComplexNativeSelect` is now also a valid child 
-> check for valid child needed to cover `displayName` as well as `name` for native select (once for imports from DS, once for imports from `Form.tsx`)

- adds `AsyncNativeSelectWrapper to`
-> TopicRequest
-> TopicSchemaRequest
-> ConnectorRequest
-> TopicDetailsSchema


Note: Following NativeSelect did **not** need a wrapper: 
-TopicPromotionRequest (https://github.com/Aiven-Open/klaw/issues/2183#issuecomment-1887201449)
- TopicEditRequest (https://github.com/Aiven-Open/klaw/issues/2183#issuecomment-1887201449)
- EntityDetailsHeader (https://github.com/Aiven-Open/klaw/issues/2183#issuecomment-1887195724)
- ConnectorEditRequest (https://github.com/Aiven-Open/klaw/issues/2183#issuecomment-1887201449)
- ConnectorPromotionRequest (https://github.com/Aiven-Open/klaw/issues/2183#issuecomment-1887201449)



# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
