### PR TITLE
 Use Enum and check permission in getTopics api

### DIFF
--- a/coral/src/app/features/components/filters/TopicTypeFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TopicTypeFilter.test.tsx
@@ -68,7 +68,7 @@ describe("TopicTypeFilter", () => {
   });
 
   describe("sets the active Topic type based on a query param", () => {
-    const producerTopic = "Producer";
+    const producerTopic = "PRODUCER";
     beforeEach(async () => {
       const routePath = `/?topicType=${producerTopic}`;
 
@@ -86,7 +86,7 @@ describe("TopicTypeFilter", () => {
         name: filterLabel,
       });
 
-      expect(select).toHaveValue("Producer");
+      expect(select).toHaveValue("PRODUCER");
       expect(select).toHaveDisplayValue("Producer");
     });
   });
@@ -119,7 +119,7 @@ describe("TopicTypeFilter", () => {
 
       await user.selectOptions(select, option);
 
-      expect(select).toHaveValue("Consumer");
+      expect(select).toHaveValue("CONSUMER");
       expect(select).toHaveDisplayValue("Consumer");
     });
 
@@ -134,10 +134,10 @@ describe("TopicTypeFilter", () => {
 
       await user.selectOptions(select, option);
 
-      expect(select).toHaveValue("Consumer");
+      expect(select).toHaveValue("CONSUMER");
 
       await waitFor(() => {
-        expect(window.location.search).toEqual(`?topicType=Consumer&page=1`);
+        expect(window.location.search).toEqual(`?topicType=CONSUMER&page=1`);
       });
     });
   });

