### PR TITLE
Admin API Guards

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/AclSyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclSyncController.java
@@ -5,7 +5,9 @@ import io.aiven.klaw.model.AclInfo;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.SyncAclUpdates;
 import io.aiven.klaw.model.SyncBackAcls;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.service.AclSyncControllerService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +28,11 @@ public class AclSyncController {
 
   @Autowired AclSyncControllerService aclSyncControllerService;
 
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.SYNC_BACK_SUBSCRIPTIONS,
+        PermissionType.SYNC_SUBSCRIPTIONS
+      })
   @PostMapping(
       value = "/updateSyncAcls",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -35,6 +42,11 @@ public class AclSyncController {
         aclSyncControllerService.updateSyncAcls(syncAclUpdates), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.SYNC_BACK_SUBSCRIPTIONS,
+        PermissionType.SYNC_SUBSCRIPTIONS
+      })
   @RequestMapping(
       value = "/getSyncBackAcls",
       method = RequestMethod.GET,
@@ -51,6 +63,11 @@ public class AclSyncController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.SYNC_BACK_SUBSCRIPTIONS,
+        PermissionType.SYNC_SUBSCRIPTIONS
+      })
   @PostMapping(
       value = "/updateSyncBackAcls",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -61,6 +78,11 @@ public class AclSyncController {
   }
 
   // get acls from kafka cluster
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.SYNC_BACK_SUBSCRIPTIONS,
+        PermissionType.SYNC_SUBSCRIPTIONS
+      })
   @RequestMapping(
       value = "/getSyncAcls",
       method = RequestMethod.GET,

--- a/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
@@ -6,6 +6,7 @@ import io.aiven.klaw.error.KlawValidationException;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.KwTenantModel;
 import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.requests.EnvModel;
 import io.aiven.klaw.model.requests.KwClustersModel;
 import io.aiven.klaw.model.response.ClusterInfo;
@@ -17,6 +18,7 @@ import io.aiven.klaw.model.response.KwClustersModelResponse;
 import io.aiven.klaw.model.response.SupportedProtocolInfo;
 import io.aiven.klaw.model.response.TenantInfo;
 import io.aiven.klaw.service.EnvsClustersTenantsControllerService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +87,7 @@ public class EnvsClustersTenantsController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_CLUSTERS})
   @PostMapping(
       value = "/deleteCluster",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -94,6 +97,7 @@ public class EnvsClustersTenantsController {
         envsClustersTenantsControllerService.deleteCluster(clusterId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_CLUSTERS})
   @PostMapping(
       value = "/addNewCluster",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -262,6 +266,7 @@ public class EnvsClustersTenantsController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_ENVS})
   @PostMapping(
       value = "/addNewEnv",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -271,6 +276,7 @@ public class EnvsClustersTenantsController {
         envsClustersTenantsControllerService.addNewEnv(newEnv), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_ENVS})
   @PostMapping(
       value = "/deleteEnvironmentRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -290,6 +296,7 @@ public class EnvsClustersTenantsController {
         envsClustersTenantsControllerService.getStandardEnvNames(), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_TENANT})
   @PostMapping(
       value = "/addTenantId",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -299,6 +306,7 @@ public class EnvsClustersTenantsController {
         envsClustersTenantsControllerService.addTenantId(kwTenantModel, true), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.UPDATE_DELETE_MY_TENANT})
   @PostMapping(
       value = "/deleteTenant",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -307,6 +315,7 @@ public class EnvsClustersTenantsController {
   }
 
   // Pattern a-zA-z and/or spaces.
+  @PermissionAllowed(permissionAllowed = {PermissionType.UPDATE_DELETE_MY_TENANT})
   @PostMapping(
       value = "/updateTenant",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/KafkaConnectController.java
@@ -154,11 +154,6 @@ public class KafkaConnectController {
    * @param isMyRequest Only return requests created by the user calling the API
    * @return A list of Kafka Connector requests
    */
-  @PermissionAllowed(
-      permissionAllowed = {
-        PermissionType.APPROVE_CONNECTORS,
-        PermissionType.APPROVE_ALL_REQUESTS_TEAMS
-      })
   @RequestMapping(
       value = "/getConnectorRequests",
       method = RequestMethod.GET,
@@ -219,7 +214,6 @@ public class KafkaConnectController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_CONNECTORS})
   @PostMapping(
       value = "/createClaimConnectorRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/controller/KafkaConnectSyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/KafkaConnectSyncController.java
@@ -3,8 +3,10 @@ package io.aiven.klaw.controller;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.SyncConnectorUpdates;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.KafkaConnectorModelResponse;
 import io.aiven.klaw.service.KafkaConnectSyncControllerService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -23,6 +25,7 @@ public class KafkaConnectSyncController {
 
   @Autowired KafkaConnectSyncControllerService kafkaConnectControllerService;
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.SYNC_CONNECTORS})
   @PostMapping(
       value = "/updateSyncConnectors",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -32,6 +35,7 @@ public class KafkaConnectSyncController {
         kafkaConnectControllerService.updateSyncConnectors(syncConnectorUpdates), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.SYNC_CONNECTORS})
   @RequestMapping(
       value = "/getConnectorDetails",
       method = RequestMethod.GET,
@@ -43,6 +47,7 @@ public class KafkaConnectSyncController {
         kafkaConnectControllerService.getConnectorDetails(connectorName, envId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.SYNC_CONNECTORS})
   @RequestMapping(
       value = "/getSyncConnectors",
       method = RequestMethod.GET,
@@ -61,6 +66,7 @@ public class KafkaConnectSyncController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.SYNC_CONNECTORS})
   @RequestMapping(
       value = "/getConnectorsToManage",
       method = RequestMethod.GET,

--- a/core/src/main/java/io/aiven/klaw/controller/OperationalRequestsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/OperationalRequestsController.java
@@ -5,11 +5,13 @@ import io.aiven.klaw.error.KlawNotAuthorizedException;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.enums.OperationalRequestType;
 import io.aiven.klaw.model.enums.Order;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.ConsumerOffsetResetRequestModel;
 import io.aiven.klaw.model.response.EnvIdInfo;
 import io.aiven.klaw.model.response.OperationalRequestsResponseModel;
 import io.aiven.klaw.service.OperationalRequestsService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,7 @@ public class OperationalRequestsController {
 
   @Autowired OperationalRequestsService operationalRequestsService;
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_OPERATIONAL_CHANGES})
   @PostMapping(
       value = "/operationalRequest/consumerOffsetsReset/create",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -44,6 +47,7 @@ public class OperationalRequestsController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_OPERATIONAL_CHANGES})
   @PostMapping(
       value = "/operationalRequest/reqId/{reqId}/approve",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -53,6 +57,7 @@ public class OperationalRequestsController {
         operationalRequestsService.approveOperationalRequests(reqId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_OPERATIONAL_CHANGES})
   @PostMapping(
       value = "/operationalRequest/reqId/{reqId}/decline",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -65,6 +70,7 @@ public class OperationalRequestsController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_OPERATIONAL_CHANGES})
   @PostMapping(
       value = "/operationalRequest/reqId/{reqId}/delete",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -74,6 +80,7 @@ public class OperationalRequestsController {
         operationalRequestsService.deleteOperationalRequest(operationalRequestId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_OPERATIONAL_CHANGES})
   @RequestMapping(
       value = "/operationalRequest/consumerOffsetsReset/validate",
       method = RequestMethod.GET,
@@ -87,6 +94,7 @@ public class OperationalRequestsController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_OPERATIONAL_CHANGES})
   @RequestMapping(
       value = "/operationalRequests/requestsFor/{requestsFor}",
       method = RequestMethod.GET,

--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegistrySyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegistrySyncController.java
@@ -4,9 +4,11 @@ import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.SchemaResetCache;
 import io.aiven.klaw.model.SyncSchemaUpdates;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.SchemaDetailsResponse;
 import io.aiven.klaw.model.response.SyncSchemasList;
 import io.aiven.klaw.service.SchemaRegistrySyncControllerService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -35,6 +37,8 @@ public class SchemaRegistrySyncController {
    * @return
    * @throws Exception
    */
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_SCHEMAS, PermissionType.SYNC_BACK_SCHEMAS})
   @RequestMapping(
       value = "/schemas",
       method = RequestMethod.GET,
@@ -61,6 +65,8 @@ public class SchemaRegistrySyncController {
    * @return
    * @throws Exception
    */
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_SCHEMAS, PermissionType.SYNC_BACK_SCHEMAS})
   @PostMapping(
       value = "/schemas",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -80,6 +86,8 @@ public class SchemaRegistrySyncController {
    * @return
    * @throws Exception
    */
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_SCHEMAS, PermissionType.SYNC_BACK_SCHEMAS})
   @RequestMapping(
       value =
           "/schemas/source/{source}/kafkaEnv/{kafkaEnvId}/topic/{topicName}/schemaVersion/{schemaVersion}",
@@ -97,6 +105,8 @@ public class SchemaRegistrySyncController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_SCHEMAS, PermissionType.SYNC_BACK_SCHEMAS})
   @RequestMapping(
       value = "/schemas/resetCache",
       method = RequestMethod.POST,

--- a/core/src/main/java/io/aiven/klaw/controller/TopicController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicController.java
@@ -99,12 +99,6 @@ public class TopicController {
    * @param isMyRequest Only return requests created by the user calling the API
    * @return A List of Topic Requests filtered by the provided parameters.
    */
-  @PermissionAllowed(
-      permissionAllowed = {
-        PermissionType.APPROVE_ALL_REQUESTS_TEAMS,
-        PermissionType.APPROVE_TOPICS,
-        PermissionType.APPROVE_TOPICS_CREATE
-      })
   @RequestMapping(
       value = "/getTopicRequests",
       method = RequestMethod.GET,

--- a/core/src/main/java/io/aiven/klaw/controller/TopicSyncController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/TopicSyncController.java
@@ -6,8 +6,10 @@ import io.aiven.klaw.model.SyncBackTopics;
 import io.aiven.klaw.model.SyncTopicUpdates;
 import io.aiven.klaw.model.SyncTopicsBulk;
 import io.aiven.klaw.model.TopicInfo;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.response.SyncTopicsList;
 import io.aiven.klaw.service.TopicSyncControllerService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -26,6 +28,8 @@ public class TopicSyncController {
 
   @Autowired private TopicSyncControllerService topicSyncControllerService;
 
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_TOPICS, PermissionType.SYNC_BACK_TOPICS})
   @PostMapping(
       value = "/updateSyncTopics",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -35,6 +39,8 @@ public class TopicSyncController {
         topicSyncControllerService.updateSyncTopics(syncTopicUpdates), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_TOPICS, PermissionType.SYNC_BACK_TOPICS})
   @PostMapping(
       value = "/updateSyncTopicsBulk",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -45,6 +51,8 @@ public class TopicSyncController {
   }
 
   // sync back topics
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_TOPICS, PermissionType.SYNC_BACK_TOPICS})
   @RequestMapping(
       value = "/getTopicsRowView",
       method = RequestMethod.GET,
@@ -62,6 +70,8 @@ public class TopicSyncController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_TOPICS, PermissionType.SYNC_BACK_TOPICS})
   @PostMapping(
       value = "/updateSyncBackTopics",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -71,6 +81,8 @@ public class TopicSyncController {
         topicSyncControllerService.updateSyncBackTopics(syncBackTopics), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.SYNC_TOPICS, PermissionType.SYNC_BACK_TOPICS})
   @RequestMapping(
       value = "/getSyncTopics",
       method = RequestMethod.GET,

--- a/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
@@ -3,6 +3,7 @@ package io.aiven.klaw.controller;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.error.KlawNotAuthorizedException;
 import io.aiven.klaw.model.ApiResponse;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.requests.ChangePasswordRequestModel;
 import io.aiven.klaw.model.requests.ProfileModel;
 import io.aiven.klaw.model.requests.RegisterUserInfoModel;
@@ -13,6 +14,7 @@ import io.aiven.klaw.model.response.ResetPasswordInfo;
 import io.aiven.klaw.model.response.TeamModelResponse;
 import io.aiven.klaw.model.response.UserInfoModelResponse;
 import io.aiven.klaw.service.UsersTeamsControllerService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +60,7 @@ public class UsersTeamsController {
     return new ResponseEntity<>(usersTeamsControllerService.getAllTeamsSUOnly(), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
   @PostMapping(
       value = "/deleteTeamRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -66,6 +69,7 @@ public class UsersTeamsController {
     return new ResponseEntity<>(usersTeamsControllerService.deleteTeam(teamId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
   @PostMapping(
       value = "/deleteUserRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -75,6 +79,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.deleteUser(userId, true), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
   @PostMapping(
       value = "/updateUser",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -93,6 +98,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.updateProfile(updateUserObj), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
   @PostMapping(
       value = "/addNewUser",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -111,6 +117,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.registerUser(newUser, true), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS})
   @RequestMapping(
       value = "/getNewUserRequests",
       method = RequestMethod.GET,
@@ -131,6 +138,7 @@ public class UsersTeamsController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS})
   @PostMapping(
       value = "/execNewUserRequestApprove",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -140,6 +148,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.approveNewUserRequests(username, true, 0, ""), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS})
   @PostMapping(
       value = "/execNewUserRequestDecline",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -149,6 +158,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.declineNewUserRequests(username), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
   @PostMapping(
       value = "/addNewTeam",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -158,6 +168,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.addNewTeam(newTeam, true), HttpStatus.OK);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
   @PostMapping(
       value = "/updateTeam",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
@@ -60,7 +60,11 @@ public class UsersTeamsController {
     return new ResponseEntity<>(usersTeamsControllerService.getAllTeamsSUOnly(), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.ADD_EDIT_DELETE_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/deleteTeamRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -69,7 +73,11 @@ public class UsersTeamsController {
     return new ResponseEntity<>(usersTeamsControllerService.deleteTeam(teamId), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.ADD_EDIT_DELETE_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/deleteUserRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -79,7 +87,11 @@ public class UsersTeamsController {
         usersTeamsControllerService.deleteUser(userId, true), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.ADD_EDIT_DELETE_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/updateUser",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -98,7 +110,11 @@ public class UsersTeamsController {
         usersTeamsControllerService.updateProfile(updateUserObj), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.ADD_EDIT_DELETE_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/addNewUser",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -117,7 +133,11 @@ public class UsersTeamsController {
         usersTeamsControllerService.registerUser(newUser, true), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.APPROVE_ALL_REQUESTS_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @RequestMapping(
       value = "/getNewUserRequests",
       method = RequestMethod.GET,
@@ -138,7 +158,11 @@ public class UsersTeamsController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.APPROVE_ALL_REQUESTS_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/execNewUserRequestApprove",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -148,7 +172,11 @@ public class UsersTeamsController {
         usersTeamsControllerService.approveNewUserRequests(username, true, 0, ""), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.APPROVE_ALL_REQUESTS_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/execNewUserRequestDecline",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -158,7 +186,11 @@ public class UsersTeamsController {
         usersTeamsControllerService.declineNewUserRequests(username), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.ADD_EDIT_DELETE_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/addNewTeam",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -168,7 +200,11 @@ public class UsersTeamsController {
         usersTeamsControllerService.addNewTeam(newTeam, true), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
+  @PermissionAllowed(
+      permissionAllowed = {
+        PermissionType.ADD_EDIT_DELETE_TEAMS,
+        PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES
+      })
   @PostMapping(
       value = "/updateTeam",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
@@ -60,7 +60,7 @@ public class UsersTeamsController {
     return new ResponseEntity<>(usersTeamsControllerService.getAllTeamsSUOnly(), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/deleteTeamRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -69,7 +69,7 @@ public class UsersTeamsController {
     return new ResponseEntity<>(usersTeamsControllerService.deleteTeam(teamId), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/deleteUserRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -79,7 +79,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.deleteUser(userId, true), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/updateUser",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -98,7 +98,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.updateProfile(updateUserObj), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/addNewUser",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -117,7 +117,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.registerUser(newUser, true), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @RequestMapping(
       value = "/getNewUserRequests",
       method = RequestMethod.GET,
@@ -138,7 +138,7 @@ public class UsersTeamsController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/execNewUserRequestApprove",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -148,7 +148,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.approveNewUserRequests(username, true, 0, ""), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_ALL_REQUESTS_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/execNewUserRequestDecline",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -158,7 +158,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.declineNewUserRequests(username), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/addNewTeam",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -168,7 +168,7 @@ public class UsersTeamsController {
         usersTeamsControllerService.addNewTeam(newTeam, true), HttpStatus.OK);
   }
 
-  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS})
+  @PermissionAllowed(permissionAllowed = {PermissionType.ADD_EDIT_DELETE_TEAMS, PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES})
   @PostMapping(
       value = "/updateTeam",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -40,6 +40,7 @@ import io.aiven.klaw.model.response.AclRequestsResponseModel;
 import io.aiven.klaw.model.response.OffsetDetails;
 import io.aiven.klaw.model.response.ServiceAccountDetails;
 import io.aiven.klaw.service.MailUtils.MailType;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -497,6 +498,7 @@ public class AclControllerService {
     return aclRequestsModels;
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SUBSCRIPTIONS})
   public ApiResponse deleteAclRequests(String req_no) throws KlawException {
     try {
       if (commonUtilsService.isNotAuthorizedUser(
@@ -636,6 +638,7 @@ public class AclControllerService {
     return executeAclRequestModel(userName, aclRequestsDao, ACL_DELETE_REQUESTED);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_SUBSCRIPTIONS})
   public ApiResponse approveAclRequests(String req_no)
       throws KlawException, KlawBadRequestException {
     log.info("approveAclRequests {}", req_no);
@@ -899,6 +902,7 @@ public class AclControllerService {
     return response;
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_SUBSCRIPTIONS})
   public ApiResponse declineAclRequests(String req_no, String reasonToDecline)
       throws KlawException {
     log.info("declineAclRequests {}", req_no);

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -50,6 +50,7 @@ import io.aiven.klaw.model.response.ConnectorOverviewPerEnv;
 import io.aiven.klaw.model.response.EnvIdInfo;
 import io.aiven.klaw.model.response.KafkaConnectorModelResponse;
 import io.aiven.klaw.model.response.KafkaConnectorRequestsResponseModel;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -482,6 +483,7 @@ public class KafkaConnectControllerService {
     return tmpTopicList;
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_CONNECTORS})
   public ApiResponse deleteConnectorRequests(String topicId) throws KlawException {
     log.info("deleteConnectorRequests {}", topicId);
 
@@ -628,6 +630,7 @@ public class KafkaConnectControllerService {
     }
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_CONNECTORS})
   public ApiResponse approveConnectorRequests(String connectorId)
       throws KlawException, KlawRestException {
     log.info("approveConnectorRequests {}", connectorId);
@@ -780,6 +783,7 @@ public class KafkaConnectControllerService {
     }
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_CONNECTORS})
   public ApiResponse declineConnectorRequests(String connectorId, String reasonForDecline)
       throws KlawException {
     log.info("declineConnectorRequests {} {}", connectorId, reasonForDecline);

--- a/core/src/main/java/io/aiven/klaw/service/OperationalRequestsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/OperationalRequestsService.java
@@ -29,6 +29,7 @@ import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.ConsumerOffsetResetRequestModel;
 import io.aiven.klaw.model.response.EnvIdInfo;
 import io.aiven.klaw.model.response.OperationalRequestsResponseModel;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -393,6 +394,7 @@ public class OperationalRequestsService {
     return Comparator.comparing(OperationalRequest::getRequesttime);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_OPERATIONAL_CHANGES})
   public ApiResponse approveOperationalRequests(String reqId) {
     log.info("approveConsumerOffsetRequests {}", reqId);
     final String userName = getUserName();

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
@@ -37,6 +37,7 @@ import io.aiven.klaw.model.requests.SchemaPromotion;
 import io.aiven.klaw.model.requests.SchemaRequestModel;
 import io.aiven.klaw.model.response.BaseRequestsResponseModel;
 import io.aiven.klaw.model.response.SchemaRequestsResponseModel;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -197,6 +198,7 @@ public class SchemaRegistryControllerService {
     return req;
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SCHEMAS})
   public ApiResponse deleteSchemaRequests(String avroSchemaId) throws KlawException {
     log.info("deleteSchemaRequests {}", avroSchemaId);
 
@@ -222,6 +224,7 @@ public class SchemaRegistryControllerService {
     }
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_SCHEMAS})
   public ApiResponse execSchemaRequests(String avroSchemaId) throws KlawException {
     log.info("execSchemaRequests {}", avroSchemaId);
     String userDetails = getUserName();
@@ -405,6 +408,7 @@ public class SchemaRegistryControllerService {
                         + schemaRequest.getSchemaversion()));
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_SCHEMAS})
   public ApiResponse execSchemaRequestsDecline(String avroSchemaId, String reasonForDecline)
       throws KlawException {
     log.info("execSchemaRequestsDecline {}", avroSchemaId);

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -59,6 +59,7 @@ import io.aiven.klaw.model.response.TopicConfig;
 import io.aiven.klaw.model.response.TopicDetailsPerEnv;
 import io.aiven.klaw.model.response.TopicRequestsResponseModel;
 import io.aiven.klaw.model.response.TopicTeamResponse;
+import io.aiven.klaw.validation.PermissionAllowed;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -663,6 +664,7 @@ public class TopicControllerService {
     return String.valueOf(approvingInfo);
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_TOPICS})
   public ApiResponse deleteTopicRequests(String topicId) throws KlawException {
     log.info("deleteTopicRequests {}", topicId);
 
@@ -689,6 +691,8 @@ public class TopicControllerService {
   - On approval, create,delete,update the topics on kafka cluster with api call
   - For claim topics, there are no kafka cluster operations
    */
+  @PermissionAllowed(
+      permissionAllowed = {PermissionType.APPROVE_TOPICS, PermissionType.APPROVE_TOPICS_CREATE})
   public ApiResponse approveTopicRequests(String topicId) throws KlawException {
     log.info("approveTopicRequests {}", topicId);
     String userName = getUserName();
@@ -862,6 +866,7 @@ public class TopicControllerService {
     return ApiResponse.SUCCESS;
   }
 
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_TOPICS})
   public ApiResponse declineTopicRequests(String topicId, String reasonForDecline)
       throws KlawException {
     log.info("declineTopicRequests {} {}", topicId, reasonForDecline);

--- a/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
@@ -236,7 +236,7 @@ public class UsersTeamsControllerIT {
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
+            .andExpect(status().isUnauthorized())
             .andReturn()
             .getResponse()
             .getContentAsString();


### PR DESCRIPTION
Update for Admin APIs to have rest endpoints protected with fine grain permission guards.

# Linked issue

Resolves: #2276 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Currently checks are done on the FE to prevent access to these pages.

# What is the new behavior?

The Admin APIs have checks on them to prevent someone from using them without the correct permission being assigned to the user.

# Other information


# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
