### PR TITLE
feat(coral): Add routes and domain for Add new clusters

### DIFF
--- a/coral/src/app/context-provider/AuthProvider.tsx
+++ b/coral/src/app/context-provider/AuthProvider.tsx
@@ -58,11 +58,11 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   // SUPERADMIN does not have access to coral, so we show a reduced page with
   // information about that and nothing else.
-  // if (!isLoading && authUser && isSuperAdmin(authUser)) {
-  //   return (
-  //     <BasePage headerContent={<></>} content={<NoCoralAccessSuperadmin />} />
-  //   );
-  // }
+  if (!isLoading && authUser && isSuperAdmin(authUser)) {
+    return (
+      <BasePage headerContent={<></>} content={<NoCoralAccessSuperadmin />} />
+    );
+  }
 
   if (!isLoading && authUser) {
     return (

--- a/coral/src/app/context-provider/AuthProvider.tsx
+++ b/coral/src/app/context-provider/AuthProvider.tsx
@@ -58,11 +58,11 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   // SUPERADMIN does not have access to coral, so we show a reduced page with
   // information about that and nothing else.
-  if (!isLoading && authUser && isSuperAdmin(authUser)) {
-    return (
-      <BasePage headerContent={<></>} content={<NoCoralAccessSuperadmin />} />
-    );
-  }
+  // if (!isLoading && authUser && isSuperAdmin(authUser)) {
+  //   return (
+  //     <BasePage headerContent={<></>} content={<NoCoralAccessSuperadmin />} />
+  //   );
+  // }
 
   if (!isLoading && authUser) {
     return (

--- a/coral/src/app/pages/configuration/clusters/add/index.tsx
+++ b/coral/src/app/pages/configuration/clusters/add/index.tsx
@@ -1,0 +1,5 @@
+const AddClusterPage = () => {
+  return <div>Add cluster form</div>;
+};
+
+export { AddClusterPage };

--- a/coral/src/app/pages/configuration/clusters/index.test.tsx
+++ b/coral/src/app/pages/configuration/clusters/index.test.tsx
@@ -1,0 +1,53 @@
+import { ClustersPage } from "src/app/pages/configuration/clusters";
+import { useAuthContext } from "src/app/context-provider/AuthProvider";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { cleanup, screen } from "@testing-library/react";
+import { testAuthUser } from "src/domain/auth-user/auth-user-test-helper";
+
+jest.mock("src/app/context-provider/AuthProvider");
+
+const mockUseAuthContext = useAuthContext as jest.MockedFunction<
+  typeof useAuthContext
+>;
+
+describe("ClustersPage", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    cleanup();
+  });
+
+  it('renders "Add new cluster" button when addDeleteEditClusters permission is true', () => {
+    mockUseAuthContext.mockReturnValue({
+      ...testAuthUser,
+      permissions: { ...testAuthUser.permissions, addDeleteEditClusters: true },
+    });
+
+    customRender(<ClustersPage />, {
+      memoryRouter: true,
+      queryClient: true,
+      aquariumContext: true,
+    });
+
+    const button = screen.getByRole("button", { name: "Add new cluster" });
+    expect(button).toBeVisible();
+  });
+
+  it('does not render "Add new cluster" button when addDeleteEditClusters permission is false', () => {
+    mockUseAuthContext.mockReturnValue({
+      ...testAuthUser,
+      permissions: {
+        ...testAuthUser.permissions,
+        addDeleteEditClusters: false,
+      },
+    });
+
+    customRender(<ClustersPage />, {
+      memoryRouter: true,
+      queryClient: true,
+      aquariumContext: true,
+    });
+
+    const button = screen.queryByRole("button", { name: "Add new cluster" });
+    expect(button).toBeNull();
+  });
+});

--- a/coral/src/app/pages/configuration/clusters/index.tsx
+++ b/coral/src/app/pages/configuration/clusters/index.tsx
@@ -8,9 +8,7 @@ import { Routes } from "src/app/router_utils";
 
 const ClustersPage = () => {
   const navigate = useNavigate();
-  const {
-    permissions: { addDeleteEditClusters },
-  } = useAuthContext();
+  const { permissions } = useAuthContext();
 
   return (
     <>
@@ -18,7 +16,7 @@ const ClustersPage = () => {
       <PageHeader
         title={"Clusters"}
         primaryAction={
-          addDeleteEditClusters
+          permissions.addDeleteEditClusters
             ? {
                 text: "Add new cluster",
                 onClick: () => navigate(Routes.ADD_CLUSTER),

--- a/coral/src/app/pages/configuration/clusters/index.tsx
+++ b/coral/src/app/pages/configuration/clusters/index.tsx
@@ -1,12 +1,32 @@
 import { PageHeader } from "@aivenio/aquarium";
+import add from "@aivenio/aquarium/icons/add";
+import { useNavigate } from "react-router-dom";
 import PreviewBanner from "src/app/components/PreviewBanner";
+import { useAuthContext } from "src/app/context-provider/AuthProvider";
 import Clusters from "src/app/features/configuration/clusters/Clusters";
+import { Routes } from "src/app/router_utils";
 
 const ClustersPage = () => {
+  const navigate = useNavigate();
+  const {
+    permissions: { addDeleteEditClusters },
+  } = useAuthContext();
+
   return (
     <>
       <PreviewBanner linkTarget={"/clusters"} />
-      <PageHeader title={"Clusters"} />
+      <PageHeader
+        title={"Clusters"}
+        primaryAction={
+          addDeleteEditClusters
+            ? {
+                text: "Add new cluster",
+                onClick: () => navigate(Routes.ADD_CLUSTER),
+                icon: add,
+              }
+            : undefined
+        }
+      />
       <Clusters />
     </>
   );

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -62,7 +62,11 @@ import {
   TopicOverviewTabEnum,
 } from "src/app/router_utils";
 import { getRouterBasename } from "src/config";
-import { createPrivateRoute } from "src/services/feature-flags/route-utils";
+import {
+  createPrivateRoute,
+  createRouteBehindFeatureFlag,
+} from "src/services/feature-flags/route-utils";
+import { FeatureFlag } from "src/services/feature-flags/types";
 
 const routes: Array<RouteObject> = [
   {
@@ -326,10 +330,15 @@ const routes: Array<RouteObject> = [
         path: Routes.CONNECTOR_PROMOTION_REQUEST,
         element: <ConnectorPromotionRequestPage />,
       },
-      createPrivateRoute({
-        path: Routes.ADD_CLUSTER,
-        element: <AddClusterPage />,
-        permission: "addDeleteEditClusters",
+      createRouteBehindFeatureFlag({
+        ...createPrivateRoute({
+          path: Routes.ADD_CLUSTER,
+          element: <AddClusterPage />,
+          permission: "addDeleteEditClusters",
+          redirectUnauthorized: Routes.CLUSTERS,
+        }),
+        featureFlag: FeatureFlag.FEATURE_FLAG_ADD_CLUSTER,
+        redirectRouteWithoutFeatureFlag: Routes.CLUSTERS,
       }),
     ],
   },

--- a/coral/src/app/router.tsx
+++ b/coral/src/app/router.tsx
@@ -12,6 +12,7 @@ import ConnectorApprovalsPage from "src/app/pages/approvals/connectors";
 import SchemaApprovalsPage from "src/app/pages/approvals/schemas";
 import TopicApprovalsPage from "src/app/pages/approvals/topics";
 import { ClustersPage } from "src/app/pages/configuration/clusters";
+import { AddClusterPage } from "src/app/pages/configuration/clusters/add";
 import EnvironmentsPage from "src/app/pages/configuration/environments";
 import KafkaEnvironmentsPage from "src/app/pages/configuration/environments/kafka";
 import KafkaConnectEnvironmentsPage from "src/app/pages/configuration/environments/kafka-connect";
@@ -61,6 +62,7 @@ import {
   TopicOverviewTabEnum,
 } from "src/app/router_utils";
 import { getRouterBasename } from "src/config";
+import { createPrivateRoute } from "src/services/feature-flags/route-utils";
 
 const routes: Array<RouteObject> = [
   {
@@ -324,6 +326,11 @@ const routes: Array<RouteObject> = [
         path: Routes.CONNECTOR_PROMOTION_REQUEST,
         element: <ConnectorPromotionRequestPage />,
       },
+      createPrivateRoute({
+        path: Routes.ADD_CLUSTER,
+        element: <AddClusterPage />,
+        permission: "addDeleteEditClusters",
+      }),
     ],
   },
   {

--- a/coral/src/app/router_utils.ts
+++ b/coral/src/app/router_utils.ts
@@ -24,6 +24,7 @@ enum Routes {
   TEAMS = "/configuration/teams",
   USERS = "/configuration/users",
   CLUSTERS = "/configuration/clusters",
+  ADD_CLUSTER = "/configuration/clusters/add",
   USER_INFORMATION = "/user",
   USER_PROFILE = "/user/profile",
   USER_CHANGE_PASSWORD = "/user/change-password",

--- a/coral/src/domain/cluster/cluster-api.ts
+++ b/coral/src/domain/cluster/cluster-api.ts
@@ -1,8 +1,11 @@
-import { Environment } from "src/domain/environment";
-import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
-import api, { API_PATHS } from "src/services/api";
-import { ClustersPaginatedApiResponse } from "src/domain/cluster/cluster-types";
 import { transformPaginatedClustersApiResponse } from "src/domain/cluster/cluster-api-transformer";
+import {
+  ClustersPaginatedApiResponse,
+  AddNewClusterPayload,
+} from "src/domain/cluster/cluster-types";
+import { Environment } from "src/domain/environment";
+import api, { API_PATHS } from "src/services/api";
+import { KlawApiRequestQueryParameters, KlawApiResponse } from "types/utils";
 
 const getClusterInfoFromEnvironment = async ({
   envSelected,
@@ -46,8 +49,20 @@ async function getClustersPaginated({
   return transformPaginatedClustersApiResponse(response);
 }
 
+async function addNewCluster(
+  payload: AddNewClusterPayload
+): Promise<KlawApiResponse<"addNewCluster">> {
+  const response = await api.post<
+    KlawApiResponse<"addNewCluster">,
+    AddNewClusterPayload
+  >(API_PATHS.getClustersPaginated, payload);
+
+  return response;
+}
+
 export {
-  getClusterInfoFromEnvironment,
+  addNewCluster,
   getClusterDetails,
+  getClusterInfoFromEnvironment,
   getClustersPaginated,
 };

--- a/coral/src/domain/cluster/cluster-types.ts
+++ b/coral/src/domain/cluster/cluster-types.ts
@@ -8,8 +8,11 @@ type ClustersPaginatedApiResponse = ResolveIntersectionTypes<
   Paginated<ClusterDetails[]>
 >;
 
+type AddNewClusterPayload = KlawApiModel<"KwClustersModel">;
+
 export type {
   ClusterInfoFromEnvironment,
   ClusterDetails,
   ClustersPaginatedApiResponse,
+  AddNewClusterPayload,
 };

--- a/coral/src/services/feature-flags/route-utils.test.tsx
+++ b/coral/src/services/feature-flags/route-utils.test.tsx
@@ -108,6 +108,7 @@ describe("route-utils", () => {
           path: privateRoute,
           element: TestElement,
           permission: "approveDeclineTopics",
+          redirectUnauthorized: Routes.DASHBOARD,
         });
       });
 
@@ -123,7 +124,7 @@ describe("route-utils", () => {
 
         expect(screen.queryByTestId("test-element")).not.toBeInTheDocument();
         expect(mockUseToast).toHaveBeenCalledWith({
-          message: `Not authorized: approveDeclineTopics`,
+          message: `Not authorized`,
           position: "bottom-left",
           variant: "danger",
         });
@@ -141,6 +142,7 @@ describe("route-utils", () => {
           path: privateRoute,
           element: TestElement,
           permission: "approveDeclineTopics",
+          redirectUnauthorized: Routes.DASHBOARD,
         });
       });
 

--- a/coral/src/services/feature-flags/route-utils.tsx
+++ b/coral/src/services/feature-flags/route-utils.tsx
@@ -57,7 +57,7 @@ const PrivateRoute = ({
   useEffect(() => {
     if (!isAuthorized) {
       toast({
-        message: `Not authorized: ${permission}`,
+        message: `Not authorized`,
         position: "bottom-left",
         variant: "danger",
       });

--- a/coral/src/services/feature-flags/route-utils.tsx
+++ b/coral/src/services/feature-flags/route-utils.tsx
@@ -19,6 +19,7 @@ type PrivateRouteArgs = {
   path: Routes;
   element: JSX.Element;
   permission: Permission;
+  redirectUnauthorized: Routes;
   children?: RouteObject[];
 };
 
@@ -28,7 +29,7 @@ function createRouteBehindFeatureFlag({
   featureFlag,
   redirectRouteWithoutFeatureFlag,
   children,
-}: FeatureFlagRouteArgs): RouteObject {
+}: FeatureFlagRouteArgs) {
   return {
     path: path,
     // if FEATURE_FLAG_<name> is not set to
@@ -46,9 +47,11 @@ function createRouteBehindFeatureFlag({
 const PrivateRoute = ({
   children,
   permission,
+  redirectUnauthorized,
 }: {
   children: React.ReactNode;
   permission: Permission;
+  redirectUnauthorized: Routes;
 }) => {
   const { permissions } = useAuthContext();
   const toast = useToast();
@@ -66,18 +69,30 @@ const PrivateRoute = ({
     }
   }, []);
 
-  return isAuthorized ? children : <Navigate to="/" replace />;
+  return isAuthorized ? (
+    children
+  ) : (
+    <Navigate to={redirectUnauthorized} replace />
+  );
 };
 
 function createPrivateRoute({
   path,
   element,
   permission,
+  redirectUnauthorized,
   children,
-}: PrivateRouteArgs): RouteObject {
+}: PrivateRouteArgs) {
   return {
     path: path,
-    element: <PrivateRoute permission={permission}>{element}</PrivateRoute>,
+    element: (
+      <PrivateRoute
+        permission={permission}
+        redirectUnauthorized={redirectUnauthorized}
+      >
+        {element}
+      </PrivateRoute>
+    ),
     ...(children && { children }),
   };
 }

--- a/coral/src/services/feature-flags/types.ts
+++ b/coral/src/services/feature-flags/types.ts
@@ -1,3 +1,5 @@
-enum FeatureFlag {}
+enum FeatureFlag {
+  FEATURE_FLAG_ADD_CLUSTER = "FEATURE_FLAG_ADD_CLUSTER",
+}
 
 export { FeatureFlag };

--- a/coral/vite.config.ts
+++ b/coral/vite.config.ts
@@ -137,6 +137,9 @@ export default defineConfig(({ mode }) => {
       "process.env": {
         ROUTER_BASENAME: getRouterBasename(environment),
         API_BASE_URL: getApiBaseUrl(environment),
+        FEATURE_FLAG_ADD_CLUSTER: ["development", "remote-api"]
+          .includes(mode)
+          .toString(),
       },
     },
     css: {


### PR DESCRIPTION
# Linked issue

Resolves: #2294

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Superadmin users currently cannot create  clusters from Coral UI.

# What is the new behavior?

- add route for add new cluster `/configuration/clusters/add`
- add button `Add new cluster` to `/configuration/clusters` view
- add domain entities for creating new Kafka cluster (`addNewCluster`)


https://github.com/Aiven-Open/klaw/assets/20607294/cbadb0ae-2f4e-427f-aafa-9cf27f93f8d3



# Other information

- no feature flag added because superadmin users cannot currently access coral
- removed information from the `PrivateRoute` error toast (security liability). It is still visible in the video though, but removed it since haha

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
