### PR TITLE
fix: Remove unused script and unsafe links

### DIFF
--- a/core/src/main/resources/static/assets/js/custom.js
+++ b/core/src/main/resources/static/assets/js/custom.js
@@ -240,14 +240,4 @@ $(function () {
         barSpacing: '4',
         barColor: '#7460ee'
     });
-    var sparkResize;
-
-    // For Custom File Input
-    $('.custom-file-input').on('change', function () {
-        //get the file name
-        var fileName = $(this).val();
-        //replace the "Choose a file" label
-        $(this).next('.custom-file-label').html(fileName);
-    })
-
 });

--- a/core/src/main/resources/templates/editTopicRequest.html
+++ b/core/src/main/resources/templates/editTopicRequest.html
@@ -555,7 +555,8 @@
 																   type="text" placeholder="" class="form-control">
 														</td>
 														<td>
-															<a ng-show="propertyInfoLink[$index] != ''" href="{{ propertyInfoLink[$index] }}" ng-model="topicConfigsSelectedLink[$index]" target="_blank">
+															<a ng-show="propertyInfoLink[$index] != ''" href="{{ propertyInfoLink[$index] }}"
+																 ng-model="topicConfigsSelectedLink[$index]" target="_blank" rel="noopener noreferrer">
 																<button type="button" class="btn btn-outline-info  mb-2">
 																	<i class="ti-info"></i>
 																</button>

--- a/core/src/main/resources/templates/requestTopics.html
+++ b/core/src/main/resources/templates/requestTopics.html
@@ -577,7 +577,8 @@
 																   type="text" placeholder="" class="form-control">
 														</td>
 														<td>
-															<a ng-show="propertyInfoLink[$index] != ''" href="{{ propertyInfoLink[$index] }}" ng-model="topicConfigsSelectedLink[$index]" target="_blank">
+															<a ng-show="propertyInfoLink[$index] != ''" href="{{ propertyInfoLink[$index] }}"
+																 ng-model="topicConfigsSelectedLink[$index]" target="_blank" rel="noopener noreferrer">
 																<button type="button" class="btn btn-outline-info  mb-2">
 																	<i class="ti-info"></i>
 																</button>


### PR DESCRIPTION
# Description

- fixes two links with `taget=_blank` I missed
- removes an unused script that introduced a possible cross-site scripting vulnerability and was not used anyways

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update



# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
