### PR TITLE
ci: Add health test e2e

### DIFF
--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -2,7 +2,8 @@
 # It will build and deploy Klaw and run E2E tests against it.
 name: E2E tests
 on:
-  workflow_dispatch:
+  - workflow_dispatch
+  - workflow_call
 
 jobs:
   end-to-end-tests:

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -1,5 +1,7 @@
 # The workflow can be triggered manually.
 # It will build and deploy Klaw and run E2E tests against it.
+# The E2E test is very basic and only makes sure that the app
+# including Coral is built successfully.
 name: E2E tests
 on:
   - workflow_dispatch

--- a/.github/workflows/workflow-merge-to-main.yaml
+++ b/.github/workflows/workflow-merge-to-main.yaml
@@ -48,6 +48,8 @@ jobs:
     if: (github.event_name == 'pull_request' && github.event.action == 'synchronize') || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
     name: Run Playwright e2e test before enabling merge to main
     needs: checkout-code
+    permissions:
+      actions: write
     uses: ./.github/workflows/end-to-end-tests.yaml
 
   merge-to-main:

--- a/.github/workflows/workflow-merge-to-main.yaml
+++ b/.github/workflows/workflow-merge-to-main.yaml
@@ -44,12 +44,17 @@ jobs:
     needs: checkout-code
     uses: ./.github/workflows/jobs-maven.yaml
 
+  run-e2e-tests:
+    if: (github.event_name == 'pull_request' && github.event.action == 'synchronize') || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+    name: Run Playwright e2e test before enabling merge to main
+    needs: checkout-code
+    uses: ./.github/workflows/end-to-end-tests.yaml
 
   merge-to-main:
     name: Status check for enabling merging to main
     if: (github.event_name == 'pull_request' && github.event.action == 'synchronize') || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
     runs-on: ubuntu-latest
-    needs: [ run-maven-jobs, run-coral-jobs ]
+    needs: [ run-maven-jobs, run-coral-jobs, run-e2e-tests ]
 
     steps:
       - name: Confirm check

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ coral/.cert*
 # Coral bundle analysis
 coral/stats.html
 
+# E2E tests playwright
+
+e2e/playwright-report*

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,6 +2,8 @@
 
 This is a work in progress, so a documentation will follow!
 
+Most importantly, we need to make sure that the tests run on a Klaw instance with a clean and reproducible database which they don't at the moment.
+
 ## Current state
 
 - to run tests on a local machine, use `pnpm test-local`

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,5 +6,6 @@ This is a work in progress, so a documentation will follow!
 
 - to run tests on a local machine, use `pnpm test-local`
   - Please note that the tests are a proof-of-concept right now. We won't tackle adding tests before we have the setup of everything figured out, for example how to add consistent test data etc.
+- to run test in development mode, use `pnpm test-local --ui`
 - scripts with a `__` as prefixed are meant to be used internally
 - the related github workflow is [end-to-end-tests.yaml](../.github/workflows/end-to-end-tests.yaml)

--- a/e2e/tests/basic-health-check.spec.ts
+++ b/e2e/tests/basic-health-check.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+const superAdminUserName = "superadmin";
+
+// ⚠️ The password is the default password set in application.properties
+// because that is the one that will work in GitHub.
+// If the tests run e.g. locally, where 'superadmin' has a different password,
+// this test will fail, because it would need to use the local password.
+// We need to make sure that Klaw runs on clean DBs for E2E tests.
+// For this basic health check, this is sufficient.
+const superAdminPassword = "welcometoklaw";
+test("has title", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveTitle(
+    "Klaw | Kafka Self-service Topic Management Portal",
+  );
+});
+
+test("user can login with default superadmin user", async ({ page }) => {
+  await page.goto("/");
+  const loader = page.locator(".preloader");
+  await expect(loader).not.toBeVisible();
+
+  await page.getByPlaceholder("Username").fill(superAdminUserName);
+  await page.getByPlaceholder("Password").fill(superAdminPassword);
+  await page.getByRole("button", { name: "LOG IN" }).click();
+
+  const profileForSuperAdmin = await page.getByRole("button", {
+    name: "superadmin",
+    exact: true,
+  });
+
+  await expect(profileForSuperAdmin).toBeVisible();
+});
+
+test("coral is build", async ({ page }) => {
+  await page.goto("/");
+  const loader = page.locator(".preloader");
+  await expect(loader).not.toBeVisible();
+
+  await page.getByPlaceholder("Username").fill(superAdminUserName);
+  await page.getByPlaceholder("Password").fill(superAdminPassword);
+  await page.getByRole("button", { name: "LOG IN" }).click();
+
+  const profileForSuperAdmin = await page.getByRole("button", {
+    name: "superadmin",
+    exact: true,
+  });
+
+  await expect(profileForSuperAdmin).toBeVisible();
+
+  await page.goto("/coral/topics");
+
+  const coralSuperAdminDialog = await page.getByRole("dialog", {
+    name: /you're currently logged in as superadmin\./i,
+  });
+
+  await expect(coralSuperAdminDialog).toBeVisible();
+});


### PR DESCRIPTION
# Linked issue

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [X] CI update

# Description

This PR introduces a new workflow that needs to be completed before being able to merge to main.

The workflow:

- builds Klaw
- opens Klaw and logs in as superadmin
- goes to a coral page and checks that the message visible is from coral

These tests are only meant to make sure that the Klaw build, including coral, was successful.  

⚠️ the test uses the default admin password to login, which will always be correct on CI, but may not be locally. To make sure we're using a clean, reproducible setup of Klaw for E2E tests, we need to setup DB etc. which we've not yet done. I've documented that in README as well as the test file itself.

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
