### PR TITLE
Reduce amount of db calls while check permissions

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
+++ b/core/src/main/java/io/aiven/klaw/config/ManageDatabase.java
@@ -83,7 +83,7 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
   private static Map<Integer, KwTenants> tenantFullMap;
 
   // key rolename, value list of permissions per tenant
-  private static Map<Integer, Map<String, List<String>>> rolesPermsMapPerTenant;
+  private static Map<Integer, Map<String, Set<String>>> rolesPermsMapPerTenant;
 
   // key tenantId, sub key clusterid Pertenant
   private static Map<Integer, Map<Integer, KwClusters>> kwAllClustersPertenant;
@@ -834,8 +834,8 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
         tenantId, allEnvs.stream().collect(Collectors.toMap(Env::getId, Function.identity())));
   }
 
-  public Map<String, List<String>> getRolesPermissionsPerTenant(int tenantId) {
-    return rolesPermsMapPerTenant.get(tenantId);
+  public Map<String, Set<String>> getRolesPermissionsPerTenant(int tenantId) {
+    return rolesPermsMapPerTenant.getOrDefault(tenantId, Collections.emptyMap());
   }
 
   public void loadRolesForAllTenants() {
@@ -855,16 +855,16 @@ public class ManageDatabase implements ApplicationContextAware, InitializingBean
 
     List<KwRolesPermissions> rolesPermsList =
         rolesPermissions.stream().filter(rolePerms -> rolePerms.getTenantId() == tenantId).toList();
-    List<String> tmpList;
-    Map<String, List<String>> rolesPermsMap = new HashMap<>();
+    Set<String> tmpSet;
+    Map<String, Set<String>> rolesPermsMap = new HashMap<>();
     for (KwRolesPermissions rolesPermission : rolesPermsList) {
       if (!rolesPermsMap.containsKey(rolesPermission.getRoleId())) {
-        tmpList = new ArrayList<>();
+        tmpSet = new HashSet<>();
       } else {
-        tmpList = rolesPermsMap.get(rolesPermission.getRoleId());
+        tmpSet = rolesPermsMap.get(rolesPermission.getRoleId());
       }
-      tmpList.add(rolesPermission.getPermission());
-      rolesPermsMap.put(rolesPermission.getRoleId(), tmpList);
+      tmpSet.add(rolesPermission.getPermission());
+      rolesPermsMap.put(rolesPermission.getRoleId(), tmpSet);
     }
     rolesPermsMapPerTenant.put(tenantId, rolesPermsMap);
   }

--- a/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -697,12 +698,12 @@ public class AclSyncControllerService {
 
   private List<String> tenantFiltering(List<String> teamList) {
     if (!commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.SYNC_BACK_SUBSCRIPTIONS)
-        || !commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_TOPICS)
-        || !commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.SYNC_SUBSCRIPTIONS)
-        || !commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.SYNC_BACK_TOPICS)) {
+        getPrincipal(),
+        Set.of(
+            PermissionType.SYNC_BACK_SUBSCRIPTIONS,
+            PermissionType.SYNC_TOPICS,
+            PermissionType.SYNC_SUBSCRIPTIONS,
+            PermissionType.SYNC_BACK_TOPICS))) {
       // tenant filtering
       int tenantId = commonUtilsService.getTenantId(getUserName());
       List<Team> teams = manageDatabase.getHandleDbRequests().getAllTeams(tenantId);

--- a/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java
@@ -175,20 +175,31 @@ public class CommonUtilsService {
   }
 
   public boolean isNotAuthorizedUser(Object principal, PermissionType permissionType) {
+    return isNotAuthorizedUser(principal, Set.of(permissionType));
+  }
+
+  public boolean isNotAuthorizedUser(Object principal, Set<PermissionType> permissionTypes) {
     try {
-      return !manageDatabase
-          .getRolesPermissionsPerTenant(getTenantId(getUserName(principal)))
-          .get(getAuthority(principal))
-          .contains(permissionType.name());
+      Set<String> existingPermissions = getPermissions(principal);
+      existingPermissions.retainAll(
+          permissionTypes.stream().map(Enum::name).collect(Collectors.toList()));
+      return existingPermissions.isEmpty();
     } catch (Exception e) {
       log.debug(
           "Error isNotAuthorizedUser / Check if role exists. {} {} {}",
           getUserName(principal),
-          permissionType.name(),
+          permissionTypes.stream().map(Enum::name).collect(Collectors.toList()),
           getAuthority(getUserName(principal)),
           e);
       return true;
     }
+  }
+
+  public Set<String> getPermissions(Object principal) {
+    return new HashSet<>(
+        manageDatabase
+            .getRolesPermissionsPerTenant(getTenantId(getUserName(principal)))
+            .get(getAuthority(principal)));
   }
 
   public static class ChartsOverviewItem<X, Y> {

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -501,7 +501,7 @@ public class MailUtils {
   private List<String> getAllUsersWithPermissionToApproveRequest(
       int tenantId, String username, Integer teamId) {
 
-    Map<String, List<String>> rolesToPermissions =
+    Map<String, Set<String>> rolesToPermissions =
         manageDatabase.getRolesPermissionsPerTenant(tenantId);
 
     Set<String> roles = new HashSet<>();

--- a/core/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
@@ -80,7 +80,7 @@ public class RolesPermissionsControllerService {
 
     Collections.sort(permsList);
 
-    Map<String, List<String>> existingPerms =
+    Map<String, Set<String>> existingPerms =
         manageDatabase.getRolesPermissionsPerTenant(commonUtilsService.getTenantId(getUserName()));
     Map<String, List<Map<String, Boolean>>> finalMap = new HashMap<>();
     List<Map<String, Boolean>> mapList;

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -586,12 +586,12 @@ public class TopicSyncControllerService {
   private List<String> tenantFilterTeams(Integer tenantId, boolean scheduledThread) {
     if (!scheduledThread
         && (!commonUtilsService.isNotAuthorizedUser(
-                getPrincipal(), PermissionType.SYNC_BACK_SUBSCRIPTIONS)
-            || !commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_TOPICS)
-            || !commonUtilsService.isNotAuthorizedUser(
-                getPrincipal(), PermissionType.SYNC_SUBSCRIPTIONS)
-            || !commonUtilsService.isNotAuthorizedUser(
-                getPrincipal(), PermissionType.SYNC_BACK_TOPICS))) {
+            getPrincipal(),
+            Set.of(
+                PermissionType.SYNC_BACK_SUBSCRIPTIONS,
+                PermissionType.SYNC_TOPICS,
+                PermissionType.SYNC_SUBSCRIPTIONS,
+                PermissionType.SYNC_BACK_TOPICS)))) {
       // tenant filtering
       if (tenantId == null) {
         tenantId = commonUtilsService.getTenantId(getUserName());

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -39,6 +39,7 @@ import io.aiven.klaw.model.response.UserInfoModelResponse;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -171,8 +172,10 @@ public class UsersTeamsControllerService {
     UserInfo existingUserInfo =
         manageDatabase.getHandleDbRequests().getUsersInfo(newUser.getUsername());
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    List<String> permissions =
-        manageDatabase.getRolesPermissionsPerTenant(tenantId).get(existingUserInfo.getRole());
+    Set<String> permissions =
+        manageDatabase
+            .getRolesPermissionsPerTenant(tenantId)
+            .getOrDefault(existingUserInfo.getRole(), Collections.emptySet());
     if (permissions != null
         && permissions.contains(PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name())) {
       if (!Objects.equals(
@@ -485,10 +488,10 @@ public class UsersTeamsControllerService {
 
     // check permissions of user to be deleted
     UserInfo existingUserInfo = manageDatabase.getHandleDbRequests().getUsersInfo(userIdToDelete);
-    List<String> permissions =
+    Set<String> permissions =
         manageDatabase
             .getRolesPermissionsPerTenant(commonUtilsService.getTenantId(getUserName()))
-            .get(existingUserInfo.getRole());
+            .getOrDefault(existingUserInfo.getRole(), Collections.emptySet());
     if (permissions != null
         && permissions.contains(PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name())) {
       // user to be deleted has superuser permissions.

--- a/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UtilControllerService.java
@@ -324,99 +324,26 @@ public class UtilControllerService implements InitializingBean {
       authenticationInfo.setKafkaconnect_clusters_count(
           "" + manageDatabase.getKafkaConnectEnvList(tenantId).size());
 
-      String canUpdatePermissions, addEditRoles;
+      final Set<String> permissions = commonUtilsService.getPermissions(getPrincipal());
+      final String canUpdatePermissions =
+          getPermission(permissions, PermissionType.UPDATE_PERMISSIONS);
+      final String addEditRoles = getPermission(permissions, PermissionType.ADD_EDIT_DELETE_ROLES);
+      final String canShutdownKw = getPermission(permissions, PermissionType.SHUTDOWN_KLAW);
+      final String syncBackTopics = getPermission(permissions, PermissionType.SYNC_BACK_TOPICS);
+      final String syncBackAcls =
+          getPermission(permissions, PermissionType.SYNC_BACK_SUBSCRIPTIONS);
+      final String addUser = getPermission(permissions, PermissionType.ADD_EDIT_DELETE_USERS);
+      final String addTeams = getPermission(permissions, PermissionType.ADD_EDIT_DELETE_TEAMS);
+      final String viewKafkaConnect = getPermission(permissions, PermissionType.VIEW_CONNECTORS);
+      final String requestTopics = getPermission(permissions, PermissionType.REQUEST_CREATE_TOPICS);
+      final String requestAcls =
+          getPermission(permissions, PermissionType.REQUEST_CREATE_SUBSCRIPTIONS);
+      final String requestSchemas =
+          getPermission(permissions, PermissionType.REQUEST_CREATE_SCHEMAS);
+      final String requestConnector =
+          getPermission(permissions, PermissionType.REQUEST_CREATE_CONNECTORS);
 
-      if (commonUtilsService.isNotAuthorizedUser(
-          getPrincipal(), PermissionType.UPDATE_PERMISSIONS)) {
-        canUpdatePermissions = "NotAuthorized";
-      } else {
-        canUpdatePermissions = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(
-          getPrincipal(), PermissionType.ADD_EDIT_DELETE_ROLES)) {
-        addEditRoles = "NotAuthorized";
-      } else {
-        addEditRoles = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      String canShutdownKw;
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.SHUTDOWN_KLAW)) {
-        canShutdownKw = "NotAuthorized";
-      } else {
-        canShutdownKw = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      String syncBackTopics, syncBackAcls, syncBackSchemas;
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.SYNC_BACK_TOPICS)) {
-        syncBackTopics = "NotAuthorized";
-      } else {
-        syncBackTopics = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(
-          userName, PermissionType.SYNC_BACK_SUBSCRIPTIONS)) {
-        syncBackAcls = "NotAuthorized";
-      } else {
-        syncBackAcls = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      String addUser, addTeams;
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_USERS)) {
-        addUser = "NotAuthorized";
-      } else {
-        addUser = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_TEAMS)) {
-        addTeams = "NotAuthorized";
-      } else {
-        addTeams = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      String viewKafkaConnect;
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.VIEW_CONNECTORS)) {
-        viewKafkaConnect = "NotAuthorized";
-      } else {
-        viewKafkaConnect = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      String requestTopics;
-      String requestAcls;
-      String requestSchemas;
-      String requestConnector;
       String requestItems;
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.REQUEST_CREATE_TOPICS)) {
-        requestTopics = "NotAuthorized";
-      } else {
-        requestTopics = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(
-          userName, PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
-        requestAcls = "NotAuthorized";
-      } else {
-        requestAcls = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.REQUEST_CREATE_SCHEMAS)) {
-        requestSchemas = "NotAuthorized";
-      } else {
-        requestSchemas = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(
-          userName, PermissionType.REQUEST_CREATE_CONNECTORS)) {
-        requestConnector = "NotAuthorized";
-      } else {
-        requestConnector = ApiResultStatus.AUTHORIZED.value;
-      }
-
       if (ApiResultStatus.AUTHORIZED.value.equals(requestTopics)
           || ApiResultStatus.AUTHORIZED.value.equals(requestAcls)
           || ApiResultStatus.AUTHORIZED.value.equals(requestSchemas)
@@ -426,44 +353,17 @@ public class UtilControllerService implements InitializingBean {
         requestItems = "NotAuthorized";
       }
 
-      String approveDeclineTopics;
-      String approveDeclineSubscriptions;
-      String approveDeclineSchemas;
-      String approveDeclineConnectors;
-      String approveDeclineOperationalReqs;
+      final String approveDeclineTopics = getPermission(permissions, PermissionType.APPROVE_TOPICS);
+      final String approveDeclineSubscriptions =
+          getPermission(permissions, PermissionType.APPROVE_SUBSCRIPTIONS);
+      final String approveDeclineSchemas =
+          getPermission(permissions, PermissionType.APPROVE_SCHEMAS);
+      final String approveDeclineConnectors =
+          getPermission(permissions, PermissionType.APPROVE_CONNECTORS);
+      final String approveDeclineOperationalReqs =
+          getPermission(permissions, PermissionType.APPROVE_OPERATIONAL_CHANGES);
 
       String approveAtleastOneRequest = "NotAuthorized";
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.APPROVE_TOPICS)) {
-        approveDeclineTopics = "NotAuthorized";
-      } else {
-        approveDeclineTopics = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.APPROVE_SUBSCRIPTIONS)) {
-        approveDeclineSubscriptions = "NotAuthorized";
-      } else {
-        approveDeclineSubscriptions = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.APPROVE_SCHEMAS)) {
-        approveDeclineSchemas = "NotAuthorized";
-      } else {
-        approveDeclineSchemas = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.APPROVE_CONNECTORS)) {
-        approveDeclineConnectors = "NotAuthorized";
-      } else {
-        approveDeclineConnectors = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(
-          userName, PermissionType.APPROVE_OPERATIONAL_CHANGES)) {
-        approveDeclineOperationalReqs = "NotAuthorized";
-      } else {
-        approveDeclineOperationalReqs = ApiResultStatus.AUTHORIZED.value;
-      }
 
       if (ApiResultStatus.AUTHORIZED.value.equals(approveDeclineTopics)
           || ApiResultStatus.AUTHORIZED.value.equals(approveDeclineSubscriptions)
@@ -492,7 +392,7 @@ public class UtilControllerService implements InitializingBean {
         }
       }
 
-      String syncTopicsAcls, syncConnectors, syncSchemas, manageConnectors;
+      String syncTopicsAcls;
 
       if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.SYNC_TOPICS)
           || commonUtilsService.isNotAuthorizedUser(userName, PermissionType.SYNC_SUBSCRIPTIONS)) {
@@ -501,41 +401,16 @@ public class UtilControllerService implements InitializingBean {
         syncTopicsAcls = ApiResultStatus.AUTHORIZED.value;
       }
 
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.SYNC_CONNECTORS)) {
-        syncConnectors = "NotAuthorized";
-      } else {
-        syncConnectors = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.MANAGE_CONNECTORS)) {
-        manageConnectors = "NotAuthorized";
-      } else {
-        manageConnectors = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.SYNC_SCHEMAS)) {
-        syncSchemas = "NotAuthorized";
-      } else {
-        syncSchemas = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.SYNC_BACK_SCHEMAS)) {
-        syncBackSchemas = "NotAuthorized";
-      } else {
-        syncBackSchemas = ApiResultStatus.AUTHORIZED.value;
-      }
+      final String syncConnectors = getPermission(permissions, PermissionType.SYNC_CONNECTORS);
+      final String manageConnectors = getPermission(permissions, PermissionType.MANAGE_CONNECTORS);
+      final String syncSchemas = getPermission(permissions, PermissionType.SYNC_SCHEMAS);
+      final String syncBackSchemas = getPermission(permissions, PermissionType.SYNC_BACK_SCHEMAS);
 
       String addDeleteEditTenants;
