### PR TITLE
fix(ui): Add padding for navigation.

### DIFF
--- a/core/src/main/resources/static/assets/css/style.css
+++ b/core/src/main/resources/static/assets/css/style.css
@@ -10279,7 +10279,7 @@ Layouts
 .page-wrapper {
   background: #eef5f9;
   padding-bottom: 60px;
-  padding-top: 60px;
+  padding-top: 85px;
 }
 
 /*******************

--- a/core/src/main/resources/templates/index.html
+++ b/core/src/main/resources/templates/index.html
@@ -442,7 +442,7 @@
             <!-- ============================================================== -->
             <div class="row page-titles">
                 <div class="row" ng-if="dashboardDetails.coralAvailableForUser === 'true' && userrole === 'SUPERADMIN'">
-                    <div class="ribbon-wrapper card">
+                    <div class="ribbon-wrapper card mt-4">
                         <div class="ribbon ribbon-success">Explore the new user interface</div>
                         <p class="ribbon-content">
                             You're currently logged in as superadmin. To experience the new user interface, switch to your user account.


### PR DESCRIPTION
# Linked issue

Resolves: #2224

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

When the navigation bar in Angular is a bit longer (always for admins), the navigation has a line break and overlays the page content.

# What is the new behavior?

Page content has a bit more padding to make it work with a line break in navigation. 

# Other information

There are screenshots in the issue 📷 

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
