### PR TITLE
User deletion with admin permissions

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -317,7 +317,7 @@ public class MailUtils {
         });
   }
 
-  private void sendMail(
+  protected void sendMail(
       String username,
       HandleDbRequests dbHandle,
       String formattedStr,

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -23,6 +23,8 @@ import io.aiven.klaw.model.enums.EntityType;
 import io.aiven.klaw.model.enums.MetadataOperationType;
 import io.aiven.klaw.model.enums.NewUserStatus;
 import io.aiven.klaw.model.enums.PermissionType;
+import io.aiven.klaw.model.enums.RequestEntityType;
+import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.requests.ChangePasswordRequestModel;
 import io.aiven.klaw.model.requests.ProfileModel;
 import io.aiven.klaw.model.requests.RegisterUserInfoModel;
@@ -479,6 +481,7 @@ public class UsersTeamsControllerService {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
+    // check permissions of user to be deleted
     UserInfo existingUserInfo = manageDatabase.getHandleDbRequests().getUsersInfo(userIdToDelete);
     List<String> permissions =
         manageDatabase
@@ -486,7 +489,12 @@ public class UsersTeamsControllerService {
             .get(existingUserInfo.getRole());
     if (permissions != null
         && permissions.contains(PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name())) {
-      return ApiResponse.notOk(TEAMS_ERR_106);
+      // user to be deleted has superuser permissions.
+      // check if you (logged in user who is deleting) have superuser permissions to delete user
+      if (commonUtilsService.isNotAuthorizedUser(
+          getPrincipal(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES)) {
+        return ApiResponse.notOk(TEAMS_ERR_106);
+      }
     }
 
     if (manageDatabase
@@ -505,6 +513,27 @@ public class UsersTeamsControllerService {
       if (result.equals(ApiResultStatus.SUCCESS.value)) {
         commonUtilsService.updateMetadata(
             tenantId, EntityType.USERS, MetadataOperationType.DELETE, userIdToDelete);
+        manageDatabase
+            .getHandleDbRequests()
+            .insertIntoActivityLog(
+                RequestEntityType.USER.value,
+                tenantId,
+                RequestOperationType.DELETE.value,
+                commonUtilsService.getTeamId(userName),
+                "User deletion : " + userIdToDelete + " by user : " + userName,
+                "-NA-",
+                userName);
+        mailService.sendMail(
+            userName,
+            manageDatabase.getHandleDbRequests(),
+            "Hello, user " + userIdToDelete + " deleted by user " + userName + ".",
+            "USER DELETION",
+            false,
+            false,
+            mailService.getEmailAddressFromUsername(userIdToDelete),
+            tenantId,
+            commonUtilsService.getLoginUrl(),
+            false);
       }
       return ApiResultStatus.SUCCESS.value.equals(result)
           ? ApiResponse.ok(result)

--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -1007,12 +1007,19 @@ public class UtilMethods {
     return kwClusters;
   }
 
-  public Map<String, List<String>> getRolesPermsMap() {
+  public Map<String, List<String>> getRolesPermsMapForSuperuser() {
     Map<String, List<String>> rolesPermsMap = new HashMap<>();
     List<String> permsList =
         List.of(
             PermissionType.ADD_EDIT_DELETE_ENVS.name(),
             PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name());
+    rolesPermsMap.put("USER", permsList);
+    return rolesPermsMap;
+  }
+
+  public Map<String, List<String>> getRolesPermsMapForNormalUser() {
+    Map<String, List<String>> rolesPermsMap = new HashMap<>();
+    List<String> permsList = new ArrayList<>();
     rolesPermsMap.put("USER", permsList);
     return rolesPermsMap;
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9373,9 +9373,15 @@
           },
           "googleFeedbackFormLink" : {
             "type" : "string"
+          },
+          "klawOptionalPermissionNewTopicCreationEnabled" : {
+            "type" : "string"
+          },
+          "klawOptionalPermissionNewTopicCreation" : {
+            "type" : "string"
           }
         },
-        "required" : [ "adAuthRoleEnabled", "addDeleteEditClusters", "addDeleteEditEnvs", "addEditRoles", "addTeams", "addUser", "approveAtleastOneRequest", "approveDeclineConnectors", "approveDeclineOperationalReqs", "approveDeclineSchemas", "approveDeclineSubscriptions", "approveDeclineTopics", "authenticationType", "broadcastText", "canShutdownKw", "canSwitchTeams", "canUpdatePermissions", "companyinfo", "contextPath", "coralAvailableForUser", "coralEnabled", "googleFeedbackFormLink", "kafka_clusters_count", "kafkaconnect_clusters_count", "klawversion", "manageConnectors", "myOrgTopics", "myteamtopics", "notifications", "notificationsAcls", "notificationsConnectors", "notificationsSchemas", "notificationsUsers", "pendingApprovalsRedirectionPage", "requestItems", "saasEnabled", "schema_clusters_count", "showAddDeleteTenants", "showServerConfigEnvProperties", "supportlink", "syncBackAcls", "syncBackSchemas", "syncBackTopics", "syncConnectors", "syncSchemas", "syncTopicsAcls", "teamId", "teamname", "teamsize", "tenantActiveStatus", "tenantName", "updateServerConfig", "username", "userrole", "viewKafkaConnect", "viewTopics" ]
+        "required" : [ "adAuthRoleEnabled", "addDeleteEditClusters", "addDeleteEditEnvs", "addEditRoles", "addTeams", "addUser", "approveAtleastOneRequest", "approveDeclineConnectors", "approveDeclineOperationalReqs", "approveDeclineSchemas", "approveDeclineSubscriptions", "approveDeclineTopics", "authenticationType", "broadcastText", "canShutdownKw", "canSwitchTeams", "canUpdatePermissions", "companyinfo", "contextPath", "coralAvailableForUser", "coralEnabled", "googleFeedbackFormLink", "kafka_clusters_count", "kafkaconnect_clusters_count", "klawOptionalPermissionNewTopicCreation", "klawOptionalPermissionNewTopicCreationEnabled", "klawversion", "manageConnectors", "myOrgTopics", "myteamtopics", "notifications", "notificationsAcls", "notificationsConnectors", "notificationsSchemas", "notificationsUsers", "pendingApprovalsRedirectionPage", "requestItems", "saasEnabled", "schema_clusters_count", "showAddDeleteTenants", "showServerConfigEnvProperties", "supportlink", "syncBackAcls", "syncBackSchemas", "syncBackTopics", "syncConnectors", "syncSchemas", "syncTopicsAcls", "teamId", "teamname", "teamsize", "tenantActiveStatus", "tenantName", "updateServerConfig", "username", "userrole", "viewKafkaConnect", "viewTopics" ]
       },
       "KwPropertiesResponse" : {
         "properties" : {


### PR DESCRIPTION
# Linked issue

Resolves: #2122

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._
Currently it is not possible to delete a user who has super user permissions.


# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

- remove check for superuser permission while deleting
- only user with permission FULL_ACCESS_USERS_TEAMS_ROLES can delete other user with FULL_ACCESS_USERS_TEAMS_ROLES
- send mail to both the users (removed user and removed by), and klaw admin
- audit log

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