-      String addDeleteEditEnvs;
-      String addDeleteEditClusters;
-      String updateServerConfig, showServerConfigEnvProperties;
-      String viewTopics;
+      String showServerConfigEnvProperties;
 
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.UPDATE_SERVERCONFIG)) {
-        updateServerConfig = "NotAuthorized";
-      } else {
-        updateServerConfig = ApiResultStatus.AUTHORIZED.value;
-      }
+      final String updateServerConfig =
+          getPermission(permissions, PermissionType.UPDATE_SERVERCONFIG);
 
       if (tenantId == KwConstants.DEFAULT_TENANT_ID
           && !commonUtilsService.isNotAuthorizedUser(
@@ -552,32 +427,19 @@ public class UtilControllerService implements InitializingBean {
         addDeleteEditTenants = "NotAuthorized";
       }
 
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_ENVS)) {
-        addDeleteEditEnvs = "NotAuthorized";
-      } else {
-        addDeleteEditEnvs = ApiResultStatus.AUTHORIZED.value;
-      }
-
-      if (commonUtilsService.isNotAuthorizedUser(
-          userName, PermissionType.ADD_EDIT_DELETE_CLUSTERS)) {
-        addDeleteEditClusters = "NotAuthorized";
-      } else {
-        addDeleteEditClusters = ApiResultStatus.AUTHORIZED.value;
-      }
+      final String addDeleteEditEnvs =
+          getPermission(permissions, PermissionType.ADD_EDIT_DELETE_ENVS);
+      final String addDeleteEditClusters =
+          getPermission(permissions, PermissionType.ADD_EDIT_DELETE_CLUSTERS);
+      final String viewTopics = getPermission(permissions, PermissionType.VIEW_TOPICS);
 
       authenticationInfo.setAdAuthRoleEnabled(
           ""
               + (ACTIVE_DIRECTORY.value.equals(authenticationType)
                   && "true".equals(adAuthRoleEnabled)));
 
