### PR TITLE
Add permission guards on ACLS and Schemas

### DIFF
--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -38,10 +38,7 @@ public class AclController {
 
   @Autowired TopicOverviewService topicOverviewService;
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.REQUEST_CREATE_SUBSCRIPTIONS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SUBSCRIPTIONS})
   @PostMapping(
       value = "/createAcl",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -119,8 +116,8 @@ public class AclController {
   */
   @PermissionAllowed(
       permissionAllowed = {
-          PermissionType.APPROVE_SUBSCRIPTIONS,
-          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+        PermissionType.APPROVE_SUBSCRIPTIONS,
+        PermissionType.APPROVE_ALL_REQUESTS_TEAMS
       })
   @RequestMapping(
       value = "/getAclRequestsForApprover",
@@ -152,10 +149,7 @@ public class AclController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.REQUEST_CREATE_SUBSCRIPTIONS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SUBSCRIPTIONS})
   @RequestMapping(
       value = "/deleteAclRequests",
       method = RequestMethod.POST,
@@ -165,10 +159,7 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.deleteAclRequests(req_no), HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.APPROVE_SUBSCRIPTIONS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_SUBSCRIPTIONS})
   @PostMapping(
       value = "/execAclRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -177,10 +168,7 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.approveAclRequests(req_no), HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.REQUEST_DELETE_SUBSCRIPTIONS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_DELETE_SUBSCRIPTIONS})
   @PostMapping(
       value = "/createDeleteAclSubscriptionRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -199,10 +187,7 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.claimAcl(aclId), HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.APPROVE_SUBSCRIPTIONS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.APPROVE_SUBSCRIPTIONS})
   @PostMapping(
       value = "/execAclRequestDecline",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/controller/AclController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/AclController.java
@@ -3,11 +3,7 @@ package io.aiven.klaw.controller;
 import io.aiven.klaw.error.KlawBadRequestException;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.model.ApiResponse;
-import io.aiven.klaw.model.enums.AclGroupBy;
-import io.aiven.klaw.model.enums.AclType;
-import io.aiven.klaw.model.enums.Order;
-import io.aiven.klaw.model.enums.RequestOperationType;
-import io.aiven.klaw.model.enums.RequestStatus;
+import io.aiven.klaw.model.enums.*;
 import io.aiven.klaw.model.requests.AclRequestsModel;
 import io.aiven.klaw.model.requests.DeleteAclRequestModel;
 import io.aiven.klaw.model.response.AclRequestsResponseModel;
@@ -16,6 +12,7 @@ import io.aiven.klaw.model.response.ServiceAccountDetails;
 import io.aiven.klaw.model.response.TopicOverview;
 import io.aiven.klaw.service.AclControllerService;
 import io.aiven.klaw.service.TopicOverviewService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Set;
@@ -41,6 +38,10 @@ public class AclController {
 
   @Autowired TopicOverviewService topicOverviewService;
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.REQUEST_CREATE_SUBSCRIPTIONS
+      })
   @PostMapping(
       value = "/createAcl",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -116,6 +117,11 @@ public class AclController {
   /*
      For executing acl requests
   */
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.APPROVE_SUBSCRIPTIONS,
+          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+      })
   @RequestMapping(
       value = "/getAclRequestsForApprover",
       method = RequestMethod.GET,
@@ -146,6 +152,10 @@ public class AclController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.REQUEST_CREATE_SUBSCRIPTIONS
+      })
   @RequestMapping(
       value = "/deleteAclRequests",
       method = RequestMethod.POST,
@@ -155,6 +165,10 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.deleteAclRequests(req_no), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.APPROVE_SUBSCRIPTIONS
+      })
   @PostMapping(
       value = "/execAclRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -163,6 +177,10 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.approveAclRequests(req_no), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.REQUEST_DELETE_SUBSCRIPTIONS
+      })
   @PostMapping(
       value = "/createDeleteAclSubscriptionRequest",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -181,6 +199,10 @@ public class AclController {
     return new ResponseEntity<>(aclControllerService.claimAcl(aclId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.APPROVE_SUBSCRIPTIONS
+      })
   @PostMapping(
       value = "/execAclRequestDecline",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
@@ -3,6 +3,7 @@ package io.aiven.klaw.controller;
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.model.ApiResponse;
 import io.aiven.klaw.model.enums.Order;
+import io.aiven.klaw.model.enums.PermissionType;
 import io.aiven.klaw.model.enums.RequestOperationType;
 import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.requests.SchemaPromotion;
@@ -11,7 +12,10 @@ import io.aiven.klaw.model.response.SchemaOverview;
 import io.aiven.klaw.model.response.SchemaRequestsResponseModel;
 import io.aiven.klaw.service.SchemaOverviewService;
 import io.aiven.klaw.service.SchemaRegistryControllerService;
+import io.aiven.klaw.validation.PermissionAllowed;
 import jakarta.validation.Valid;
+
+import java.security.Permission;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -96,6 +100,11 @@ public class SchemaRegistryController {
    *     OLDEST_FIRST/NEWEST_FIRST
    * @return A list of filtered Schema Requests for approval
    */
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.APPROVE_SCHEMAS,
+          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+      })
   @RequestMapping(
       value = "/getSchemaRequestsForApprover",
       method = RequestMethod.GET,
@@ -126,6 +135,10 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.REQUEST_CREATE_SCHEMAS
+      })
   @PostMapping(
       value = "/deleteSchemaRequests",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -135,6 +148,11 @@ public class SchemaRegistryController {
         schemaRegistryControllerService.deleteSchemaRequests(avroSchemaReqId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.APPROVE_SCHEMAS,
+          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+      })
   @PostMapping(
       value = "/execSchemaRequests",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -144,6 +162,11 @@ public class SchemaRegistryController {
         schemaRegistryControllerService.execSchemaRequests(avroSchemaReqId), HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.APPROVE_SCHEMAS,
+          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+      })
   @PostMapping(
       value = "/execSchemaRequestsDecline",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -157,6 +180,10 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.REQUEST_CREATE_SCHEMAS
+      })
   @PostMapping(
       value = "/uploadSchema",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -167,6 +194,10 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.REQUEST_CREATE_SCHEMAS
+      })
   @PostMapping(
       value = "/promote/schema",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -196,6 +227,10 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
+  @PermissionAllowed(
+      permissionAllowed = {
+          PermissionType.REQUEST_CREATE_SCHEMAS
+      })
   @PostMapping(
       value = "/validate/schema",
       produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/SchemaRegistryController.java
@@ -14,8 +14,6 @@ import io.aiven.klaw.service.SchemaOverviewService;
 import io.aiven.klaw.service.SchemaRegistryControllerService;
 import io.aiven.klaw.validation.PermissionAllowed;
 import jakarta.validation.Valid;
-
-import java.security.Permission;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,8 +100,8 @@ public class SchemaRegistryController {
    */
   @PermissionAllowed(
       permissionAllowed = {
-          PermissionType.APPROVE_SCHEMAS,
-          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+        PermissionType.APPROVE_SCHEMAS,
+        PermissionType.APPROVE_ALL_REQUESTS_TEAMS
       })
   @RequestMapping(
       value = "/getSchemaRequestsForApprover",
@@ -135,10 +133,7 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.REQUEST_CREATE_SCHEMAS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SCHEMAS})
   @PostMapping(
       value = "/deleteSchemaRequests",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -150,8 +145,8 @@ public class SchemaRegistryController {
 
   @PermissionAllowed(
       permissionAllowed = {
-          PermissionType.APPROVE_SCHEMAS,
-          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+        PermissionType.APPROVE_SCHEMAS,
+        PermissionType.APPROVE_ALL_REQUESTS_TEAMS
       })
   @PostMapping(
       value = "/execSchemaRequests",
@@ -164,8 +159,8 @@ public class SchemaRegistryController {
 
   @PermissionAllowed(
       permissionAllowed = {
-          PermissionType.APPROVE_SCHEMAS,
-          PermissionType.APPROVE_ALL_REQUESTS_TEAMS
+        PermissionType.APPROVE_SCHEMAS,
+        PermissionType.APPROVE_ALL_REQUESTS_TEAMS
       })
   @PostMapping(
       value = "/execSchemaRequestsDecline",
@@ -180,10 +175,7 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.REQUEST_CREATE_SCHEMAS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SCHEMAS})
   @PostMapping(
       value = "/uploadSchema",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -194,10 +186,7 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.REQUEST_CREATE_SCHEMAS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SCHEMAS})
   @PostMapping(
       value = "/promote/schema",
       produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -227,10 +216,7 @@ public class SchemaRegistryController {
         HttpStatus.OK);
   }
 
-  @PermissionAllowed(
-      permissionAllowed = {
-          PermissionType.REQUEST_CREATE_SCHEMAS
-      })
+  @PermissionAllowed(permissionAllowed = {PermissionType.REQUEST_CREATE_SCHEMAS})
   @PostMapping(
       value = "/validate/schema",
       produces = {MediaType.APPLICATION_JSON_VALUE})


### PR DESCRIPTION
# Linked issue

Resolves: #2277 #2279  

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The permission guards are not applied uniformly this PR adds the permission guards to the endpoints where modifications to the acls and schemas can be made.
# What is the new behavior?

Permission Guards are added to the endpoints where modification or creation of the resources can be made.

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
