### PR TITLE
Use `spring.main.lazy-initialization=true`

### DIFF
--- a/cluster-api/src/main/resources/application.properties
+++ b/cluster-api/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.main.lazy-initialization=true
 # Uncomment the below SSL/Https Properties to secure this Cluster Api application
 
 #server.ssl.key-store=client.keystore.p12

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.main.lazy-initialization=true
 # Uncomment the below SSL/Https Properties to secure this Cluster Api application
 
 #server.ssl.key-store=client.keystore.p12


### PR DESCRIPTION
The idea is pretty straightforward: just use  `spring.main.lazy-initialization=true` since by default it is false
 based on https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html

it makes startup of springboot app a bit faster (locally about 10% 10.5 sec vs 11.5sec)