### PR TITLE
feat(coral): Add timeframe dropdown

### DIFF
--- a/coral/src/app/features/dashboard/Dashboard.tsx
+++ b/coral/src/app/features/dashboard/Dashboard.tsx
@@ -1,17 +1,28 @@
-import { Box, Card, Grid, Icon, Template, useToast } from "@aivenio/aquarium";
+import {
+  Box,
+  Card,
+  Grid,
+  Icon,
+  NativeSelect,
+  Option,
+  Template,
+  useToast,
+} from "@aivenio/aquarium";
 import { AreaChart, Axis, BarChart, Tooltip } from "@aivenio/aquarium/charts";
 import loading from "@aivenio/aquarium/icons/loading";
 import { useEffect, useState } from "react";
 import StatsDisplay from "src/app/components/StatsDisplay";
 import { useDashboardData } from "src/app/features/dashboard/hooks/useDashboardData";
+import loadingIcon from "@aivenio/aquarium/dist/src/icons/loading";
 
 const Dashboard = () => {
+  const [numberOfDays, setNumberOfDays] = useState("30");
   const {
     data: { chartsData, statsData },
     isLoading,
     isError,
     error,
-  } = useDashboardData();
+  } = useDashboardData({ numberOfDays });
 
   const toast = useToast();
 
@@ -59,22 +70,22 @@ const Dashboard = () => {
       <Card title="Topics" fullWidth>
         <Grid cols={"4"}>
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.statsData}
             amount={statsData.totalTeamTopics}
             entity={"My team's topics"}
           />
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.statsData}
             amount={statsData.totalOrgTopics}
             entity={"My organization's topics"}
           />
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.statsData}
             amount={statsData.producerCount}
             entity={"My producer topics"}
           />
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.statsData}
             amount={statsData.consumerCount}
             entity={"My consumer topics"}
           />
@@ -83,30 +94,46 @@ const Dashboard = () => {
       <Card title="My team's pending requests" fullWidth>
         <Grid cols={"4"}>
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.pendingRequestsData}
             amount={statsData.pendingTopicRequests}
             entity={"Topic requests"}
           />
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.pendingRequestsData}
             amount={statsData.pendingAclRequests}
             entity={"ACL requests"}
           />
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.pendingRequestsData}
             amount={statsData.pendingSchemaRequests}
             entity={"Schema requests"}
           />
           <StatsDisplay
-            isLoading={isLoading}
+            isLoading={isLoading.pendingRequestsData}
             amount={statsData.pendingConnectorRequests}
             entity={"Connector requests"}
           />
         </Grid>
       </Card>
 