-      if (commonUtilsService.isNotAuthorizedUser(userName, PermissionType.VIEW_TOPICS)) {
-        viewTopics = "NotAuthorized";
-      } else {
-        viewTopics = ApiResultStatus.AUTHORIZED.value;
-      }
-
       String companyInfo = manageDatabase.getTenantFullConfig(tenantId).getOrgName();
-      if (companyInfo == null || companyInfo.equals("")) {
+      if (companyInfo == null || companyInfo.isEmpty()) {
         companyInfo = ENV_CLUSTER_TNT_109;
       }
 
@@ -591,11 +453,11 @@ public class UtilControllerService implements InitializingBean {
           manageDatabase.getKwPropertyValue(
               KwConstants.broadCastTextProperty, KwConstants.DEFAULT_TENANT_ID);
 
-      if (broadCastTextLocal != null && !broadCastTextLocal.equals("")) {
+      if (broadCastTextLocal != null && !broadCastTextLocal.isEmpty()) {
         broadCastText = "Announcement : " + broadCastTextLocal;
       }
       if (broadCastTextGlobal != null
-          && !broadCastTextGlobal.equals("")
+          && !broadCastTextGlobal.isEmpty()
           && tenantId != KwConstants.DEFAULT_TENANT_ID) {
         broadCastText += " Announcement : " + broadCastTextGlobal;
       }
@@ -671,6 +533,16 @@ public class UtilControllerService implements InitializingBean {
 
       return authenticationInfo;
     } else return null;
+  }
+
+  private static String getPermission(Set<String> permissions, PermissionType permissionType) {
+    String canUpdatePermissions;
+    if (permissions.contains(permissionType.name())) {
+      canUpdatePermissions = ApiResultStatus.AUTHORIZED.value;
+    } else {
+      canUpdatePermissions = "NotAuthorized";
+    }
+    return canUpdatePermissions;
   }
 
   public void getLogoutPage(HttpServletRequest request, HttpServletResponse response) {

--- a/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicRequestValidatorImplIT.java
@@ -76,7 +76,7 @@ public class TopicRequestValidatorImplIT {
   @Order(1)
   public void isValidTestNotAuthorizedUser() {
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     Set<ConstraintViolation<TopicCreateRequestModel>> violations =
         validator.validate(addTopicRequest);
     assertThat(violations).hasSize(1);
@@ -87,7 +87,8 @@ public class TopicRequestValidatorImplIT {
   @Order(2)
   public void isValidTestTenantFiltering() {
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn(KWUSER);
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("2"));
     Set<ConstraintViolation<TopicCreateRequestModel>> violations =
@@ -101,7 +102,8 @@ public class TopicRequestValidatorImplIT {
   @Order(3)
   public void isValidTestTopicName() {
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn(KWUSER);
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
 
@@ -126,7 +128,8 @@ public class TopicRequestValidatorImplIT {
   public void isValidTestVerifyTenantConfigExists() {
     Integer tenantId = 1;
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn(KWUSER);
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
@@ -147,7 +150,8 @@ public class TopicRequestValidatorImplIT {
     Topic topic = utilMethods.getTopic("testtopic");
 
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
@@ -174,7 +178,8 @@ public class TopicRequestValidatorImplIT {
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
     addTopicRequest.setRequestOperationType(RequestOperationType.PROMOTE);
     addTopicRequest.setEnvironment("2");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");
     when(commonUtilsService.getTeamId(anyString())).thenReturn(teamId);
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1", "2"));
@@ -215,7 +220,8 @@ public class TopicRequestValidatorImplIT {
     env.setParams(new EnvParams());
     env.getParams().setTopicPrefix(List.of(topicPrefixSuffix));
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
@@ -247,7 +253,8 @@ public class TopicRequestValidatorImplIT {
 
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
     TopicRequest topicRequest = utilMethods.getTopicRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
@@ -274,7 +281,8 @@ public class TopicRequestValidatorImplIT {
     TopicCreateRequestModel editTopicRequest = utilMethods.getTopicCreateRequestModel(1001);
     editTopicRequest.setRequestId(1010);
     TopicRequest topicRequest = utilMethods.getTopicRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
@@ -305,7 +313,8 @@ public class TopicRequestValidatorImplIT {
     editTopicRequest.setRequestId(1010);
     editTopicRequest.setRequestOperationType(RequestOperationType.DELETE);
     TopicRequest topicRequest = utilMethods.getTopicRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));
     when(commonUtilsService.getTenantId(any())).thenReturn(tenantId);
@@ -331,7 +340,8 @@ public class TopicRequestValidatorImplIT {
     topic.setEnvironment("1");
 
     TopicCreateRequestModel addTopicRequest = utilMethods.getTopicCreateRequestModel(teamId);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(topicControllerService.getUserName()).thenReturn("superadmin");
     when(commonUtilsService.getTeamId(anyString())).thenReturn(teamId);
     when(commonUtilsService.getEnvsFromUserId(any())).thenReturn(Set.of("1"));

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -1007,19 +1007,19 @@ public class UtilMethods {
     return kwClusters;
   }
 
-  public Map<String, List<String>> getRolesPermsMapForSuperuser() {
-    Map<String, List<String>> rolesPermsMap = new HashMap<>();
-    List<String> permsList =
-        List.of(
+  public Map<String, Set<String>> getRolesPermsMapForSuperuser() {
+    Map<String, Set<String>> rolesPermsMap = new HashMap<>();
+    Set<String> permsSet =
+        Set.of(
             PermissionType.ADD_EDIT_DELETE_ENVS.name(),
             PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name());
-    rolesPermsMap.put("USER", permsList);
+    rolesPermsMap.put("USER", permsSet);
     return rolesPermsMap;
   }
 
-  public Map<String, List<String>> getRolesPermsMapForNormalUser() {
-    Map<String, List<String>> rolesPermsMap = new HashMap<>();
-    List<String> permsList = new ArrayList<>();
+  public Map<String, Set<String>> getRolesPermsMapForNormalUser() {
+    Map<String, Set<String>> rolesPermsMap = new HashMap<>();
+    Set<String> permsList = new HashSet<>();
     rolesPermsMap.put("USER", permsList);
     return rolesPermsMap;
   }

--- a/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclControllerServiceTest.java
@@ -33,6 +33,7 @@ import io.aiven.klaw.model.enums.AclPatternType;
 import io.aiven.klaw.model.enums.AclType;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.KafkaFlavors;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.AclRequestsModel;
@@ -200,7 +201,7 @@ public class AclControllerServiceTest {
     AclRequests aclRequestsDao = new AclRequests();
     AclRequestsModel aclRequests = getAclRequestProducer();
     copyProperties(aclRequests, aclRequestsDao);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     stubUserInfo();
 
     ApiResponse resultResp = aclControllerService.createAcl(aclRequests);
@@ -419,7 +420,7 @@ public class AclControllerServiceTest {
             any(),
             anyInt()))
         .thenReturn(getAclRequests("testtopic", 16));
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(manageDatabase.getTeamNameFromTeamId(anyInt(), anyInt())).thenReturn(teamName);
@@ -454,7 +455,7 @@ public class AclControllerServiceTest {
   @Order(14)
   public void deleteAclRequestsNotAuthorized() throws KlawException {
     String req_no = "1001";
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     ApiResponse result = aclControllerService.deleteAclRequests(req_no);
     assertThat(result.getMessage()).isEqualTo(ApiResultStatus.NOT_AUTHORIZED.value);
   }
@@ -463,7 +464,7 @@ public class AclControllerServiceTest {
   @Order(14)
   public void deleteAclRequestsNotRequestOwner() throws KlawException {
     String req_no = "1001";
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     ApiResponse result = aclControllerService.deleteAclRequests(req_no);
     assertThat(result.getMessage()).isEqualTo(ApiResultStatus.NOT_AUTHORIZED.value);
   }
@@ -542,7 +543,7 @@ public class AclControllerServiceTest {
   @Order(18)
   public void approveAclRequestsNotAuthorized() throws KlawException, KlawBadRequestException {
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     ApiResponse apiResp = aclControllerService.approveAclRequests("112");
     assertThat(apiResp.getMessage()).isEqualTo(ApiResultStatus.NOT_AUTHORIZED.value);
   }

--- a/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
@@ -28,6 +28,7 @@ import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.KafkaFlavors;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.model.enums.PermissionType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -95,7 +96,8 @@ public class AclSyncControllerServiceTest {
   public void updateSyncAcls() throws KlawException {
     stubUserInfo();
     when(handleDbRequests.addToSyncacls(anyList())).thenReturn(ApiResultStatus.SUCCESS.value);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
 
@@ -108,7 +110,8 @@ public class AclSyncControllerServiceTest {
   @Order(2)
   public void updateSyncAclsFailure1() throws KlawException {
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     ApiResponse resultResp =
         aclSyncControllerService.updateSyncAcls(utilMethods.getSyncAclsUpdates());
@@ -119,7 +122,8 @@ public class AclSyncControllerServiceTest {
   @Order(3)
   public void updateSyncAclsFailure2() {
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.addToSyncacls(anyList())).thenThrow(new RuntimeException("Error"));
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -136,7 +140,8 @@ public class AclSyncControllerServiceTest {
   public void updateSyncAclsFailure3() throws KlawException {
     List<SyncAclUpdates> updates = new ArrayList<>();
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
     ApiResponse resultResp = aclSyncControllerService.updateSyncAcls(updates);
@@ -148,7 +153,8 @@ public class AclSyncControllerServiceTest {
   public void updateSyncAclsFailure4() {
     when(handleDbRequests.addToSyncacls(anyList())).thenThrow(new RuntimeException("Error"));
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
 
@@ -318,7 +324,8 @@ public class AclSyncControllerServiceTest {
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getKafkaFlavor()).thenReturn(KafkaFlavors.AIVEN_FOR_APACHE_KAFKA.value);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getSyncAclsFromReqNo(anyInt(), anyInt()))
         .thenReturn(getAclsSOT0().get(0));
     when(clusterApiService.approveAclRequests(any(), anyInt()))

--- a/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/EnvsClustersTenantsControllerServiceTest.java
@@ -20,6 +20,7 @@ import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.EntityType;
 import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.requests.EnvModel;
 import io.aiven.klaw.model.response.EnvModelResponse;
 import io.aiven.klaw.model.response.EnvParams;
@@ -275,7 +276,8 @@ class EnvsClustersTenantsControllerServiceTest {
                 put(101, "");
               }
             });
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     List<EnvModelResponse> response = service.getEnvsPaginated(type, "", pageNo, searchBy);
 

--- a/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
@@ -26,6 +26,7 @@ import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.KwTenantConfigModel;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.PromotionStatusType;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
@@ -126,7 +127,8 @@ public class KafkaConnectControllerServiceTest {
     resultMap.put("result", ApiResultStatus.SUCCESS.value);
 
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(TENANT_ID);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncKafkaConnectCluster()).thenReturn("1");
@@ -153,7 +155,8 @@ public class KafkaConnectControllerServiceTest {
     KafkaConnectorRequestModel kafkaConnectorRequestModel = getConnectRequestModel();
     kafkaConnectorRequestModel.setConnectorConfig("plain string"); // Invalid json
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.requestForConnector(any()))
         .thenThrow(new RuntimeException("Unrecognized token"));
 
@@ -170,7 +173,8 @@ public class KafkaConnectControllerServiceTest {
     KafkaConnectorRequestModel kafkaConnectorRequestModel = getConnectRequestModel();
     kafkaConnectorRequestModel.setConnectorConfig(getInvalidValidConnConfig());
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     ApiResponse apiResponse =
         kafkaConnectControllerService.createConnectorRequest(kafkaConnectorRequestModel);
@@ -185,7 +189,8 @@ public class KafkaConnectControllerServiceTest {
     KafkaConnectorRequestModel kafkaConnectorRequestModel = getConnectRequestModel();
     kafkaConnectorRequestModel.setConnectorConfig(getInvalidValidConnConfigTopicsTopicsRegex());
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     ApiResponse apiResponse =
         kafkaConnectControllerService.createConnectorRequest(kafkaConnectorRequestModel);
@@ -199,7 +204,8 @@ public class KafkaConnectControllerServiceTest {
     Set<String> envListIds = new HashSet<>();
     envListIds.add("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
     when(handleDbRequests.getConnectorsFromName(eq("ConnectorOne"), eq(TENANT_ID)))
         .thenReturn(List.of(getKwKafkaConnector()));
@@ -221,7 +227,8 @@ public class KafkaConnectControllerServiceTest {
     Set<String> envListIds = new HashSet<>();
     envListIds.add("DEV");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
     when(handleDbRequests.existsConnectorRequest(
             "ConnectorOne", "1", RequestStatus.CREATED.value, TENANT_ID))
@@ -240,7 +247,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -283,7 +291,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -326,7 +335,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -370,7 +380,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -414,7 +425,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     List<KafkaConnectorRequest> connectorRequests = generateKafkaConnectorRequests(9);
     connectorRequests.addAll(generateKafkaConnectorRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllConnectorRequests(
@@ -461,7 +473,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     List<KafkaConnectorRequest> connectorRequests = generateKafkaConnectorRequests(9);
     connectorRequests.addAll(generateKafkaConnectorRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllConnectorRequests(
@@ -511,7 +524,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -528,7 +542,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -573,7 +588,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -605,7 +621,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -638,7 +655,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -672,7 +690,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -756,7 +775,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -790,7 +810,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -834,7 +855,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -875,7 +897,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -900,7 +923,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -930,7 +954,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -980,7 +1005,8 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));

--- a/core/src/test/java/io/aiven/klaw/service/KafkaConnectSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/KafkaConnectSyncControllerServiceTest.java
@@ -23,6 +23,7 @@ import io.aiven.klaw.model.cluster.ConnectorsStatus;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.KafkaConnectorModelResponse;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -133,7 +134,8 @@ public class KafkaConnectSyncControllerServiceTest {
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(manageDatabase.getKafkaConnectEnvList(anyInt())).thenReturn(List.of(env));

--- a/core/src/test/java/io/aiven/klaw/service/MailUtilsTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/MailUtilsTest.java
@@ -13,9 +13,9 @@ import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
 import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.service.MailUtils.MailType;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -329,20 +329,15 @@ public class MailUtilsTest {
     return Stream.of(MailType.CONNECTOR_CLAIM_REQUESTED, MailType.TOPIC_CLAIM_REQUESTED);
   }
 
-  private Map<String, List<String>> getRolesToPermissionsMap() {
+  private Map<String, Set<String>> getRolesToPermissionsMap() {
 
-    List<String> user = List.of(PermissionType.APPROVE_TOPICS.name());
+    Set<String> user = Set.of(PermissionType.APPROVE_TOPICS.name());
 
-    List<String> admin =
-        List.of(
+    Set<String> admin =
+        Set.of(
             PermissionType.APPROVE_TOPICS.name(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS.name());
 
-    return new HashMap<>() {
-      {
-        put("USER", user);
-        put("ADMIN", admin);
-      }
-    };
+    return Map.of("USER", user, "ADMIN", admin);
   }
 
   private static UserInfo createUserInfo(String username, String role) {

--- a/core/src/test/java/io/aiven/klaw/service/OperationalRequestsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/OperationalRequestsServiceTest.java
@@ -24,6 +24,7 @@ import io.aiven.klaw.model.cluster.consumergroup.OffsetResetType;
 import io.aiven.klaw.model.cluster.consumergroup.OffsetsTiming;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.OperationalRequestType;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.ConsumerOffsetResetRequestModel;
 import java.util.ArrayList;
@@ -109,7 +110,8 @@ public class OperationalRequestsServiceTest {
   public void createConsumerOffsetsResetRequestDoesNotOwnGroup() throws KlawNotAuthorizedException {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     ApiResponse apiResponse =
         operationalRequestsService.createConsumerOffsetsResetRequest(
@@ -123,7 +125,8 @@ public class OperationalRequestsServiceTest {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
     consumerOffsetResetRequestModel.setOffsetResetType(OffsetResetType.TO_DATE_TIME);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt(), anyString(), anyInt()))
         .thenReturn(utilMethods.getAcls());
     when(commonUtilsService.getEnvDetails(anyString(), anyInt())).thenReturn(env);
@@ -138,7 +141,8 @@ public class OperationalRequestsServiceTest {
   public void createRequestWhichAlreadyExists() throws KlawNotAuthorizedException {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt(), anyString(), anyInt()))
         .thenReturn(utilMethods.getAcls());
     when(commonUtilsService.getEnvDetails(anyString(), anyInt())).thenReturn(env);
@@ -165,7 +169,8 @@ public class OperationalRequestsServiceTest {
   public void createRequestSuccess() throws KlawNotAuthorizedException {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt(), anyString(), anyInt()))
         .thenReturn(utilMethods.getAcls());
     when(commonUtilsService.getEnvDetails(anyString(), anyInt())).thenReturn(env);
@@ -198,7 +203,8 @@ public class OperationalRequestsServiceTest {
         UtilMethods.getOffsetsTimingMapMap();
     ApiResponse apiResponse =
         ApiResponse.builder().success(true).data(offsetPositionsBeforeAndAfter).build();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getCurrentUserName()).thenReturn("testuser");
     when(handleDbRequests.getOperationalRequest(anyInt(), anyInt())).thenReturn(getReqs().get(0));
@@ -214,7 +220,8 @@ public class OperationalRequestsServiceTest {
   @Order(6)
   public void approveOperationalRequestsFailure() throws KlawException {
     ApiResponse apiResponse = ApiResponse.builder().success(false).build();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getCurrentUserName()).thenReturn("testuser");
     when(handleDbRequests.getOperationalRequest(anyInt(), anyInt())).thenReturn(getReqs().get(0));

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistryControllerServiceTest.java
@@ -223,7 +223,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     ApiResponse resultResp = schemaRegistryControllerService.execSchemaRequests("" + schemaReqId);
     assertThat(resultResp.isSuccess()).isTrue();
@@ -251,7 +252,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     ApiResponse resultResp = schemaRegistryControllerService.execSchemaRequests("" + schemaReqId);
     assertThat(resultResp.getMessage()).contains("Schema not registered");
@@ -284,7 +286,8 @@ public class SchemaRegistryControllerServiceTest {
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     try {
       schemaRegistryControllerService.execSchemaRequests("" + schemaReqId);
@@ -307,7 +310,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     mockGetEnvironment();
     when(manageDatabase.getEnv(eq(101), eq(1))).thenReturn(Optional.of(createEnv(1)));
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.requestForSchema(any())).thenReturn(ApiResultStatus.SUCCESS.value);
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(topic));
@@ -327,7 +331,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.requestForSchema(any()))
         .thenThrow(new RuntimeException("Error from schema upload"));
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
@@ -509,7 +514,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     mockGetEnvironment();
     when(manageDatabase.getEnv(eq(101), eq(1))).thenReturn(Optional.of(createEnv(1)));
 
@@ -613,7 +619,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.requestForSchema(any())).thenReturn(ApiResultStatus.SUCCESS.value);
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(topic));
@@ -643,7 +650,8 @@ public class SchemaRegistryControllerServiceTest {
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     mockGetEnvironment();
     when(manageDatabase.getEnv(eq(101), eq(1))).thenReturn(Optional.of(createEnv(1)));
 

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistrySyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistrySyncControllerServiceTest.java
@@ -27,6 +27,7 @@ import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.SyncSchemaUpdates;
 import io.aiven.klaw.model.cluster.SchemasInfoOfClusterResponse;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.SchemaDetailsResponse;
 import io.aiven.klaw.model.response.SchemaSubjectInfoResponse;
 import io.aiven.klaw.model.response.SyncSchemasList;
@@ -123,7 +124,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
@@ -157,7 +159,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
@@ -217,7 +220,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     List<Topic> topics = utilMethods.generateTopics(14);
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
 
@@ -248,7 +252,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     List<Topic> topics = utilMethods.generateTopics(14);
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
 
@@ -282,7 +287,8 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
 
     when(clusterApiService.getAvroSchema(anyString(), any(), anyString(), anyString(), anyInt()))
@@ -324,7 +330,8 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
 
     when(clusterApiService.getAvroSchema(anyString(), any(), anyString(), anyString(), anyInt()))
@@ -381,7 +388,8 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
     when(clusterApiService.getAvroSchema(anyString(), any(), anyString(), anyString(), anyInt()))
         .thenReturn(utilMethods.createSchemaList());
@@ -408,7 +416,8 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     MessageSchema schema = utilMethods.getMSchemas().get(0);
     schema.setTopicname(topicName);
     schema.setSchemafull("\"namespace : klaw.avro\"");
@@ -444,7 +453,8 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
 
     when(clusterApiService.getAvroSchema(anyString(), any(), anyString(), anyString(), anyInt()))
@@ -482,7 +492,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
@@ -526,7 +537,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(3))).thenReturn("Team1");
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
@@ -577,7 +589,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     clusterResp.setSchemaInfoOfTopicList(new ArrayList<>());
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(3))).thenReturn("Team1");
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
@@ -629,7 +642,8 @@ public class SchemaRegistrySyncControllerServiceTest {
     SchemasInfoOfClusterResponse clusterResp = new SchemasInfoOfClusterResponse();
     clusterResp.setSchemaInfoOfTopicList(new ArrayList<>());
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
     assertThatThrownBy(

--- a/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
@@ -24,6 +24,7 @@ import io.aiven.klaw.model.TenantConfig;
 import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.ClusterStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.KwPropertiesResponse;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,7 +78,7 @@ public class ServerConfigServiceTest {
   @Test
   @Order(1)
   public void getAllPropsNotAuthorized() {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     serverConfigService.getAllProperties();
     Collection<ServerConfigProperties> collection = serverConfigService.getAllProps();
     assertThat(collection).isEmpty(); // filtering for spring. and klaw.
@@ -86,7 +87,8 @@ public class ServerConfigServiceTest {
   @Test
   @Order(2)
   public void getAllProps() {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     serverConfigService.getAllProperties();
     Collection<ServerConfigProperties> collection = serverConfigService.getAllProps();
     assertThat(collection).isEmpty(); // filtering for spring. and klaw.

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -139,7 +139,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -161,7 +162,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -185,7 +187,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -205,7 +208,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvListsIncorrect1());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -223,7 +227,7 @@ public class TopicControllerServiceTest {
   public void createTopicDeleteRequestFailureNotAuthorized() throws KlawNotAuthorizedException {
     String topicName = "testtopic1";
     String envId = "1";
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
 
     assertThrows(
         KlawNotAuthorizedException.class,
@@ -237,7 +241,8 @@ public class TopicControllerServiceTest {
   public void createTopicDeleteRequestFailureTopicAlreadyExists() {
     String topicName = "testtopic1";
     String envId = "1";
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(getListTopicRequests());
@@ -259,7 +264,8 @@ public class TopicControllerServiceTest {
     String topicName = "testtopic1";
     String envId = "1";
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -285,7 +291,8 @@ public class TopicControllerServiceTest {
     String envId = "1";
     stubUserInfo();
     when(commonUtilsService.getTeamId(anyString())).thenReturn(1);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -311,7 +318,8 @@ public class TopicControllerServiceTest {
     String envId = "2";
     stubUserInfo();
     when(userInfo.getTeamId()).thenReturn(1);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -337,7 +345,8 @@ public class TopicControllerServiceTest {
     String envId = "1";
     stubUserInfo();
     when(commonUtilsService.getTeamId(anyString())).thenReturn(1);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -636,7 +645,8 @@ public class TopicControllerServiceTest {
     when(handleDbRequests.deleteTopicRequest(anyInt(), anyString(), anyInt()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(mailService.getUserName(any())).thenReturn("uiuser1");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     ApiResponse resultResp = topicControllerService.deleteTopicRequests("1001");
     assertThat(resultResp.getMessage()).isEqualTo(ApiResultStatus.SUCCESS.value);
   }
@@ -1019,7 +1029,8 @@ public class TopicControllerServiceTest {
 
     stubUserInfo();
     when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(handleDbRequests.declineTopicRequest(any(), anyString()))
@@ -1039,7 +1050,8 @@ public class TopicControllerServiceTest {
 
     stubUserInfo();
     when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.declineTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     ApiResponse resultResp = topicControllerService.declineTopicRequests(topicId + "", "Reason");
@@ -1100,7 +1112,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1122,7 +1135,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1146,7 +1160,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1166,7 +1181,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvListsIncorrect1());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1301,7 +1317,8 @@ public class TopicControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     List<TopicRequest> topicRequests = generateRequests(9);
     topicRequests.addAll(generateRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllTopicRequests(
@@ -1348,7 +1365,8 @@ public class TopicControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     List<TopicRequest> topicRequests = generateRequests(9);
     topicRequests.addAll(generateRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllTopicRequests(
@@ -1484,7 +1502,8 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));

--- a/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
@@ -30,6 +30,7 @@ import io.aiven.klaw.model.enums.ApiResultStatus;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.KafkaFlavors;
 import io.aiven.klaw.model.enums.KafkaSupportedProtocol;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.EnvParams;
 import io.aiven.klaw.model.response.SyncTopicsList;
 import io.aiven.klaw.model.response.TopicConfig;
@@ -198,7 +199,8 @@ public class TopicSyncControllerServiceTest {
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
     when(handleDbRequests.addToSynctopics(any()))
@@ -219,7 +221,8 @@ public class TopicSyncControllerServiceTest {
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
 

--- a/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
@@ -12,6 +12,7 @@ import io.aiven.klaw.dao.KwClusters;
 import io.aiven.klaw.dao.UserInfo;
 import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
 import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.requests.EnvModel;
 import io.aiven.klaw.model.response.EnvModelResponse;
 import java.util.ArrayList;
@@ -98,7 +99,8 @@ public class UiConfigControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.getEnvProperty(anyInt(), anyString())).thenReturn("1");
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(getAllEnvs());
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(manageDatabase.getTenantMap()).thenReturn(tenantMap);
     when(tenantMap.get(anyInt())).thenReturn("1");
     when(manageDatabase.getClusters(any(KafkaClustersType.class), anyInt()))
@@ -115,7 +117,8 @@ public class UiConfigControllerServiceTest {
   @Order(4)
   public void getSchemaRegEnvs() {
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
 
     when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());
     List<EnvModelResponse> envsList = envsClustersTenantsControllerService.getSchemaRegEnvs();

--- a/core/src/test/java/io/aiven/klaw/service/UiControllerLoginServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UiControllerLoginServiceTest.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.catalina.connector.Response;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -256,7 +257,7 @@ class UiControllerLoginServiceTest {
     Mockito.when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequestsJdbc);
     Mockito.when(handleDbRequestsJdbc.getUsersInfo(TestConstants.USERNAME)).thenReturn(null);
     Mockito.when(manageDatabase.getRolesPermissionsPerTenant(KwConstants.DEFAULT_TENANT_ID))
-        .thenReturn(Map.of(TestConstants.ROLE, List.of(TestConstants.PERMISSION)));
+        .thenReturn(Map.of(TestConstants.ROLE, Set.of(TestConstants.PERMISSION)));
     Mockito.when(handleDbRequestsJdbc.getRegistrationId(TestConstants.USERNAME)).thenReturn(null);
     Mockito.when(
             manageDatabase.getTeamIdFromTeamName(
@@ -293,7 +294,7 @@ class UiControllerLoginServiceTest {
     Mockito.when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequestsJdbc);
     Mockito.when(handleDbRequestsJdbc.getUsersInfo(TestConstants.USERNAME)).thenReturn(null);
     Mockito.when(manageDatabase.getRolesPermissionsPerTenant(KwConstants.DEFAULT_TENANT_ID))
-        .thenReturn(Map.of(TestConstants.ROLE, List.of(TestConstants.PERMISSION)));
+        .thenReturn(Map.of(TestConstants.ROLE, Set.of(TestConstants.PERMISSION)));
 
     String actual =
         uiControllerLoginService.checkAnonymousLogin(
@@ -317,7 +318,7 @@ class UiControllerLoginServiceTest {
     Mockito.when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequestsJdbc);
     Mockito.when(handleDbRequestsJdbc.getUsersInfo(TestConstants.USERNAME)).thenReturn(null);
     Mockito.when(manageDatabase.getRolesPermissionsPerTenant(KwConstants.DEFAULT_TENANT_ID))
-        .thenReturn(Map.of(TestConstants.ROLE, List.of(TestConstants.PERMISSION)));
+        .thenReturn(Map.of(TestConstants.ROLE, Set.of(TestConstants.PERMISSION)));
 
     String actual =
         uiControllerLoginService.checkAnonymousLogin(

--- a/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
@@ -18,6 +18,7 @@ import io.aiven.klaw.error.KlawNotAuthorizedException;
 import io.aiven.klaw.helpers.db.rdbms.HandleDbRequestsJdbc;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.enums.ApiResultStatus;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.requests.ProfileModel;
 import io.aiven.klaw.model.requests.UserInfoModel;
 import io.aiven.klaw.model.response.ResetPasswordInfo;
@@ -116,7 +117,7 @@ public class UsersTeamsControllerServiceTest {
   @Test
   void updateUserNotAuthorized() throws KlawException {
     UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     ApiResponse apiResponse = usersTeamsControllerService.updateUser(userInfoModel);
     assertThat(apiResponse.getMessage()).isEqualTo(ApiResultStatus.NOT_AUTHORIZED.value);
   }
@@ -124,7 +125,8 @@ public class UsersTeamsControllerServiceTest {
   @Test
   void updateUserNotAuthorizedToUpdateSuperAdmin() throws KlawException {
     UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");
@@ -245,7 +247,8 @@ public class UsersTeamsControllerServiceTest {
     when(mailService.getUserName(any())).thenReturn("testuser");
     when(commonUtilsService.getTenantId(anyString())).thenReturn(tenantId);
     when(manageDatabase.getTeamObjForTenant(tenantId)).thenReturn(utilMethods.getTeams());
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.existsComponentsCountForTeam(teamId, tenantId)).thenReturn(false);
     when(handleDbRequests.existsUsersInfoForTeam(teamId, tenantId)).thenReturn(false);
     List<TeamModelResponse> teams = usersTeamsControllerService.getAllTeamsSU();
@@ -260,7 +263,8 @@ public class UsersTeamsControllerServiceTest {
   void deleteTeamFailure() throws KlawException {
     int teamId = 101;
     int tenantId = 101;
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(tenantId);
     when(mailService.getUserName(any())).thenReturn("testuser");
@@ -274,7 +278,8 @@ public class UsersTeamsControllerServiceTest {
 
   @Test
   void deleteUserFailureHasRequests() throws KlawException {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");
@@ -287,8 +292,9 @@ public class UsersTeamsControllerServiceTest {
   }
 
   @Test
-  void deleteUserSuccessSuperUser() throws KlawException {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+  void deleteUserFailureisAdmin() throws KlawException {
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");
@@ -301,7 +307,7 @@ public class UsersTeamsControllerServiceTest {
 
   @Test
   void deleteUserSuccessNormalUser() throws KlawException {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(false);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");
@@ -314,7 +320,7 @@ public class UsersTeamsControllerServiceTest {
 
   @Test
   void deleteUserFailureNoSuperUserPermission() throws KlawException {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(false, true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(false, true);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");
@@ -326,7 +332,7 @@ public class UsersTeamsControllerServiceTest {
 
   @Test
   void deleteUserFailureNoDeletionPermission() throws KlawException {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any())).thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");

--- a/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
@@ -307,7 +307,8 @@ public class UsersTeamsControllerServiceTest {
 
   @Test
   void deleteUserSuccessNormalUser() throws KlawException {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");
@@ -320,7 +321,8 @@ public class UsersTeamsControllerServiceTest {
 
   @Test
   void deleteUserFailureNoSuperUserPermission() throws KlawException {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(false, true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false, true);
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getUserName(any())).thenReturn("testuser");


### PR DESCRIPTION
The current issue with `isNotAuthorizedUser` is that it goes each time to db

the idea of this optimization especially for the code like that
```java
if (!commonUtilsService.isNotAuthorizedUser(
            getPrincipal(), PermissionType.SYNC_BACK_SUBSCRIPTIONS)
        || !commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_TOPICS)
        || !commonUtilsService.isNotAuthorizedUser(
            getPrincipal(), PermissionType.SYNC_SUBSCRIPTIONS)
        || !commonUtilsService.isNotAuthorizedUser(
            getPrincipal(), PermissionType.SYNC_BACK_TOPICS)) {
...
```
retrieve permisions for current pricipal and then check against them instead of going to db for each check