### PR TITLE
Fix for new user mail content

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -332,7 +332,8 @@ public class MailUtils {
     formattedStr = String.format(newUserAdded, username, pwd);
     subject = "Access to Klaw";
 
-    sendMail(username, dbHandle, formattedStr, subject, false, false, null, tenantId, loginUrl);
+    sendMail(
+        username, dbHandle, formattedStr, subject, false, false, null, tenantId, loginUrl, false);
   }
 
   void sendMailResetPwd(
@@ -416,7 +417,8 @@ public class MailUtils {
         false,
         registerUserInfo.getMailid(),
         tenantId,
-        loginUrl);
+        loginUrl,
+        true);
   }
 
   void sendMailRegisteredUser(
@@ -459,7 +461,8 @@ public class MailUtils {
           false,
           registerUserInfo.getMailid(),
           tenantId,
-          loginUrl);
+          loginUrl,
+          true);
     } catch (Exception e) {
       log.error(registerUserInfo.toString(), e);
     }
@@ -505,7 +508,8 @@ public class MailUtils {
       boolean requiresApproval,
       String otherMailId,
       int tenantId,
-      String loginUrl) {
+      String loginUrl,
+      boolean copyTeam) {
 
     CompletableFuture.runAsync(
         () -> {
@@ -540,7 +544,9 @@ public class MailUtils {
               log.debug("emailId: {} Team: {}", emailId, emailIdTeam);
 
               CollectionUtils.addIgnoreNull(to, emailId);
-              CollectionUtils.addIgnoreNull(to, emailIdTeam);
+              if (copyTeam) {
+                CollectionUtils.addIgnoreNull(to, emailIdTeam);
+              }
               emailService.sendSimpleMessage(
                   to, cc, allApprovers, subject, formattedStr, tenantId, loginUrl);
             } else {


### PR DESCRIPTION
# Linked issue

Resolves: #xxxxx

When a new user is added, user details email should be sent to user only and not to team.
This fix, sends email only to user and not to team.

# What kind of change does this PR introduce?

- [ X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
