### PR TITLE
(fix): Fix target=blank vulnerabilities in Klaw core

### DIFF
--- a/core/src/main/resources/static/index.html
+++ b/core/src/main/resources/static/index.html
@@ -227,7 +227,8 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-file-document"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+                                                    <td><a class="dropdown-item" target="_blank"
+                                                           rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -235,7 +236,8 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-blinds"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+                                                    <td><a class="dropdown-item" rel="noopener noreferrer"
+                                                           target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -243,7 +245,7 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-hexagon"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+                                                    <td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -257,19 +259,19 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+                                                    <td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+                                                    <td><a class="dropdown-item" href="envs">Environments</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+                                                    <td><a class="dropdown-item" href="users">Users</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+                                                    <td><a class="dropdown-item" href="teams">Teams</a></td>
                                                 </tr>
                                             </table>
                                         </li>

--- a/core/src/main/resources/templates/activityLog.html
+++ b/core/src/main/resources/templates/activityLog.html
@@ -224,7 +224,8 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer"
+																 href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +233,8 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer"
+																 href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -240,7 +242,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -254,19 +256,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addCluster.html
+++ b/core/src/main/resources/templates/addCluster.html
@@ -222,7 +222,8 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer"
+																 href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -230,7 +231,8 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer"
+																 href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -238,7 +240,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,19 +254,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addEnv.html
+++ b/core/src/main/resources/templates/addEnv.html
@@ -222,7 +222,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -230,7 +230,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -238,7 +238,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,19 +252,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addKafkaConnectEnv.html
+++ b/core/src/main/resources/templates/addKafkaConnectEnv.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addRole.html
+++ b/core/src/main/resources/templates/addRole.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addSchemaEnv.html
+++ b/core/src/main/resources/templates/addSchemaEnv.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addTeam.html
+++ b/core/src/main/resources/templates/addTeam.html
@@ -222,7 +222,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -230,7 +230,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -238,7 +238,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,19 +252,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addTenant.html
+++ b/core/src/main/resources/templates/addTenant.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addUser.html
+++ b/core/src/main/resources/templates/addUser.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/addUserLdap.html
+++ b/core/src/main/resources/templates/addUserLdap.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/analytics.html
+++ b/core/src/main/resources/templates/analytics.html
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -240,7 +240,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -248,7 +248,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -262,19 +262,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -215,7 +215,8 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer"
+																 href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -223,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -245,19 +246,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/browseTopics.html
+++ b/core/src/main/resources/templates/browseTopics.html
@@ -244,7 +244,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,7 +252,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -260,7 +260,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -274,19 +274,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/changePwd.html
+++ b/core/src/main/resources/templates/changePwd.html
@@ -224,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -240,7 +240,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -254,19 +254,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/clusters.html
+++ b/core/src/main/resources/templates/clusters.html
@@ -233,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -241,7 +241,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -249,7 +249,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -263,19 +263,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/connectorOverview.html
+++ b/core/src/main/resources/templates/connectorOverview.html
@@ -215,7 +215,8 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer"
+																 href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -223,7 +224,8 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer"
+																 href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -245,19 +247,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/editAclRequest.html
+++ b/core/src/main/resources/templates/editAclRequest.html
@@ -218,7 +218,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -226,7 +226,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -234,7 +234,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -248,19 +248,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/editSchemaRequest.html
+++ b/core/src/main/resources/templates/editSchemaRequest.html
@@ -217,7 +217,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -225,7 +225,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -233,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -247,19 +247,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/editTopicRequest.html
+++ b/core/src/main/resources/templates/editTopicRequest.html
@@ -217,7 +217,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -225,7 +225,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -233,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -247,19 +247,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/envs.html
+++ b/core/src/main/resources/templates/envs.html
@@ -224,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -240,7 +240,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -254,19 +254,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/error.html
+++ b/core/src/main/resources/templates/error.html
@@ -3,7 +3,7 @@
 <body>
 <h1>Something went wrong! </h1>
 <h2>If you are accessing new Coral interface, please go through
-    <a target="_blank" href="https://github.com/aiven/klaw/blob/main/coral/README.md">Read Me</a>
+    <a target="_blank" rel="noopener noreferrer" href="https://github.com/aiven/klaw/blob/main/coral/README.md">Read Me</a>
 </h2>
 
 <a href="/">Go Home</a>

