### PR TITLE
fix(coral): New enums for kafkaFlavor and clusterType break existing UI

### DIFF
--- a/coral/src/app/features/configuration/clusters/AddNewClusterForm.test.tsx
+++ b/coral/src/app/features/configuration/clusters/AddNewClusterForm.test.tsx
@@ -200,7 +200,7 @@ describe("<AddNewClusterForm />", () => {
       name: "Kafka Connect",
     });
     const schemaRegistryOption = screen.getByRole("radio", {
-      name: "Schema registry",
+      name: "Schema Registry",
     });
     const protocolSelect = screen.getByRole("combobox", {
       name: "Protocol *",

--- a/coral/src/app/features/configuration/clusters/AddNewClusterForm.tsx
+++ b/coral/src/app/features/configuration/clusters/AddNewClusterForm.tsx
@@ -24,6 +24,8 @@ import {
 import { addNewCluster } from "src/domain/cluster";
 import { parseErrorMsg } from "src/services/mutation-utils";
 import { Routes } from "src/services/router-utils/types";
+import { kafkaFlavorToString } from "src/services/formatter/kafka-flavor-formatter";
+import { clusterTypeToString } from "src/services/formatter/cluster-type-formatter";
 
 const AddNewClusterForm = () => {
   const navigate = useNavigate();
@@ -89,13 +91,13 @@ const AddNewClusterForm = () => {
         required
       >
         <BaseRadioButton name="KAFKA" value="KAFKA">
-          Kafka
+          {clusterTypeToString["KAFKA"]}
         </BaseRadioButton>
         <BaseRadioButton name="KAFKA_CONNECT" value="KAFKA_CONNECT">
-          Kafka Connect
+          {clusterTypeToString["KAFKA_CONNECT"]}
         </BaseRadioButton>
         <BaseRadioButton name="SCHEMA_REGISTRY" value="SCHEMA_REGISTRY">
-          Schema registry
+          {clusterTypeToString["SCHEMA_REGISTRY"]}
         </BaseRadioButton>
       </RadioButtonGroup>
       <TextInput<AddNewClusterFormSchema>
@@ -136,11 +138,17 @@ const AddNewClusterForm = () => {
         placeholder="-- Please select --"
         required
       >
-        <Option value="APACHE_KAFKA">Apache Kafka</Option>
-        <Option value="AIVEN_FOR_APACHE_KAFKA">Aiven for Apache Kafka</Option>
-        <Option value="CONFLUENT">Confluent</Option>
-        <Option value="CONFLUENT_CLOUD">Confluent Cloud</Option>
-        <Option value="OTHERS">Others</Option>
+        <Option value="APACHE_KAFKA">
+          {kafkaFlavorToString["APACHE_KAFKA"]}
+        </Option>
+        <Option value="AIVEN_FOR_APACHE_KAFKA">
+          {kafkaFlavorToString["AIVEN_FOR_APACHE_KAFKA"]}
+        </Option>
+        <Option value="CONFLUENT">{kafkaFlavorToString["CONFLUENT"]}</Option>
+        <Option value="CONFLUENT_CLOUD">
+          {kafkaFlavorToString["CONFLUENT_CLOUD"]}
+        </Option>
+        <Option value="OTHERS">{kafkaFlavorToString["OTHERS"]}</Option>
       </NativeSelect>
 
       {kafkaFlavor === "AIVEN_FOR_APACHE_KAFKA" && clusterType === "KAFKA" && (

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.test.tsx
@@ -3,6 +3,8 @@ import { mockIntersectionObserver } from "src/services/test-utils/mock-intersect
 import { customRender } from "src/services/test-utils/render-with-wrappers";
 import { ClusterDetails } from "src/domain/cluster";
 import { ClustersTable } from "src/app/features/configuration/clusters/components/ClustersTable";
+import { clusterTypeToString } from "src/services/formatter/cluster-type-formatter";
+import { kafkaFlavorToString } from "src/services/formatter/kafka-flavor-formatter";
 
 const testCluster: ClusterDetails[] = [
   {
@@ -154,7 +156,7 @@ describe("ClusterTable.tsx", () => {
           name: new RegExp(`${cluster.clusterName}`, "i"),
         });
         const type = within(row).getByRole("cell", {
-          name: cluster.clusterType,
+          name: clusterTypeToString[cluster.clusterType],
         });
 
         expect(type).toBeVisible();
@@ -168,7 +170,7 @@ describe("ClusterTable.tsx", () => {
           name: new RegExp(`${cluster.clusterName}`, "i"),
         });
         const kafkaFlavor = within(row).getByRole("cell", {
-          name: cluster.kafkaFlavor,
+          name: kafkaFlavorToString[cluster.kafkaFlavor],
         });
 
         expect(kafkaFlavor).toBeVisible();

--- a/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
+++ b/coral/src/app/features/configuration/clusters/components/ClustersTable.tsx
@@ -1,5 +1,7 @@
 import { Box, DataTable, DataTableColumn, EmptyState } from "@aivenio/aquarium";
 import { ClusterDetails } from "src/domain/cluster";
+import { clusterTypeToString } from "src/services/formatter/cluster-type-formatter";
+import { kafkaFlavorToString } from "src/services/formatter/kafka-flavor-formatter";
 
 type ClustersTableProps = {
   clusters: ClusterDetails[];
@@ -46,7 +48,7 @@ const ClustersTable = (props: ClustersTableProps) => {
       type: "status",
       headerName: "Type",
       status: ({ clusterType }) => ({
-        text: clusterType,
+        text: clusterTypeToString[clusterType],
         status: "neutral",
       }),
     },
@@ -55,6 +57,7 @@ const ClustersTable = (props: ClustersTableProps) => {
       field: "kafkaFlavor",
       headerName: "Kafka flavor",
       width: 180,
+      formatter: (value) => kafkaFlavorToString[value],
     },
     {
       type: "text",

--- a/coral/src/app/features/topics/details/overview/components/ClusterDetails.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/ClusterDetails.test.tsx
@@ -6,6 +6,7 @@ import {
   getDefinitionList,
   getAllDefinitions,
 } from "src/services/test-utils/custom-queries";
+import { kafkaFlavorToString } from "src/services/formatter/kafka-flavor-formatter";
 
 const testClusterDetails: ClusterDetailsType = {
   allPageNos: [],
@@ -66,7 +67,7 @@ describe("ClusterDetails", () => {
 
       expect(term).toBeVisible();
       expect(definition[0]).toHaveTextContent(
-        String(testClusterDetails.kafkaFlavor)
+        kafkaFlavorToString[testClusterDetails.kafkaFlavor]
       );
     });
 

--- a/coral/src/app/features/topics/details/overview/components/ClusterDetails.tsx
+++ b/coral/src/app/features/topics/details/overview/components/ClusterDetails.tsx
@@ -8,6 +8,7 @@ import {
 } from "@aivenio/aquarium";
 import React from "react";
 import { ClusterDetails as ClusterDetailsType } from "src/domain/cluster";
+import { kafkaFlavorToString } from "src/services/formatter/kafka-flavor-formatter";
 
 function DefinitionBlock({
   term,
@@ -92,7 +93,11 @@ function ClusterDetails({ clusterDetails, isUpdating }: ClusterDetailsProps) {
 
           <DefinitionBlock
             term={"Kafka flavor"}
-            definition={clusterDetails?.kafkaFlavor}
+            definition={
+              clusterDetails
+                ? kafkaFlavorToString[clusterDetails.kafkaFlavor]
+                : undefined
+            }
             isUpdating={isUpdating}
           />
           <DefinitionBlock

--- a/coral/src/domain/cluster/cluster-types.ts
+++ b/coral/src/domain/cluster/cluster-types.ts
@@ -10,9 +10,16 @@ type ClustersPaginatedApiResponse = ResolveIntersectionTypes<
 
 type AddNewClusterPayload = KlawApiModel<"KwClustersModel">;
 
+type ClusterKafkaFlavor =
+  KlawApiModel<"KwClustersModelResponse">["kafkaFlavor"];
+
+type ClusterType = KlawApiModel<"KwClustersModelResponse">["clusterType"];
+
 export type {
   ClusterInfoFromEnvironment,
   ClusterDetails,
   ClustersPaginatedApiResponse,
   AddNewClusterPayload,
+  ClusterKafkaFlavor,
+  ClusterType,
 };

--- a/coral/src/domain/cluster/index.ts
+++ b/coral/src/domain/cluster/index.ts
@@ -8,6 +8,8 @@ import {
   AddNewClusterPayload,
   ClusterInfoFromEnvironment,
   ClusterDetails,
+  ClusterKafkaFlavor,
+  ClusterType,
 } from "src/domain/cluster/cluster-types";
 
 export {
@@ -20,4 +22,6 @@ export type {
   AddNewClusterPayload,
   ClusterInfoFromEnvironment,
   ClusterDetails,
+  ClusterKafkaFlavor,
+  ClusterType,
 };

--- a/coral/src/services/formatter/cluster-type-formatter.ts
+++ b/coral/src/services/formatter/cluster-type-formatter.ts
@@ -1,0 +1,11 @@
+import { ClusterType } from "src/domain/cluster";
+
+type ClusterTypeMap = Record<ClusterType, string>;
+const clusterTypeToString: ClusterTypeMap = {
+  ALL: "All",
+  KAFKA: "Kafka",
+  SCHEMA_REGISTRY: "Schema Registry",
+  KAFKA_CONNECT: "Kafka Connect",
+};
+
+export { clusterTypeToString };

--- a/coral/src/services/formatter/kafka-flavor-formatter.ts
+++ b/coral/src/services/formatter/kafka-flavor-formatter.ts
@@ -1,0 +1,12 @@
+import { ClusterKafkaFlavor } from "src/domain/cluster";
+
+type ClusterKafkaFlavorMap = Record<ClusterKafkaFlavor, string>;
+const kafkaFlavorToString: ClusterKafkaFlavorMap = {
+  APACHE_KAFKA: "Apache Kafka",
+  AIVEN_FOR_APACHE_KAFKA: "Aiven for Apache Kafka",
+  CONFLUENT: "Confluent",
+  CONFLUENT_CLOUD: "Confluent Cloud",
+  OTHERS: "others",
+};
+
+export { kafkaFlavorToString };


### PR DESCRIPTION
## Linked issue

Resolves: #2308

## What kind of change does this PR introduce?

- [x] (UI) Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

## What is the current behavior?

The enum values are shown, e.g.:

<img width="903" alt="Screenshot 2024-02-26 at 15 55 46" src="https://github.com/Aiven-Open/klaw/assets/943800/9075d776-4561-4e95-a004-c02db4535428">


## What is the new behavior?

Kafka flavor as well as Cluster type have a const that map the ENUM to a more readable string value. This is used where we show date in the UI. 


##  Screenshots of all places I found 

### Cluster table (browse cluster)

<img width="1292" alt="Screenshot 2024-02-26 at 15 57 34" src="https://github.com/Aiven-Open/klaw/assets/943800/8c5b00c6-ee23-4188-a5c5-76006bc8c15e">

### Topic overview
<img width="628" alt="Screenshot 2024-02-26 at 15 58 16" src="https://github.com/Aiven-Open/klaw/assets/943800/4eeeb86a-313b-458f-8f98-10f78ba8dc15">


### Add new Cluster (superadmin)

<img width="996" alt="Screenshot 2024-02-26 at 16 03 30" src="https://github.com/Aiven-Open/klaw/assets/943800/850895fa-61b2-460f-897a-3cf7d4d1617d">



# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
