### PR TITLE
Return all environments in the topics overview

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KlawResourceUtils.java
@@ -20,7 +20,6 @@ public class KlawResourceUtils {
     for (Env env1 : allEnvs) {
       if (selectedEnvs.contains(env1.getId())) {
         newEnvSet.add(new EnvIdInfo(env1.getId(), env1.getName()));
-        break;
       }
     }
 


### PR DESCRIPTION
Remove the break that was only adding one environment to the list of environments.

# Linked issue

Resolves: #2220 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Only one environment is currently returned when you call getTopics

# What is the new behavior?
All the environments the topic exists on are added.

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