-      <Card title="My team's requests per day" fullWidth>
-        {isLoading || forceLoading ? (
+      <Card title="My team's approved requests" fullWidth>
+        <NativeSelect
+          labelText={"Timeframe"}
+          defaultValue={"30"}
+          value={numberOfDays}
+          onChange={(e) => setNumberOfDays(e.target.value)}
+        >
+          <Option key={"7"} value={"7"}>
+            Last 7 days <Icon icon={loadingIcon} />
+          </Option>
+          <Option key={"30"} value={"30"}>
+            Last 30 days
+          </Option>
+          <Option key={"90"} value={"90"}>
+            Last 90 days
+          </Option>
+        </NativeSelect>
+        {isLoading.chartsData || forceLoading ? (
           <Box.Flex
             justifyContent={"center"}
             alignContent={"center"}
@@ -126,7 +153,7 @@ const Dashboard = () => {
       </Card>
 
       <Card title="My team's topics per environment" fullWidth>
-        {isLoading || forceLoading ? (
+        {isLoading.chartsData || forceLoading ? (
           <Box.Flex
             justifyContent={"center"}
             alignContent={"center"}
@@ -136,11 +163,7 @@ const Dashboard = () => {
             <Icon icon={loading} fontSize={"30px"} />
           </Box.Flex>
         ) : (
-          <BarChart
-            height={250}
-            layout={"vertical"}
-            data={chartsData?.topicsPerEnv}
-          >
+          <BarChart height={250} data={chartsData?.topicsPerEnv}>
             <Axis.XAxis dataKey="environment" />
             <Axis.YAxis width={10} />
             {/* fill is --aquarium-colors-primary-100 */}

--- a/coral/src/app/features/dashboard/__snapshots__/Dasboard.test.tsx.snap
+++ b/coral/src/app/features/dashboard/__snapshots__/Dasboard.test.tsx.snap
@@ -240,11 +240,89 @@ exports[`Dashboard.tsx renders correct DOM according to data received from getRe
         <div
           class="typography-default-strong text-black"
         >
-          My team's requests per day
+          My team's approved requests
         </div>
         <div
           class="typography-caption text-grey-70"
         >
+          <div
+            class="Aquarium-NativeSelect"
+            style="display: flex; flex-direction: column;"
+          >
+            <label
+              class="w-full"
+              for="react-aria-:r0:"
+              id="react-aria-:r0:-label"
+            >
+              <span
+                class="block mb-2"
+              >
+                <span
+                  class="inline-flex items-center typography-small-strong text-grey-70"
+                >
+                  Timeframe
+                </span>
+              </span>
+              <span
+                class="Aquarium-NativeSelectBase relative block"
+              >
+                <span
+                  class="absolute right-0 inset-y-0 mr-4 text-grey-40 flex ml-3 pointer-events-none typography-default-strong mt-4"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="Aquarium-Icon"
+                    data-testid="icon-dropdown"
+                    height="1em"
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 22 22"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                  >
+                    <path
+                      d="m5.5 8.25 5.5 5.5 5.5-5.5"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="1.5"
+                    />
+                  </svg>
+                </span>
+                <select
+                  class="block w-full rounded-sm appearance-none disabled:cursor-not-allowed typography-small text-grey-70 placeholder:text-grey-40 focus:outline-none px-3 py-3 disabled:border-grey-20 disabled:bg-grey-5 disabled:text-grey-40 border border-grey-20 hover:border-grey-50 focus:border-info-70"
+                  id="react-aria-:r0:"
+                >
+                  <option
+                    value="7"
+                  >
+                    Last 7 days 
+                    <div
+                      data-icon="<g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="3" transform="translate(1 1)"><circle cx="18" cy="18" r="18" stroke-opacity=".5"/><path d="M36 18c0-9.94-8.06-18-18-18"><animateTransform attributeName="transform" dur="1s" from="0 18 18" repeatCount="indefinite" to="360 18 18" type="rotate"/></path></g>"
+                      data-testid="ds-icon"
+                    />
+                  </option>
+                  <option
+                    value="30"
+                  >
+                    Last 30 days
+                  </option>
+                  <option
+                    value="90"
+                  >
+                    Last 90 days
+                  </option>
+                </select>
+              </span>
+            </label>
+            <p
+              class="block mt-1 mb-3 typography-caption"
+            >
+               
+            </p>
+          </div>
           <div
             style="display: flex; justify-content: center; align-content: center; flex-wrap: wrap; min-height: 250px;"
           >

--- a/coral/src/app/features/dashboard/hooks/useDashboardData.ts
+++ b/coral/src/app/features/dashboard/hooks/useDashboardData.ts
@@ -46,7 +46,7 @@ export const useDashboardData = ({
         getActivityLogForTeamOverview({
           numberOfDays: Number(numberOfDays),
         }),
-      // keepPreviousData: true,
+      keepPreviousData: true,
     }
   );
 

--- a/coral/src/app/features/dashboard/hooks/useDashboardData.ts
+++ b/coral/src/app/features/dashboard/hooks/useDashboardData.ts
@@ -21,9 +21,17 @@ type DashboardData = {
   };
 };
 
-export const useDashboardData = (): {
+export const useDashboardData = ({
+  numberOfDays,
+}: {
+  numberOfDays: string;
+}): {
   data: DashboardData;
-  isLoading: boolean;
+  isLoading: {
+    chartsData: boolean;
+    statsData: boolean;
+    pendingRequestsData: boolean;
+  };
   isError: boolean;
   error: string;
 } => {
@@ -32,9 +40,13 @@ export const useDashboardData = (): {
     isLoading: isLoadingChartsData,
     isError: isErrorChartsData,
   } = useQuery<DashboardsAnalyticsData, Error>(
-    ["getActivityLogForTeamOverview"],
+    ["getActivityLogForTeamOverview", numberOfDays],
     {
-      queryFn: () => getActivityLogForTeamOverview(),
+      queryFn: () =>
+        getActivityLogForTeamOverview({
+          numberOfDays: Number(numberOfDays),
+        }),
+      // keepPreviousData: true,
     }
   );
 
@@ -73,11 +85,11 @@ export const useDashboardData = (): {
         pendingConnectorRequests: pendingRequestsData?.CONNECTOR,
       },
     },
-    isLoading:
-      isLoadingChartsData ||
-      isLoadingStatsData ||
-      isLoadingAuthUserData ||
-      isLoadingPendingRequestsData,
+    isLoading: {
+      chartsData: isLoadingChartsData,
+      statsData: isLoadingStatsData || isLoadingAuthUserData,
+      pendingRequestsData: isLoadingPendingRequestsData,
+    },
     isError:
       isErrorChartsData ||
       isErrorStatsData ||

--- a/coral/src/domain/analytics/analytics-api.ts
+++ b/coral/src/domain/analytics/analytics-api.ts
@@ -4,8 +4,10 @@ import api, { API_PATHS } from "src/services/api";
 import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
 
 const getActivityLogForTeamOverview = async (
-  params: KlawApiRequestQueryParameters<"getActivityLogForTeamOverview"> = {
-    activityLogForTeam: "true",
+  params: Omit<
+    KlawApiRequestQueryParameters<"getActivityLogForTeamOverview">,
+    "activityLogForTeam"
+  > = {
     numberOfDays: 30,
   }
 ): Promise<DashboardsAnalyticsData> => {


### PR DESCRIPTION
# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

 Currently we can't change the timeframe of the requests chart on Dashboard.
 
 Additionally, the copy is wrong, as it shows the *approved* requests.
 
# What is the new behavior?

- Add select component to show 7, 30 or 90 days worth of approved requests
- Change title of section


https://github.com/Aiven-Open/klaw/assets/20607294/6ca88d6c-968b-4438-9753-8c55867db202



# Other information

Other changes:
- Make each data point have their own loading state as opposed to one loading state for everything on dashboard
- Remove `layout="vertical"` which does nothing (yet)

# Requirements (all must be checked before review)

- [ x The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