--- a/core/src/main/resources/templates/execAcls.html
+++ b/core/src/main/resources/templates/execAcls.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/execConnectors.html
+++ b/core/src/main/resources/templates/execConnectors.html
@@ -220,7 +220,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -228,7 +228,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -236,7 +236,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -250,19 +250,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/execOperationalChanges.html
+++ b/core/src/main/resources/templates/execOperationalChanges.html
@@ -220,7 +220,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -228,7 +228,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -236,7 +236,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -250,19 +250,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/execRegisteredUsers.html
+++ b/core/src/main/resources/templates/execRegisteredUsers.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/execSchemas.html
+++ b/core/src/main/resources/templates/execSchemas.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/execTopics.html
+++ b/core/src/main/resources/templates/execTopics.html
@@ -220,7 +220,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -228,7 +228,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -236,7 +236,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -250,19 +250,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/helpwizard.html
+++ b/core/src/main/resources/templates/helpwizard.html
@@ -223,7 +223,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +231,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -239,7 +239,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -253,19 +253,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/index.html
+++ b/core/src/main/resources/templates/index.html
@@ -227,7 +227,7 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-file-document"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+                                                    <td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -235,7 +235,7 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-blinds"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+                                                    <td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -243,7 +243,7 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-hexagon"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+                                                    <td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -257,19 +257,19 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+                                                    <td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+                                                    <td><a class="dropdown-item" href="envs">Environments</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+                                                    <td><a class="dropdown-item" href="users">Users</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+                                                    <td><a class="dropdown-item" href="teams">Teams</a></td>
                                                 </tr>
                                             </table>
                                         </li>

--- a/core/src/main/resources/templates/kafkaConnectors.html
+++ b/core/src/main/resources/templates/kafkaConnectors.html
@@ -244,7 +244,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,7 +252,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -260,7 +260,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -274,19 +274,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/kwmetrics.html
+++ b/core/src/main/resources/templates/kwmetrics.html
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -240,7 +240,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -248,7 +248,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -262,19 +262,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/manageConnectors.html
+++ b/core/src/main/resources/templates/manageConnectors.html
@@ -243,7 +243,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,7 +251,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -259,7 +259,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -273,19 +273,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/modifyCluster.html
+++ b/core/src/main/resources/templates/modifyCluster.html
@@ -222,7 +222,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -230,7 +230,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -238,7 +238,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,19 +252,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/modifyEnv.html
+++ b/core/src/main/resources/templates/modifyEnv.html
@@ -222,7 +222,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -230,7 +230,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -238,7 +238,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,19 +252,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/modifyTeam.html
+++ b/core/src/main/resources/templates/modifyTeam.html
@@ -222,7 +222,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -230,7 +230,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -238,7 +238,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -252,19 +252,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/modifyUser.html
+++ b/core/src/main/resources/templates/modifyUser.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/monitorEnvs.html
+++ b/core/src/main/resources/templates/monitorEnvs.html
@@ -218,7 +218,9 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-file-document"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="docs">Documentation</a></td>
+                                                    <td><a class="dropdown-item" target="_blank"
+                                                           rel="noopener noreferrer" href="https://klaw-project.io/docs">
+                                                        Documentation</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -226,7 +228,7 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-blinds"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+                                                    <td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -234,7 +236,7 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-hexagon"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+                                                    <td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
                                                 </tr>
                                             </table>
                                         </li>
@@ -248,19 +250,19 @@
                                             <table>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+                                                    <td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+                                                    <td><a class="dropdown-item" href="envs">Environments</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+                                                    <td><a class="dropdown-item" href="users">Users</a></td>
                                                 </tr>
                                                 <tr>
                                                     <td><i class="mdi mdi-blender"></i></td>
-                                                    <td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+                                                    <td><a class="dropdown-item" href="teams">Teams</a></td>
                                                 </tr>
                                             </table>
                                         </li>