--- a/coral/src/app/features/components/filters/TopicTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/TopicTypeFilter.tsx
@@ -6,8 +6,8 @@ import upperFirst from "lodash/upperFirst";
 type TopicTypeForFilter = TopicType | "ALL";
 const topicTypesForFilter: TopicTypeForFilter[] = [
   "ALL",
-  "Consumer",
-  "Producer",
+  "CONSUMER",
+  "PRODUCER",
 ];
 function TopicTypeFilter() {
   const { topicType, setFilterValue } = useFiltersContext();

--- a/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
+++ b/coral/src/app/features/topics/browse/BrowseTopics.test.tsx
@@ -436,7 +436,7 @@ describe("BrowseTopics.tsx", () => {
       await userEvent.selectOptions(select, option);
 
       expect(select).toHaveDisplayValue("Consumer");
-      expect(select).toHaveValue("Consumer");
+      expect(select).toHaveValue("CONSUMER");
     });
 
     it("fetches new data when user selects 'Consumer Topics'", async () => {
@@ -451,7 +451,7 @@ describe("BrowseTopics.tsx", () => {
 
       expect(mockGetTopics).toHaveBeenNthCalledWith(2, {
         ...defaultApiParams,
-        topicType: "Consumer",
+        topicType: "CONSUMER",
       });
     });
   });

--- a/coral/src/domain/topic/topic-types.ts
+++ b/coral/src/domain/topic/topic-types.ts
@@ -20,7 +20,9 @@ type NoContent = {
   status: boolean;
 };
 
-type TopicType = "Consumer" | "Producer";
+type TopicType = NonNullable<
+  KlawApiRequestQueryParameters<"getTopics">["topicType"]
+>;
 
 type GetTopicsQueryParameter = KlawApiRequestQueryParameters<"getTopics"> & {
   topicType?: TopicType;

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -3272,7 +3272,7 @@ export type operations = {
         currentPage?: string;
         topicnamesearch?: string;
         teamId?: number;
-        topicType?: string;
+        topicType?: "PRODUCER" | "CONSUMER";
       };
     };
     responses: {

--- a/core/src/main/java/io/aiven/klaw/controller/TopicController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicController.java
@@ -230,7 +230,8 @@ public class TopicController {
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "topicnamesearch", required = false) String topicNameSearch,
       @RequestParam(value = "teamId", required = false) Integer teamId,
-      @RequestParam(value = "topicType", required = false) AclType topicType) throws KlawNotAuthorizedException {
+      @RequestParam(value = "topicType", required = false) AclType topicType)
+      throws KlawNotAuthorizedException {
 
     return new ResponseEntity<>(
         topicControllerService.getTopics(

--- a/core/src/main/java/io/aiven/klaw/controller/TopicController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicController.java
@@ -4,10 +4,7 @@ import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.error.KlawNotAuthorizedException;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.TopicInfo;
-import io.aiven.klaw.model.enums.AclPatternType;
-import io.aiven.klaw.model.enums.Order;
-import io.aiven.klaw.model.enums.RequestOperationType;
-import io.aiven.klaw.model.enums.RequestStatus;
+import io.aiven.klaw.model.enums.*;
 import io.aiven.klaw.model.requests.TopicClaimRequestModel;
 import io.aiven.klaw.model.requests.TopicCreateRequestModel;
 import io.aiven.klaw.model.requests.TopicDeleteRequestModel;
@@ -233,11 +230,16 @@ public class TopicController {
       @RequestParam(value = "currentPage", defaultValue = "") String currentPage,
       @RequestParam(value = "topicnamesearch", required = false) String topicNameSearch,
       @RequestParam(value = "teamId", required = false) Integer teamId,
-      @RequestParam(value = "topicType", required = false) String topicType) {
+      @RequestParam(value = "topicType", required = false) AclType topicType) throws KlawNotAuthorizedException {
 
     return new ResponseEntity<>(
         topicControllerService.getTopics(
-            envId, pageNo, currentPage, topicNameSearch, teamId, topicType),
+            envId,
+            pageNo,
+            currentPage,
+            topicNameSearch,
+            teamId,
+            topicType != null ? topicType.value : null),
         HttpStatus.OK);
   }
 

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -1080,7 +1080,8 @@ public class TopicControllerService {
       String currentPage,
       String topicNameSearch,
       Integer teamId,
-      String topicType) throws KlawNotAuthorizedException {
+      String topicType)
+      throws KlawNotAuthorizedException {
     log.debug("getTopics {}", topicNameSearch);
     String userName = getUserName();
     checkIsAuthorized(PermissionType.VIEW_TOPICS);

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -1080,9 +1080,10 @@ public class TopicControllerService {
       String currentPage,
       String topicNameSearch,
       Integer teamId,
-      String topicType) {
+      String topicType) throws KlawNotAuthorizedException {
     log.debug("getTopics {}", topicNameSearch);
     String userName = getUserName();
+    checkIsAuthorized(PermissionType.VIEW_TOPICS);
     List<TopicInfo> topicListUpdated =
         getTopicsPaginated(
             env,

--- a/core/src/main/resources/static/js/browseTopics.js
+++ b/core/src/main/resources/static/js/browseTopics.js
@@ -259,11 +259,11 @@ app.controller("browseTopicsCtrl", function($scope, $http, $location, $window) {
                         }
                         else if (sParameterName[0] === "producer")
                         {
-                            topicType = 'Producer';
+                            topicType = 'PRODUCER';
                         }
                         else if (sParameterName[0] === "consumer")
                         {
-                            topicType = 'Consumer';
+                            topicType = 'CONSUMER';
                         }
                     }
         }

--- a/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/TopicControllerTest.java
@@ -248,7 +248,6 @@ public class TopicControllerTest {
                 .param("pageNo", "1")
                 .param("topicnamesearch", "testtopic")
                 .param("teamId", "1001")
-                .param("topicType", "")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -904,7 +904,7 @@ public class TopicControllerServiceTest {
 
   @Test
   @Order(35)
-  public void getTopics() {
+  public void getTopics() throws KlawNotAuthorizedException {
     String envSel = "1", pageNo = "1", topicNameSearch = "top";
 
     stubUserInfo();
@@ -930,7 +930,7 @@ public class TopicControllerServiceTest {
 
   @Test
   @Order(36)
-  public void getTopicsWithProducerFilterAndEnvNoResults() {
+  public void getTopicsWithProducerFilterAndEnvNoResults() throws KlawNotAuthorizedException {
     String envSel = "2", pageNo = "1", topicNameSearch = "top";
 
     stubUserInfo();
@@ -960,7 +960,7 @@ public class TopicControllerServiceTest {
 
   @Test
   @Order(37)
-  public void getTopicsWithPatternFilter() {
+  public void getTopicsWithPatternFilter() throws KlawNotAuthorizedException {
     String envSel = "1", pageNo = "1", topicNameSearch = "toppic";
 
     stubUserInfo();
@@ -996,7 +996,7 @@ public class TopicControllerServiceTest {
   // topicSearch does not exist in topic names
   @Test
   @Order(38)
-  public void getTopicsSearchFailureNotExistingSearch() {
+  public void getTopicsSearchFailureNotExistingSearch() throws KlawNotAuthorizedException {
     String envSel = "1", pageNo = "1", topicNameSearch = "demo";
     stubUserInfo();
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
@@ -1577,7 +1577,7 @@ public class TopicControllerServiceTest {
 
   @Test
   @Order(59)
-  public void getTopicsWithProducerFilterAndEnv() {
+  public void getTopicsWithProducerFilterAndEnv() throws KlawNotAuthorizedException {
     String envSel = "1", pageNo = "1";
 
     stubUserInfo();
@@ -1607,7 +1607,7 @@ public class TopicControllerServiceTest {
 
   @Test
   @Order(60)
-  public void getTopicsWithConsumerFilterNoResults() {
+  public void getTopicsWithConsumerFilterNoResults() throws KlawNotAuthorizedException {
     String envSel = "1", pageNo = "1", topicNameSearch = "top";
 
     stubUserInfo();
@@ -1637,7 +1637,7 @@ public class TopicControllerServiceTest {
 
   @Test
   @Order(61)
-  public void getTopicsWithPatternFilterOneResult() {
+  public void getTopicsWithPatternFilterOneResult() throws KlawNotAuthorizedException {
     String envSel = "1", pageNo = "1", topicNameSearch = "2";
 
     stubUserInfo();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2822,7 +2822,8 @@
           "in" : "query",
           "required" : false,
           "schema" : {
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "PRODUCER", "CONSUMER" ]
           }
         } ],
         "responses" : {


### PR DESCRIPTION
Add the permission check and also use an enum to get the topics with producers or consumer acls you have setup.

# Linked issue

Resolves: #2216

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Uses a string

# What is the new behavior?

Uses an enum
# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
