### PR TITLE
feat(coral): Add `application.properties` recap after adding a new cluster

### DIFF
--- a/coral/src/app/components/Clipboard.test.tsx
+++ b/coral/src/app/components/Clipboard.test.tsx
@@ -42,7 +42,7 @@ describe("ClipBoard", () => {
     );
   });
 
-  it("renders tooltip after button is clicked", async () => {
+  it("renders feedback tooltip after button is clicked", async () => {
     const button = screen.getByRole("button", {
       name: props.accessibleCopyDescription,
     });
@@ -50,7 +50,7 @@ describe("ClipBoard", () => {
     await waitFor(() => expect(screen.getByText("Copied")).toBeVisible());
   });
 
-  it("changes aria-label after button is clicked", async () => {
+  it("renders accessible feedback after button is clicked", async () => {
     const button = screen.getByRole("button", {
       name: props.accessibleCopyDescription,
     });

--- a/coral/src/app/components/Clipboard.test.tsx
+++ b/coral/src/app/components/Clipboard.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import ClipBoard from "src/app/components/Clipboard";
+
+describe("ClipBoard", () => {
+  const mockCopyToClipboard = jest.fn();
+  Object.defineProperty(global.navigator, "clipboard", {
+    value: { writeText: mockCopyToClipboard },
+    writable: true,
+  });
+
+  const props = {
+    text: "Test text",
+    accessibleCopyDescription: "Copy to clipboard",
+    accessibleCopiedDescription: "Copied to clipboard",
+    description: "Test description",
+  };
+
+  beforeEach(() => {
+    render(<ClipBoard {...props} />);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it("renders correctly", () => {
+    const button = screen.getByRole("button", {
+      name: props.accessibleCopyDescription,
+    });
+    expect(button).toBeVisible();
+  });
+
+  it("copies text to clipboard when button is clicked", async () => {
+    const button = screen.getByRole("button", {
+      name: props.accessibleCopyDescription,
+    });
+    await userEvent.click(button);
+    await waitFor(() =>
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(props.text)
+    );
+  });
+
+  it("renders tooltip after button is clicked", async () => {
+    const button = screen.getByRole("button", {
+      name: props.accessibleCopyDescription,
+    });
+    await userEvent.click(button);
+    await waitFor(() => expect(screen.getByText("Copied")).toBeVisible());
+  });
+
+  it("changes aria-label after button is clicked", async () => {
+    const button = screen.getByRole("button", {
+      name: props.accessibleCopyDescription,
+    });
+    await userEvent.click(button);
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText(props.accessibleCopiedDescription)
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/coral/src/app/components/Clipboard.tsx
+++ b/coral/src/app/components/Clipboard.tsx
@@ -57,7 +57,9 @@ const ClipBoard = ({
         >
           {description}
         </Button.SecondaryGhost>
-        <div className={"visually-hidden"}>{accessibleCopiedDescription}</div>
+        <div aria-live="polite" className={"visually-hidden"}>
+          {accessibleCopiedDescription}
+        </div>
       </Tooltip>
     );
   }

--- a/coral/src/app/components/Clipboard.tsx
+++ b/coral/src/app/components/Clipboard.tsx
@@ -1,0 +1,83 @@
+import { Tooltip, PositionerPlacement, Button } from "@aivenio/aquarium";
+import duplicate from "@aivenio/aquarium/icons/duplicate";
+import { useRef, useState, useEffect, FormEvent } from "react";
+
+const copyToClipboard = async (text: string): Promise<void> => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    console.error("Failed to copy to clipboard:", error);
+  }
+};
+
+const ClipBoard = ({
+  text,
+  accessibleCopyDescription,
+  accessibleCopiedDescription,
+  description,
+}: {
+  text: string;
+  accessibleCopyDescription: string;
+  accessibleCopiedDescription: string;
+  description?: string;
+}) => {
+  const feedbackTimerRef = useRef<number>();
+
+  const [showCopyFeedback, setShowCopyFeedback] = useState(false);
+
+  const clearTimeouts = () => {
+    window.clearTimeout(feedbackTimerRef.current);
+  };
+
+  useEffect(() => () => clearTimeouts(), []);
+
+  function handleCopy(event: FormEvent) {
+    event.preventDefault();
+    copyToClipboard(text);
+    setShowCopyFeedback(true);
+    feedbackTimerRef.current = window.setTimeout(
+      () => setShowCopyFeedback(false),
+      1000
+    );
+  }
+
+  if (showCopyFeedback) {
+    return (
+      <Tooltip
+        key="copied"
+        content="Copied"
+        isOpen
+        placement={PositionerPlacement.top}
+      >
+        <Button.SecondaryGhost
+          key="copy-button"
+          aria-label={accessibleCopiedDescription}
+          onClick={handleCopy}
+          icon={duplicate}
+        >
+          {description}
+        </Button.SecondaryGhost>
+        <div className={"visually-hidden"}>{accessibleCopiedDescription}</div>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip
+      key="copy-to-clipboard"
+      content="Copy"
+      placement={PositionerPlacement.top}
+    >
+      <Button.SecondaryGhost
+        key="copy-button"
+        aria-label={accessibleCopyDescription}
+        onClick={handleCopy}
+        icon={duplicate}
+      >
+        {description}
+      </Button.SecondaryGhost>
+    </Tooltip>
+  );
+};
+
+export default ClipBoard;

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -15,7 +15,7 @@ type ModalProps = {
   title: string;
   subtitle?: string;
   close?: () => void;
-  primaryAction?: ModalAction;
+  primaryAction: ModalAction;
   secondaryAction?: ModalAction;
   children: ReactElement;
   isDialog?: boolean;
@@ -163,7 +163,7 @@ function Modal(props: ModalProps) {
                   icon={cross}
                   onClick={close}
                   data-focusable
-                  disabled={secondaryAction?.loading || primaryAction?.loading}
+                  disabled={secondaryAction?.loading || primaryAction.loading}
                 />
               )}
             </Box>
@@ -186,17 +186,15 @@ function Modal(props: ModalProps) {
                   {secondaryAction.text}
                 </Button>
               )}
-              {primaryAction && (
-                <Button
-                  kind={isDialog ? "secondary" : "primary"}
-                  onClick={primaryAction.onClick}
-                  data-focusable
-                  disabled={primaryAction.disabled}
-                  loading={primaryAction.loading}
-                >
-                  {primaryAction.text}
-                </Button>
-              )}
+              <Button
+                kind={isDialog ? "secondary" : "primary"}
+                onClick={primaryAction.onClick}
+                data-focusable
+                disabled={primaryAction.disabled}
+                loading={primaryAction.loading}
+              >
+                {primaryAction.text}
+              </Button>
             </Box>
           </Box>
         </Box>,

--- a/coral/src/app/components/Modal.tsx
+++ b/coral/src/app/components/Modal.tsx
@@ -15,7 +15,7 @@ type ModalProps = {
   title: string;
   subtitle?: string;
   close?: () => void;
-  primaryAction: ModalAction;
+  primaryAction?: ModalAction;
   secondaryAction?: ModalAction;
   children: ReactElement;
   isDialog?: boolean;
@@ -125,7 +125,7 @@ function Modal(props: ModalProps) {
             flexDirection={"column"}
             borderRadius={"4px"}
             backgroundColor={"white"}
-            width={"6/12"}
+            width={"7/12"}
             // value is arbitrary, it should prevent buttons overflowing
             // the modal in a very small screen
             //eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -163,7 +163,7 @@ function Modal(props: ModalProps) {
                   icon={cross}
                   onClick={close}
                   data-focusable
-                  disabled={secondaryAction?.loading || primaryAction.loading}
+                  disabled={secondaryAction?.loading || primaryAction?.loading}
                 />
               )}
             </Box>
@@ -186,15 +186,17 @@ function Modal(props: ModalProps) {
                   {secondaryAction.text}
                 </Button>
               )}
-              <Button
-                kind={isDialog ? "secondary" : "primary"}
-                onClick={primaryAction.onClick}
-                data-focusable
-                disabled={primaryAction.disabled}
-                loading={primaryAction.loading}
-              >
-                {primaryAction.text}
-              </Button>
+              {primaryAction && (
+                <Button
+                  kind={isDialog ? "secondary" : "primary"}
+                  onClick={primaryAction.onClick}
+                  data-focusable
+                  disabled={primaryAction.disabled}
+                  loading={primaryAction.loading}
+                >
+                  {primaryAction.text}
+                </Button>
+              )}
             </Box>
           </Box>
         </Box>,

--- a/coral/src/app/features/components/filters/SearchClusterParamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/SearchClusterParamFilter.test.tsx
@@ -13,7 +13,7 @@ describe("SearchClusterParamFilter.tsx", () => {
 
   it("renders a search input", () => {
     const searchInput = screen.getByRole("search", {
-      name: "Search Cluster params",
+      name: "Search Cluster parameters",
     });
 
     expect(searchInput).toBeEnabled();
@@ -21,7 +21,7 @@ describe("SearchClusterParamFilter.tsx", () => {
 
   it("shows a placeholder with an example search value", () => {
     const searchInput = screen.getByRole<HTMLInputElement>("search", {
-      name: "Search Cluster params",
+      name: "Search Cluster parameters",
     });
 
     expect(searchInput.placeholder).toEqual("kafkaconnect");
@@ -29,7 +29,7 @@ describe("SearchClusterParamFilter.tsx", () => {
 
   it("shows a description", () => {
     const searchInput = screen.getByRole<HTMLInputElement>("search", {
-      name: "Search Cluster params",
+      name: "Search Cluster parameters",
     });
 
     expect(searchInput).toHaveAccessibleDescription(

--- a/coral/src/app/features/components/filters/SearchClusterParamFilter.tsx
+++ b/coral/src/app/features/components/filters/SearchClusterParamFilter.tsx
@@ -3,7 +3,7 @@ import { SearchFilter } from "src/app/features/components/filters/SearchFilter";
 function SearchClusterParamFilter() {
   return (
     <SearchFilter
-      label={"Search Cluster params"}
+      label={"Search Cluster parameters"}
       placeholder={"kafkaconnect"}
       description={
         "Partial match for: Cluster name, bootstrap server and protocol."

--- a/coral/src/app/features/configuration/clusters/AddNewClusterForm.test.tsx
+++ b/coral/src/app/features/configuration/clusters/AddNewClusterForm.test.tsx
@@ -280,7 +280,7 @@ describe("<AddNewClusterForm />", () => {
       position: "bottom-left",
     });
     expect(mockedUsedNavigate).toHaveBeenCalledWith(
-      "/configuration/clusters?search=MyCluster"
+      "/configuration/clusters?search=MyCluster&showConnectHelp=true"
     );
   });
 

--- a/coral/src/app/features/configuration/clusters/AddNewClusterForm.tsx
+++ b/coral/src/app/features/configuration/clusters/AddNewClusterForm.tsx
@@ -56,7 +56,7 @@ const AddNewClusterForm = () => {
 
   const addNewClusterMutation = useMutation(addNewCluster, {
     onSuccess: () => {
-      navigate(`${Routes.CLUSTERS}?search=${clusterName}`);
+      navigate(`${Routes.CLUSTERS}?search=${clusterName}&showConnectHelp=true`);
       toast({
         message: "Cluster successfully added",
         position: "bottom-left",

--- a/coral/src/app/features/configuration/clusters/Clusters.test.tsx
+++ b/coral/src/app/features/configuration/clusters/Clusters.test.tsx
@@ -304,4 +304,46 @@ describe("Clusters.tsx", () => {
       );
     });
   });
+
+  describe("renders ClusterConnectHelpModal on first load when needed", () => {
+    beforeAll(async () => {
+      mockGetClustersPaginated.mockResolvedValue({
+        currentPage: 1,
+        totalPages: 1,
+        entries: [testCluster[0]],
+      });
+
+      customRender(<Clusters />, {
+        queryClient: true,
+        memoryRouter: true,
+        customRoutePath: `/configuration/clusters?search=${testCluster[0].clusterName}&showConnectHelp=true`,
+      });
+
+      await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+    });
+
+    afterAll(() => {
+      cleanup();
+      jest.resetAllMocks();
+    });
+
+    it("renders ClusterConnectHelpModal on first render if correct query params are set", () => {
+      const modal = screen.getByRole("dialog");
+      expect(modal).toBeVisible();
+      expect(
+        within(modal).getByText("Connecting clusters to Klaw")
+      ).toBeVisible();
+    });
+
+    it("remove showConnectHelp query param when closing ClusterConnectHelpModal ", async () => {
+      const modal = screen.getByRole("dialog");
+      expect(modal).toBeVisible();
+
+      const closeButton = within(modal).getByRole("button", { name: "Done" });
+
+      await userEvent.click(closeButton);
+
+      expect(window.location.search).not.toContain("showConnectHelp=true");
+    });
+  });
 });

--- a/coral/src/app/features/configuration/clusters/Clusters.test.tsx
+++ b/coral/src/app/features/configuration/clusters/Clusters.test.tsx
@@ -160,7 +160,7 @@ describe("Clusters.tsx", () => {
 
     it("renders a search field for cluster params", () => {
       const search = screen.getByRole("search", {
-        name: "Search Cluster params",
+        name: "Search Cluster parameters",
       });
 
       expect(search).toBeEnabled();
@@ -289,7 +289,7 @@ describe("Clusters.tsx", () => {
       const testSearchInput = "MyCluster";
 
       const search = screen.getByRole("search", {
-        name: "Search Cluster params",
+        name: "Search Cluster parameters",
       });
 
       await user.type(search, testSearchInput);
@@ -330,9 +330,7 @@ describe("Clusters.tsx", () => {
     it("renders ClusterConnectHelpModal on first render if correct query params are set", () => {
       const modal = screen.getByRole("dialog");
       expect(modal).toBeVisible();
-      expect(
-        within(modal).getByText("Connecting clusters to Klaw")
-      ).toBeVisible();
+      expect(within(modal).getByText("Connect cluster to Klaw")).toBeVisible();
     });
 
     it("remove showConnectHelp query param when closing ClusterConnectHelpModal ", async () => {

--- a/coral/src/app/features/configuration/clusters/Clusters.tsx
+++ b/coral/src/app/features/configuration/clusters/Clusters.tsx
@@ -61,7 +61,11 @@ function Clusters() {
       ? clusters?.entries[0]
       : undefined;
     const isShowingOnlyLatestAddedCluster =
-      latestAddedCluster !== undefined && search.length !== 0;
+      // If there is more than one cluster resulting from the searchClusterParam filter, we should not show the modal
+      // As we currently can't know which one was the latest added
+      clusters?.entries.length === 1 &&
+      latestAddedCluster !== undefined &&
+      search.length !== 0;
 
     if (showConnectHelp && isShowingOnlyLatestAddedCluster) {
       const { kafkaFlavor, protocol, clusterType, clusterName, clusterId } =

--- a/coral/src/app/features/configuration/clusters/Clusters.tsx
+++ b/coral/src/app/features/configuration/clusters/Clusters.tsx
@@ -1,16 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
-import { TableLayout } from "src/app/features/components/layouts/TableLayout";
-import { getClustersPaginated } from "src/domain/cluster";
-import { ClustersTable } from "src/app/features/configuration/clusters/components/ClustersTable";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Pagination } from "src/app/components/Pagination";
+import { useAuthContext } from "src/app/context-provider/AuthProvider";
+import { SearchClusterParamFilter } from "src/app/features/components/filters/SearchClusterParamFilter";
 import {
   useFiltersContext,
   withFiltersContext,
 } from "src/app/features/components/filters/useFiltersContext";
-import { SearchClusterParamFilter } from "src/app/features/components/filters/SearchClusterParamFilter";
+import { TableLayout } from "src/app/features/components/layouts/TableLayout";
+import ClusterConnectHelpModal from "src/app/features/configuration/clusters/components/ClusterConnectHelpModal";
+import { ClustersTable } from "src/app/features/configuration/clusters/components/ClustersTable";
+import { ClusterDetails, getClustersPaginated } from "src/domain/cluster";
+
+// We add this default data to avoid dealing with the fact that it may be undefined when closing the modal...
+// ... and resetting the state
+const DEFAULT_MODAL_DATA: ClusterModal["data"] = {
+  kafkaFlavor: "AIVEN_FOR_APACHE_KAFKA",
+  protocol: "PLAINTEXT",
+  clusterType: "KAFKA",
+  clusterName: "",
+  clusterId: 0,
+};
 
 function Clusters() {
+  const { permissions } = useAuthContext();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = searchParams.get("page")
     ? Number(searchParams.get("page"))
@@ -32,6 +46,52 @@ function Clusters() {
     keepPreviousData: true,
   });
 
+  const [modal, setModal] = useState<ClusterModal>({
+    show: false,
+    data: DEFAULT_MODAL_DATA,
+  });
+
+  // Automatically open the Connect mhelp modal after adding a cluster.
+  // We know how to populate the modal data from the fact that we redirect...
+  // ... to a filtered table from the AddNewClusterForm, along with a specific query param
+  // For example: /configuration/clusters?search=MyCluster&showConnectHelp=true
+  useEffect(() => {
+    const showConnectHelp = searchParams.get("showConnectHelp") !== null;
+    const latestAddedCluster = showConnectHelp
+      ? clusters?.entries[0]
+      : undefined;
+    const isShowingOnlyLatestAddedCluster =
+      latestAddedCluster !== undefined && search.length !== 0;
+
+    if (showConnectHelp && isShowingOnlyLatestAddedCluster) {
+      const { kafkaFlavor, protocol, clusterType, clusterName, clusterId } =
+        latestAddedCluster;
+
+      handleShowModal({
+        show: true,
+        data: {
+          kafkaFlavor,
+          protocol,
+          clusterType,
+          clusterName,
+          clusterId,
+        },
+      });
+    }
+  });
+
+  function handleShowModal({ show, data }: ClusterModal) {
+    setModal({
+      show,
+      data,
+    });
+
+    // If showConnectHelp is present, remove it on next call of handleShowModal
+    // Most probably when closing the modal opened automatically after adding a cluster
+    searchParams.delete("showConnectHelp");
+    setSearchParams(searchParams);
+  }
+
   function handleChangePage(page: number) {
     searchParams.set("page", page.toString());
     setSearchParams(searchParams);
@@ -47,22 +107,50 @@ function Clusters() {
     ) : undefined;
 
   return (
-    <TableLayout
-      filters={[<SearchClusterParamFilter key={"search"} />]}
-      table={
-        <ClustersTable
-          clusters={clusters?.entries || []}
-          ariaLabel={`Cluster overview, page ${clusters?.currentPage ?? 0} of ${
-            clusters?.totalPages ?? 0
-          }`}
+    <>
+      {modal.show && (
+        <ClusterConnectHelpModal
+          onClose={() =>
+            setModal({
+              show: false,
+              data: DEFAULT_MODAL_DATA,
+            })
+          }
+          modalData={modal.data}
         />
-      }
-      isLoading={isLoading}
-      isErrorLoading={isError}
-      errorMessage={error}
-      pagination={pagination}
-    />
+      )}
+
+      <TableLayout
+        filters={[<SearchClusterParamFilter key={"search"} />]}
+        table={
+          <ClustersTable
+            clusters={clusters?.entries || []}
+            handleShowModal={
+              permissions.addDeleteEditClusters ? handleShowModal : undefined
+            }
+            ariaLabel={`Cluster overview, page ${clusters?.currentPage ?? 0} of ${
+              clusters?.totalPages ?? 0
+            }`}
+          />
+        }
+        isLoading={isLoading}
+        isErrorLoading={isError}
+        errorMessage={error}
+        pagination={pagination}
+      />
+    </>
   );
+}
+
+export interface ClusterModal {
+  show: boolean;
+  data: {
+    kafkaFlavor: ClusterDetails["kafkaFlavor"];
+    protocol: ClusterDetails["protocol"];
+    clusterType: ClusterDetails["clusterType"];
+    clusterName: ClusterDetails["clusterName"];
+    clusterId: ClusterDetails["clusterId"];
+  };
 }
 
 export default withFiltersContext({ element: <Clusters /> });

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.test.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import ClusterConnectHelpModal from "src/app/features/configuration/clusters/components/ClusterConnectHelpModal";
+import { ClusterDetails } from "src/domain/cluster";
+
+const onClose = jest.fn();
+const modalDataWithApplicationPropertiesToCopy: {
+  kafkaFlavor: ClusterDetails["kafkaFlavor"];
+  protocol: ClusterDetails["protocol"];
+  clusterType: ClusterDetails["clusterType"];
+  clusterName: ClusterDetails["clusterName"];
+  clusterId: ClusterDetails["clusterId"];
+} = {
+  kafkaFlavor: "APACHE_KAFKA",
+  protocol: "SSL",
+  clusterType: "KAFKA",
+  clusterName: "TestCluster",
+  clusterId: 123,
+};
+const modalDataWithoutApplicationPropertiesToCopy: {
+  kafkaFlavor: ClusterDetails["kafkaFlavor"];
+  protocol: ClusterDetails["protocol"];
+  clusterType: ClusterDetails["clusterType"];
+  clusterName: ClusterDetails["clusterName"];
+  clusterId: ClusterDetails["clusterId"];
+} = {
+  kafkaFlavor: "APACHE_KAFKA",
+  protocol: "PLAINTEXT",
+  clusterType: "KAFKA",
+  clusterName: "TestCluster",
+  clusterId: 123,
+};
+
+describe("ClusterConnectHelpModal", () => {
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it("renders with applicationPropertiesString", async () => {
+    render(
+      <ClusterConnectHelpModal
+        onClose={onClose}
+        modalData={modalDataWithApplicationPropertiesToCopy}
+      />
+    );
+    const expectedApplicationPropertiesString = `${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.keystore.pwd=keystorePw\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.key.pwd=keyPw\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.truststore.pwd=truststorePw\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.keystore.type=pkcs12\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.truststore.type=JKS`;
+
+    expect(screen.getByText("Connecting clusters to Klaw")).toBeVisible();
+    expect(
+      screen.getByText(/Copy and paste these lines with the correct values/)
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: /Learn more/ })).toHaveAttribute(
+      "href",
+      "https://www.klaw-project.io/docs/cluster-connectivity-setup/"
+    );
+    // Contraption needed to assert the expectedApplicationPropertiesString when it is broken on multiple lines
+    expect(
+      screen.getByText((_, node) => {
+        const hasText = (node: Element) =>
+          node.textContent === expectedApplicationPropertiesString;
+        const nodeHasText = node ? hasText(node) : false;
+        const childrenDontHaveText = Array.from(node?.children || []).every(
+          (child) => !hasText(child)
+        );
+
+        return nodeHasText && childrenDontHaveText;
+      })
+    ).toBeVisible();
+
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders without applicationPropertiesString", async () => {
+    render(
+      <ClusterConnectHelpModal
+        onClose={onClose}
+        modalData={modalDataWithoutApplicationPropertiesToCopy}
+      />
+    );
+
+    expect(screen.getByText("Connecting clusters to Klaw")).toBeVisible();
+    expect(
+      screen.queryByText(/Copy and paste these lines with the correct values/)
+    ).toBeNull();
+    expect(
+      screen.getByRole("link", {
+        name: /Learn more about cluster connectivity setup/,
+      })
+    ).toHaveAttribute(
+      "href",
+      "https://www.klaw-project.io/docs/cluster-connectivity-setup/"
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.test.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.test.tsx
@@ -46,9 +46,9 @@ describe("ClusterConnectHelpModal", () => {
     );
     const expectedApplicationPropertiesString = `${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.keystore.pwd=keystorePw\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.key.pwd=keyPw\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.truststore.pwd=truststorePw\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.keystore.type=pkcs12\n${modalDataWithApplicationPropertiesToCopy.clusterName.toLowerCase() + modalDataWithApplicationPropertiesToCopy.clusterId}.kafkassl.truststore.type=JKS`;
 
-    expect(screen.getByText("Connecting clusters to Klaw")).toBeVisible();
+    expect(screen.getByText("Connect cluster to Klaw")).toBeVisible();
     expect(
-      screen.getByText(/Copy and paste these lines with the correct values/)
+      screen.getByText(/Copy, paste, and replace placeholders/)
     ).toBeVisible();
     expect(screen.getByRole("link", { name: /Learn more/ })).toHaveAttribute(
       "href",
@@ -81,9 +81,9 @@ describe("ClusterConnectHelpModal", () => {
       />
     );
 
-    expect(screen.getByText("Connecting clusters to Klaw")).toBeVisible();
+    expect(screen.getByText("Connect cluster to Klaw")).toBeVisible();
     expect(
-      screen.queryByText(/Copy and paste these lines with the correct values/)
+      screen.queryByText(/Copy, paste, and replace placeholders/)
     ).toBeNull();
     expect(
       screen.getByRole("link", {

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
@@ -1,5 +1,6 @@
 import { Box, Icon, Spacing, Typography } from "@aivenio/aquarium";
 import link from "@aivenio/aquarium/icons/link";
+import { a } from "msw/lib/core/RequestHandler-CwjkprZE";
 import ClipBoard from "src/app/components/Clipboard";
 import { Modal } from "src/app/components/Modal";
 import { ClusterDetails } from "src/domain/cluster";
@@ -108,7 +109,11 @@ const ClusterConnectHelpModal = ({
               klaw/cluster-api/src/main/resources/application.properties
             </pre>
             .
-            <a href="https://www.klaw-project.io/docs/cluster-connectivity-setup/">
+            <br />
+            <a
+              href="https://www.klaw-project.io/docs/cluster-connectivity-setup/"
+              style={{ display: "inline-block" }}
+            >
               <Box.Flex alignItems="center" gap={"2"}>
                 Learn more <Icon icon={link} />
               </Box.Flex>

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
@@ -99,7 +99,7 @@ const getApplicationPropertiesString = ({
   clusterType: ClusterDetails["clusterType"];
   protocol: ClusterDetails["protocol"];
 }) => {
-  if (kafkaFlavor === "APACHE_KAFKA" && clusterType === "KAFKA") {
+  if (clusterType === "KAFKA" && kafkaFlavor === "APACHE_KAFKA") {
     if (protocol === "SSL") {
       return `${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.pwd=keystorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.key.pwd=keyPw\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.pwd=truststorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.type=pkcs12\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.type=JKS`;
     }
@@ -116,7 +116,7 @@ const getApplicationPropertiesString = ({
       return `${clusterName.toLowerCase() + clusterId}.kafkasasl.jaasconfig.gssapi=com.sun.security.auth.module.Krb5LoginModule\nrequired useKeyTab=true storeKey=true keyTab="/path/to/kafka_client.keytab"\n<principal=%22kafkaclient1@EXAMPLE.COM>"`;
     }
   }
-  if (kafkaFlavor === "AIVEN_FOR_APACHE_KAFKA" && clusterType === "KAFKA") {
+  if (clusterType === "KAFKA" && kafkaFlavor === "AIVEN_FOR_APACHE_KAFKA") {
     if (protocol === "SSL") {
       return `${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.pwd=keystorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.key.pwd=keyPw\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.pwd=truststorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.type=pkcs12\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.type=JKS\nklaw.clusters.accesstoken=yourAivenAccessToken`;
     }
@@ -135,10 +135,13 @@ const getApplicationPropertiesString = ({
   }
 
   if (clusterType === "SCHEMA_REGISTRY" && protocol === "SSL") {
-    return `${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.pwd=keystorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.key.pwd=keyPw\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.pwd=truststorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.type=pkcs12\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.type=JKS\n`;
+    return `${clusterName.toLowerCase() + clusterId}.klaw.schemaregistry.credentials=username:password`;
   }
 
   if (clusterType === "KAFKA_CONNECT") {
+    if (kafkaFlavor === "APACHE_KAFKA" && protocol === "SSL") {
+      return `${clusterName.toLowerCase() + clusterId}.klaw.kafkaconnect.credentials=username:password`;
+    }
     if (kafkaFlavor === "AIVEN_FOR_APACHE_KAFKA") {
       return `${clusterName.toLowerCase() + clusterId}.klaw.kafkaconnect.credentials=aivenUsername:aivenPassword`;
     }
@@ -147,7 +150,7 @@ const getApplicationPropertiesString = ({
     }
   }
 
-  // Default case: no specific application.properties to copy
+  // Default case: no necessary application.properties to copy
   return "";
 };
 

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
@@ -176,19 +176,18 @@ const ClusterConnectHelpModal = ({
     clusterType,
     protocol,
   });
-
   return (
     <Modal
-      title={"Connecting clusters to Klaw"}
+      title={"Connect cluster to Klaw"}
       close={onClose}
       primaryAction={{ text: "Done", onClick: onClose }}
     >
       {applicationPropertiesString.length > 0 ? (
         <Spacing gap={"l2"}>
           <Typography.Default>
-            Copy and paste these lines with the correct values to{" "}
+            Copy, paste, and replace placeholders in{" "}
             <pre style={{ display: "inline" }}>
-              klaw/cluster-api/src/main/resources
+              klaw/cluster-api/src/main/resources/application.properties
             </pre>
             .
             <a href="https://www.klaw-project.io/docs/cluster-connectivity-setup/">

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
@@ -120,9 +120,11 @@ const ClusterConnectHelpModal = ({
             borderRadius={"4px"}
             borderWidth={"1px"}
             justifyContent={"space-between"}
+            // flex-direction is set to row-reverse...
+            //... so that the copy button is first to be selected when navigating with keyboard
+            flexDirection="row-reverse"
             padding={"l1"}
           >
-            <pre>{applicationPropertiesString}</pre>
             <ClipBoard
               text={applicationPropertiesString}
               accessibleCopyDescription={
@@ -132,6 +134,7 @@ const ClusterConnectHelpModal = ({
                 "Copied application.properties to clipboard"
               }
             />
+            <pre>{applicationPropertiesString}</pre>
           </Box.Flex>
         </Spacing>
       ) : (

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
@@ -1,0 +1,225 @@
+import {
+  Box,
+  Button,
+  Icon,
+  PositionerPlacement,
+  Spacing,
+  Tooltip,
+  Typography,
+} from "@aivenio/aquarium";
+import duplicate from "@aivenio/aquarium/icons/duplicate";
+import link from "@aivenio/aquarium/icons/link";
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { Modal } from "src/app/components/Modal";
+import { ClusterDetails } from "src/domain/cluster";
+
+const copyToClipboard = async (text: string): Promise<void> => {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    console.error("Failed to copy to clipboard:", error);
+  }
+};
+
+const ClipBoard = ({
+  text,
+  description,
+}: {
+  text: string;
+  description?: string;
+}) => {
+  const feedbackTimerRef = useRef<number>();
+
+  const [showCopyFeedback, setShowCopyFeedback] = useState(false);
+
+  const clearTimeouts = () => {
+    window.clearTimeout(feedbackTimerRef.current);
+  };
+
+  useEffect(() => () => clearTimeouts(), []);
+
+  function handleCopy(event: FormEvent) {
+    event.preventDefault();
+    copyToClipboard(text);
+    setShowCopyFeedback(true);
+    feedbackTimerRef.current = window.setTimeout(
+      () => setShowCopyFeedback(false),
+      1000
+    );
+  }
+
+  if (showCopyFeedback) {
+    return (
+      <Tooltip
+        key="copied"
+        content="Copied"
+        isOpen
+        placement={PositionerPlacement.top}
+      >
+        <Button.SecondaryGhost
+          key="copy-button"
+          aria-label="Copy"
+          onClick={handleCopy}
+          icon={duplicate}
+        >
+          {description}
+        </Button.SecondaryGhost>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip
+      key="copy-to-clipboard"
+      content="Copy to clipboard"
+      placement={PositionerPlacement.top}
+    >
+      <Button.SecondaryGhost
+        key="copy-button"
+        aria-label="Copy"
+        onClick={handleCopy}
+        icon={duplicate}
+      >
+        {description}
+      </Button.SecondaryGhost>
+    </Tooltip>
+  );
+};
+
+const getApplicationPropertiesString = ({
+  clusterName,
+  clusterId,
+  kafkaFlavor,
+  clusterType,
+  protocol,
+}: {
+  clusterName: ClusterDetails["clusterName"];
+  clusterId: ClusterDetails["clusterId"];
+  kafkaFlavor: ClusterDetails["kafkaFlavor"];
+  clusterType: ClusterDetails["clusterType"];
+  protocol: ClusterDetails["protocol"];
+}) => {
+  if (kafkaFlavor === "APACHE_KAFKA" && clusterType === "KAFKA") {
+    if (protocol === "SSL") {
+      return `${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.pwd=keystorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.key.pwd=keyPw\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.pwd=truststorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.type=pkcs12\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.type=JKS`;
+    }
+    if (protocol === "SASL_PLAIN" || protocol === "SASL_SSL_PLAIN_MECHANISM") {
+      return `${clusterName.toLowerCase() + clusterId}.kafkasasl.jaasconfig.plain=org.apache.kafka.common.security.plain.PlainLoginModule\nrequired username='kwuser' password='kwuser-secret'`;
+    }
+    if (
+      protocol === "SASL_SSL_SCRAM_MECHANISM_256" ||
+      protocol === "SASL_SSL_SCRAM_MECHANISM_512"
+    ) {
+      return `${clusterName.toLowerCase() + clusterId}.kafkasasl.jaasconfig.scram=org.apache.kafka.common.security.scram.ScramLoginModule\nrequired username='kwuser' password='kwuser-secret'`;
+    }
+    if (protocol === "SASL_SSL_GSSAPI_MECHANISM") {
+      return `${clusterName.toLowerCase() + clusterId}.kafkasasl.jaasconfig.gssapi=com.sun.security.auth.module.Krb5LoginModule\nrequired useKeyTab=true storeKey=true keyTab="/path/to/kafka_client.keytab"\n<principal=%22kafkaclient1@EXAMPLE.COM>"`;
+    }
+  }
+  if (kafkaFlavor === "AIVEN_FOR_APACHE_KAFKA" && clusterType === "KAFKA") {
+    if (protocol === "SSL") {
+      return `${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.pwd=keystorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.key.pwd=keyPw\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.pwd=truststorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.type=pkcs12\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.type=JKS\nklaw.clusters.accesstoken=yourAivenAccessToken`;
+    }
+    if (protocol === "SASL_PLAIN" || protocol === "SASL_SSL_PLAIN_MECHANISM") {
+      return `${clusterName.toLowerCase() + clusterId}.kafkasasl.jaasconfig.plain=org.apache.kafka.common.security.plain.PlainLoginModule\nrequired username='kwuser' password='kwuser-secret'\nklaw.clusters.accesstoken=yourAivenAccessToken`;
+    }
+    if (
+      protocol === "SASL_SSL_SCRAM_MECHANISM_256" ||
+      protocol === "SASL_SSL_SCRAM_MECHANISM_512"
+    ) {
+      return `${clusterName.toLowerCase() + clusterId}.kafkasasl.jaasconfig.scram=org.apache.kafka.common.security.scram.ScramLoginModule\nrequired username='kwuser' password='kwuser-secret'\nklaw.clusters.accesstoken=yourAivenAccessToken`;
+    }
+    if (protocol === "SASL_SSL_GSSAPI_MECHANISM") {
+      return `${clusterName.toLowerCase() + clusterId}.kafkasasl.jaasconfig.gssapi=com.sun.security.auth.module.Krb5LoginModule\nrequired useKeyTab=true storeKey=true keyTab="/path/to/kafka_client.keytab"\n<principal=%22kafkaclient1@EXAMPLE.COM>\nklaw.clusters.accesstoken=yourAivenAccessToken"`;
+    }
+  }
+
+  if (clusterType === "SCHEMA_REGISTRY" && protocol === "SSL") {
+    return `${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.location=path/to/client.keystore.p12\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.pwd=keystorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.key.pwd=keyPw\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.location=path/to/client.truststore.jks\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.pwd=truststorePw\n${clusterName.toLowerCase() + clusterId}.kafkassl.keystore.type=pkcs12\n${clusterName.toLowerCase() + clusterId}.kafkassl.truststore.type=JKS\n`;
+  }
+
+  if (clusterType === "KAFKA_CONNECT") {
+    if (kafkaFlavor === "AIVEN_FOR_APACHE_KAFKA") {
+      return `${clusterName.toLowerCase() + clusterId}.klaw.kafkaconnect.credentials=aivenUsername:aivenPassword`;
+    }
+    if (kafkaFlavor === "CONFLUENT_CLOUD") {
+      return `${clusterName.toLowerCase() + clusterId}.klaw.confluentcloud.credentials=confluentApikey:confluentApisecret\n${clusterName.toLowerCase() + clusterId}.klaw.clusters.counfluentcloud.acls.api=/kafka/v3/clusters/${clusterId}/acls\n${clusterName.toLowerCase() + clusterId}.klaw.clusters.counfluentcloud.topics.api=/kafka/v3/clusters/${clusterId}/topics\n`;
+    }
+  }
+
+  // Default case: no specific application.properties to copy
+  return "";
+};
+
+interface ClusterConnectHelpModalProps {
+  onClose: () => void;
+  modalData: {
+    kafkaFlavor: ClusterDetails["kafkaFlavor"];
+    protocol: ClusterDetails["protocol"];
+    clusterType: ClusterDetails["clusterType"];
+    clusterName: ClusterDetails["clusterName"];
+    clusterId: ClusterDetails["clusterId"];
+  };
+}
+
+const ClusterConnectHelpModal = ({
+  onClose,
+  modalData: { kafkaFlavor, protocol, clusterType, clusterName, clusterId },
+}: ClusterConnectHelpModalProps) => {
+  const applicationPropertiesString = getApplicationPropertiesString({
+    clusterName,
+    clusterId,
+    kafkaFlavor,
+    clusterType,
+    protocol,
+  });
+
+  return (
+    <Modal
+      title={"Connecting clusters to Klaw"}
+      close={onClose}
+      primaryAction={{ text: "Done", onClick: onClose }}
+    >
+      {applicationPropertiesString.length > 0 ? (
+        <Spacing gap={"l2"}>
+          <Typography.Default>
+            Copy and paste these lines with the correct values to{" "}
+            <pre style={{ display: "inline" }}>
+              klaw/cluster-api/src/main/resources
+            </pre>
+            .
+            <a href="https://www.klaw-project.io/docs/cluster-connectivity-setup/">
+              <Box.Flex alignItems="center" gap={"2"}>
+                Learn more <Icon icon={link} />
+              </Box.Flex>
+            </a>
+          </Typography.Default>
+          <Box.Flex
+            borderColor={"grey-10"}
+            backgroundColor={"grey-0"}
+            borderRadius={"4px"}
+            borderWidth={"1px"}
+            justifyContent={"space-between"}
+            padding={"l1"}
+          >
+            <pre>{applicationPropertiesString}</pre>
+            <ClipBoard text={applicationPropertiesString} />
+          </Box.Flex>
+        </Spacing>
+      ) : (
+        <Typography.Default>
+          <a
+            href="https://www.klaw-project.io/docs/cluster-connectivity-setup/"
+            style={{ display: "inline block" }}
+          >
+            <Box.Flex alignItems="center" gap={"2"}>
+              Learn more about cluster connectivity setup <Icon icon={link} />
+            </Box.Flex>
+          </a>
+        </Typography.Default>
+      )}
+    </Modal>
+  );
+};
+
+export default ClusterConnectHelpModal;

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
@@ -1,6 +1,5 @@
 import { Box, Icon, Spacing, Typography } from "@aivenio/aquarium";
 import link from "@aivenio/aquarium/icons/link";
-import { a } from "msw/lib/core/RequestHandler-CwjkprZE";
 import ClipBoard from "src/app/components/Clipboard";
 import { Modal } from "src/app/components/Modal";
 import { ClusterDetails } from "src/domain/cluster";

--- a/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClusterConnectHelpModal.tsx
@@ -1,90 +1,8 @@
-import {
-  Box,
-  Button,
-  Icon,
-  PositionerPlacement,
-  Spacing,
-  Tooltip,
-  Typography,
-} from "@aivenio/aquarium";
-import duplicate from "@aivenio/aquarium/icons/duplicate";
+import { Box, Icon, Spacing, Typography } from "@aivenio/aquarium";
 import link from "@aivenio/aquarium/icons/link";
-import { FormEvent, useEffect, useRef, useState } from "react";
+import ClipBoard from "src/app/components/Clipboard";
 import { Modal } from "src/app/components/Modal";
 import { ClusterDetails } from "src/domain/cluster";
-
-const copyToClipboard = async (text: string): Promise<void> => {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    console.error("Failed to copy to clipboard:", error);
-  }
-};
-
-const ClipBoard = ({
-  text,
-  description,
-}: {
-  text: string;
-  description?: string;
-}) => {
-  const feedbackTimerRef = useRef<number>();
-
-  const [showCopyFeedback, setShowCopyFeedback] = useState(false);
-
-  const clearTimeouts = () => {
-    window.clearTimeout(feedbackTimerRef.current);
-  };
-
-  useEffect(() => () => clearTimeouts(), []);
-
-  function handleCopy(event: FormEvent) {
-    event.preventDefault();
-    copyToClipboard(text);
-    setShowCopyFeedback(true);
-    feedbackTimerRef.current = window.setTimeout(
-      () => setShowCopyFeedback(false),
-      1000
-    );
-  }
-
-  if (showCopyFeedback) {
-    return (
-      <Tooltip
-        key="copied"
-        content="Copied"
-        isOpen
-        placement={PositionerPlacement.top}
-      >
-        <Button.SecondaryGhost
-          key="copy-button"
-          aria-label="Copy"
-          onClick={handleCopy}
-          icon={duplicate}
-        >
-          {description}
-        </Button.SecondaryGhost>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Tooltip
-      key="copy-to-clipboard"
-      content="Copy to clipboard"
-      placement={PositionerPlacement.top}
-    >
-      <Button.SecondaryGhost
-        key="copy-button"
-        aria-label="Copy"
-        onClick={handleCopy}
-        icon={duplicate}
-      >
-        {description}
-      </Button.SecondaryGhost>
-    </Tooltip>
-  );
-};
 
 const getApplicationPropertiesString = ({
   clusterName,
@@ -205,7 +123,15 @@ const ClusterConnectHelpModal = ({
             padding={"l1"}
           >
             <pre>{applicationPropertiesString}</pre>
-            <ClipBoard text={applicationPropertiesString} />
+            <ClipBoard
+              text={applicationPropertiesString}
+              accessibleCopyDescription={
+                "Copy application.properties to clipboard"
+              }
+              accessibleCopiedDescription={
+                "Copied application.properties to clipboard"
+              }
+            />
           </Box.Flex>
         </Spacing>
       ) : (

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
@@ -321,7 +321,7 @@ describe("ClusterTable.tsx", () => {
           name: new RegExp(`${cluster.clusterName}`, "i"),
         });
         const type = within(row).getByRole("cell", {
-          name: cluster.clusterType,
+          name: clusterTypeToString[cluster.clusterType],
         });
 
         expect(type).toBeVisible();
@@ -335,7 +335,7 @@ describe("ClusterTable.tsx", () => {
           name: new RegExp(`${cluster.clusterName}`, "i"),
         });
         const kafkaFlavor = within(row).getByRole("cell", {
-          name: cluster.kafkaFlavor,
+          name: kafkaFlavorToString[cluster.kafkaFlavor],
         });
 
         expect(kafkaFlavor).toBeVisible();

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { mockIntersectionObserver } from "src/services/test-utils/mock-intersection-observer";
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { ClusterDetails } from "src/domain/cluster";
@@ -48,6 +49,8 @@ const tableRowHeader = [
   "Other params",
 ];
 
+const mockHandleShowModal = jest.fn();
+
 describe("ClusterTable.tsx", () => {
   beforeAll(() => {
     mockIntersectionObserver();
@@ -74,7 +77,7 @@ describe("ClusterTable.tsx", () => {
     });
   });
 
-  describe("shows all clusters as a table", () => {
+  describe("shows all clusters as a table (user without permissions.addDeleteEditClusters)", () => {
     const tableLabel = "Cluster overview";
     beforeAll(() => {
       customRender(
@@ -230,6 +233,207 @@ describe("ClusterTable.tsx", () => {
           expect(projectName).toBeVisible();
         });
       }
+    });
+  });
+  describe("shows all clusters as a table (user with permissions.addDeleteEditClusters)", () => {
+    const tableLabel = "Cluster overview";
+    beforeAll(() => {
+      customRender(
+        <ClustersTable
+          clusters={testCluster}
+          ariaLabel={tableLabel}
+          handleShowModal={mockHandleShowModal}
+        />,
+        { queryClient: true }
+      );
+    });
+
+    afterAll(cleanup);
+
+    it("renders a table with an acessible name", async () => {
+      const table = screen.getByRole("table", {
+        name: tableLabel,
+      });
+
+      expect(table).toBeVisible();
+    });
+
+    tableRowHeader.forEach((header) => {
+      it(`renders a column header for ${header}`, () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const colHeader = within(table).getByRole("columnheader", {
+          name: header,
+        });
+
+        expect(colHeader).toBeVisible();
+      });
+    });
+
+    testCluster.forEach((cluster) => {
+      it(`renders the cluster name "${cluster.clusterName}" as row header`, () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const rowHeader = within(table).getByRole("cell", {
+          name: cluster.clusterName,
+        });
+        const name = within(rowHeader).getByText(cluster.clusterName);
+
+        expect(rowHeader).toBeVisible();
+        expect(name).toBeVisible();
+      });
+
+      it(`renders the bootstrap servers for ${cluster.clusterName} `, () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${cluster.clusterName}`, "i"),
+        });
+        const bootstrapServer = within(row).getByRole("cell", {
+          name: cluster.bootstrapServers,
+        });
+
+        expect(bootstrapServer).toBeVisible();
+      });
+
+      it(`renders the protocol for ${cluster.clusterName}`, () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${cluster.clusterName}`, "i"),
+        });
+        const protocol = within(row).getByRole("cell", {
+          name: cluster.protocol,
+        });
+
+        expect(protocol).toBeVisible();
+      });
+
+      it(`renders the type for ${cluster.clusterName}`, () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${cluster.clusterName}`, "i"),
+        });
+        const type = within(row).getByRole("cell", {
+          name: cluster.clusterType,
+        });
+
+        expect(type).toBeVisible();
+      });
+
+      it(`renders the kafka flavor for ${cluster.clusterName}`, () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${cluster.clusterName}`, "i"),
+        });
+        const kafkaFlavor = within(row).getByRole("cell", {
+          name: cluster.kafkaFlavor,
+        });
+
+        expect(kafkaFlavor).toBeVisible();
+      });
+
+      if (cluster.associatedServers)
+        it(`renders the rest api servers for ${cluster.clusterName}`, () => {
+          const table = screen.getByRole("table", {
+            name: tableLabel,
+          });
+          const row = within(table).getByRole("row", {
+            name: new RegExp(`${cluster.clusterName}`, "i"),
+          });
+          const restApiServer = within(row).getByRole("cell", {
+            name: cluster.associatedServers,
+          });
+
+          expect(restApiServer).toBeVisible();
+        });
+
+      if (cluster.serviceName) {
+        it(`optionally renders the serviceName as other params for ${cluster.clusterName}`, () => {
+          const table = screen.getByRole("table", {
+            name: tableLabel,
+          });
+          const row = within(table).getByRole("row", {
+            name: new RegExp(`${cluster.clusterName}`, "i"),
+          });
+          const serviceNameRegex = new RegExp(
+            `serviceName=${cluster.serviceName}`
+          );
+
+          const serviceName = within(row).getByRole("cell", {
+            name: serviceNameRegex,
+          });
+
+          expect(serviceName).toBeVisible();
+        });
+      }
+
+      if (cluster.projectName) {
+        it(`optionally renders the projectName as other params for ${cluster.clusterName}`, () => {
+          const table = screen.getByRole("table", {
+            name: tableLabel,
+          });
+          const row = within(table).getByRole("row", {
+            name: new RegExp(`${cluster.clusterName}`, "i"),
+          });
+          const projectNameRegex = new RegExp(
+            `projectName=${cluster.projectName}`
+          );
+
+          const projectName = within(row).getByRole("cell", {
+            name: projectNameRegex,
+          });
+
+          expect(projectName).toBeVisible();
+        });
+      }
+
+      it(`renders the Connect help button for ${cluster.clusterName}`, () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${cluster.clusterName}`, "i"),
+        });
+        const connectButton = within(row).getByRole("button", {
+          name: `Display help for connecting the cluster ${cluster.clusterName} to Klaw`,
+        });
+
+        expect(connectButton).toBeEnabled();
+      });
+
+      it(`displays Connect help modal when clicking the Connect help button for ${cluster.clusterName}`, async () => {
+        const table = screen.getByRole("table", {
+          name: tableLabel,
+        });
+        const row = within(table).getByRole("row", {
+          name: new RegExp(`${cluster.clusterName}`, "i"),
+        });
+        const connectButton = within(row).getByRole("button", {
+          name: `Display help for connecting the cluster ${cluster.clusterName} to Klaw`,
+        });
+
+        await userEvent.click(connectButton);
+
+        expect(mockHandleShowModal).toHaveBeenCalledWith({
+          show: true,
+          data: {
+            kafkaFlavor: cluster.kafkaFlavor,
+            protocol: cluster.protocol,
+            clusterType: cluster.clusterType,
+            clusterName: cluster.clusterName,
+            clusterId: cluster.clusterId,
+          },
+        });
+      });
     });
   });
 });

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
@@ -404,7 +404,7 @@ describe("ClusterTable.tsx", () => {
           name: new RegExp(`${cluster.clusterName}`, "i"),
         });
         const connectButton = within(row).getByRole("button", {
-          name: `Display help for connecting the cluster ${cluster.clusterName} to Klaw`,
+          name: `Show help for connecting the cluster ${cluster.clusterName} to Klaw`,
         });
 
         expect(connectButton).toBeEnabled();
@@ -418,7 +418,7 @@ describe("ClusterTable.tsx", () => {
           name: new RegExp(`${cluster.clusterName}`, "i"),
         });
         const connectButton = within(row).getByRole("button", {
-          name: `Display help for connecting the cluster ${cluster.clusterName} to Klaw`,
+          name: `Show help for connecting the cluster ${cluster.clusterName} to Klaw`,
         });
 
         await userEvent.click(connectButton);

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
@@ -44,9 +44,9 @@ const tableRowHeader = [
   "Cluster",
   "Bootstrap servers",
   "Protocol",
-  "Type",
-  "RestApi server",
-  "Other params",
+  "Cluster type",
+  "REST API servers",
+  "Other parameters",
 ];
 
 const mockHandleShowModal = jest.fn();

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
@@ -48,7 +48,7 @@ const ClustersTable = (props: ClustersTableProps) => {
     },
     {
       type: "status",
-      headerName: "Type",
+      headerName: "Cluster type",
       status: ({ clusterType }) => ({
         text: clusterTypeToString[clusterType],
         status: "neutral",
@@ -64,11 +64,11 @@ const ClustersTable = (props: ClustersTableProps) => {
     {
       type: "text",
       field: "restApiServer",
-      headerName: "RestApi server",
+      headerName: "REST API servers",
     },
     {
       type: "custom",
-      headerName: "Other params",
+      headerName: "Other parameters",
       UNSAFE_render: ({ otherParams }: ClustersTableRow) => {
         if (!otherParams.projectName && !otherParams.serviceName) {
           return <div>-NA-</div>;

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
@@ -1,4 +1,5 @@
 import { Box, DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
+import type { ClusterModal } from "src/app/features/configuration/clusters/Clusters";
 import { ClusterDetails } from "src/domain/cluster";
 import { clusterTypeToString } from "src/services/formatter/cluster-type-formatter";
 import { kafkaFlavorToString } from "src/services/formatter/kafka-flavor-formatter";
@@ -6,6 +7,7 @@ import { kafkaFlavorToString } from "src/services/formatter/kafka-flavor-formatt
 type ClustersTableProps = {
   clusters: ClusterDetails[];
   ariaLabel: string;
+  handleShowModal?: ({ show, data }: ClusterModal) => void;
 };
 
 interface ClustersTableRow {
@@ -23,7 +25,7 @@ interface ClustersTableRow {
 }
 
 const ClustersTable = (props: ClustersTableProps) => {
-  const { clusters, ariaLabel } = props;
+  const { clusters, ariaLabel, handleShowModal } = props;
 
   const columns: Array<DataTableColumn<ClustersTableRow>> = [
     {
@@ -84,6 +86,29 @@ const ClustersTable = (props: ClustersTableProps) => {
       },
     },
   ];
+
+  if (handleShowModal !== undefined) {
+    columns.push({
+      type: "action",
+      headerName: "Help",
+      headerInvisible: true,
+      action: ({ kafkaFlavor, protocol, clusterType, clusterName, id }) => ({
+        text: "Connect",
+        onClick: () =>
+          handleShowModal({
+            show: true,
+            data: {
+              kafkaFlavor,
+              protocol,
+              clusterType,
+              clusterName,
+              clusterId: id,
+            },
+          }),
+        "aria-label": `Display help for connecting the cluster ${clusterName} to Klaw`,
+      }),
+    });
+  }
 
   const rows: ClustersTableRow[] = clusters.map((cluster) => {
     return {

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
@@ -90,7 +90,7 @@ const ClustersTable = (props: ClustersTableProps) => {
   if (handleShowModal !== undefined) {
     columns.push({
       type: "action",
-      headerName: "Help",
+      headerName: "",
       headerInvisible: true,
       action: ({ kafkaFlavor, protocol, clusterType, clusterName, id }) => ({
         text: "Connect",
@@ -105,7 +105,7 @@ const ClustersTable = (props: ClustersTableProps) => {
               clusterId: id,
             },
           }),
-        "aria-label": `Display help for connecting the cluster ${clusterName} to Klaw`,
+        "aria-label": `Show help for connecting the cluster ${clusterName} to Klaw`,
       }),
     });
   }


### PR DESCRIPTION
# Linked issue

Resolves: #2295

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

After adding a new clusters, users need to edit application.properties to allow Klaw to connect to the cluster. This is documented, but it would be more accessible and pleasant to have the ui provide copy pasteable config to add to it.

This data should stay available easily.

# What is the new behavior?

- Add action column in the clusters table opening a modal with copy pasteable `application.properties` values
- Automatically open modal after redirecting to clusters table when adding a new cluster
- Only show for users with the right to act on clusters
- Hide for other users


https://github.com/Aiven-Open/klaw/assets/20607294/da2d22a4-9af5-493e-912f-0bcf19afee3a


https://github.com/Aiven-Open/klaw/assets/20607294/4622398d-66f2-4e87-bd26-cc576b8590f2



# Other information

If a newly added cluster has exactly the same `clusterName` as another (which is not uncommon), then we do not open the modal automatically to avoid possibly showing wrong data. This would probably be fixed if theses were implemented:
- https://github.com/Aiven-Open/klaw/issues/2314
- https://github.com/Aiven-Open/klaw/issues/2316

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