--- a/core/src/main/resources/templates/myAclRequests.html
+++ b/core/src/main/resources/templates/myAclRequests.html
@@ -220,7 +220,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -228,7 +228,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -236,7 +236,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -250,19 +250,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/myConnectorRequests.html
+++ b/core/src/main/resources/templates/myConnectorRequests.html
@@ -215,7 +215,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -223,7 +223,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +231,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -245,19 +245,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/myOperationalRequests.html
+++ b/core/src/main/resources/templates/myOperationalRequests.html
@@ -215,7 +215,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -223,7 +223,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +231,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -245,19 +245,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/myProfile.html
+++ b/core/src/main/resources/templates/myProfile.html
@@ -223,7 +223,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +231,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -239,7 +239,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -253,19 +253,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/mySchemaRequests.html
+++ b/core/src/main/resources/templates/mySchemaRequests.html
@@ -215,7 +215,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -223,7 +223,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +231,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -245,19 +245,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/myTopicRequests.html
+++ b/core/src/main/resources/templates/myTopicRequests.html
@@ -215,7 +215,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -223,7 +223,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +231,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -245,19 +245,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/permissions.html
+++ b/core/src/main/resources/templates/permissions.html
@@ -216,7 +216,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -224,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -246,19 +246,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/requestAcls.html
+++ b/core/src/main/resources/templates/requestAcls.html
@@ -218,7 +218,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -226,7 +226,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -234,7 +234,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -248,19 +248,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/requestConnector.html
+++ b/core/src/main/resources/templates/requestConnector.html
@@ -217,7 +217,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -225,7 +225,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -233,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -247,19 +247,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/requestConsumerOffsetReset.html
+++ b/core/src/main/resources/templates/requestConsumerOffsetReset.html
@@ -217,7 +217,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -225,7 +225,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -233,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -247,19 +247,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/requestSchema.html
+++ b/core/src/main/resources/templates/requestSchema.html
@@ -217,7 +217,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -225,7 +225,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -233,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -247,19 +247,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/requestTopics.html
+++ b/core/src/main/resources/templates/requestTopics.html
@@ -217,7 +217,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -225,7 +225,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -233,7 +233,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -247,19 +247,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/roles.html
+++ b/core/src/main/resources/templates/roles.html
@@ -216,7 +216,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -224,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -246,19 +246,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/serverConfig.html
+++ b/core/src/main/resources/templates/serverConfig.html
@@ -216,7 +216,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -224,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -246,19 +246,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/showTeams.html
+++ b/core/src/main/resources/templates/showTeams.html
@@ -221,7 +221,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -229,7 +229,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -237,7 +237,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,19 +251,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/showUsers.html
+++ b/core/src/main/resources/templates/showUsers.html
@@ -216,7 +216,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -224,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -246,19 +246,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/syncBackAcls.html
+++ b/core/src/main/resources/templates/syncBackAcls.html
@@ -248,7 +248,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -256,7 +256,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -264,7 +264,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -278,19 +278,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/syncBackSchemas.html
+++ b/core/src/main/resources/templates/syncBackSchemas.html
@@ -248,7 +248,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -256,7 +256,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -264,7 +264,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -278,19 +278,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/syncBackTopics.html
+++ b/core/src/main/resources/templates/syncBackTopics.html
@@ -248,7 +248,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -256,7 +256,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -264,7 +264,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -278,19 +278,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/synchronizeAcls.html
+++ b/core/src/main/resources/templates/synchronizeAcls.html
@@ -243,7 +243,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,7 +251,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -259,7 +259,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -273,19 +273,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/synchronizeConnectors.html
+++ b/core/src/main/resources/templates/synchronizeConnectors.html
@@ -243,7 +243,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -251,7 +251,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -259,7 +259,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -273,19 +273,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/synchronizeSchemas.html
+++ b/core/src/main/resources/templates/synchronizeSchemas.html
@@ -242,7 +242,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -250,7 +250,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -258,7 +258,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -272,19 +272,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/synchronizeTopics.html
+++ b/core/src/main/resources/templates/synchronizeTopics.html
@@ -242,7 +242,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -250,7 +250,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -258,7 +258,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -272,19 +272,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/tenantInfo.html
+++ b/core/src/main/resources/templates/tenantInfo.html
@@ -223,7 +223,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -231,7 +231,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -239,7 +239,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -253,19 +253,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>

--- a/core/src/main/resources/templates/tenants.html
+++ b/core/src/main/resources/templates/tenants.html
@@ -216,7 +216,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-file-document"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="https://klaw-project.io/docs">Documentation</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="https://klaw-project.io/docs">Documentation</a></td>
 												</tr>
 											</table>
 										</li>
@@ -224,7 +224,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blinds"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
+													<td><a class="dropdown-item" target="_blank" rel="noopener noreferrer" href="{{ dashboardDetails.supportlink }}">Raise a git issue</a></td>
 												</tr>
 											</table>
 										</li>
@@ -232,7 +232,7 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-hexagon"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="helpwizard">Starting Wizard</a></td>
+													<td><a class="dropdown-item" href="helpwizard">Starting Wizard</a></td>
 												</tr>
 											</table>
 										</li>
@@ -246,19 +246,19 @@
 											<table>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="requestTopics">Request Topic</a></td>
+													<td><a class="dropdown-item" href="requestTopics">Request Topic</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="envs">Environments</a></td>
+													<td><a class="dropdown-item" href="envs">Environments</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="users">Users</a></td>
+													<td><a class="dropdown-item" href="users">Users</a></td>
 												</tr>
 												<tr>
 													<td><i class="mdi mdi-blender"></i></td>
-													<td><a class="dropdown-item" target="_blank" href="teams">Teams</a></td>
+													<td><a class="dropdown-item" href="teams">Teams</a></td>
 												</tr>
 											</table>
 										</li>


### PR DESCRIPTION
# Description

Fixes 124 `Potentially unsafe external link` code scanning alerts. 

Links with `target=_blank" introduce a vulnerability:

> HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using window.opener unless link type noopener or noreferrer is specified. This is a potential security risk.


## This PR

- removes target=_blank from internal links (it's often considered a bad UX pattern anyways)
- adds `rel="noopener noreferrer"` to external links with target blank 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update
# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
