### PR TITLE
fix(angular-ui): New enums for kafkaFlavor and clusterType break existing UI 

### DIFF
--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -4,6 +4,7 @@
 // edit 
 // solution for transaction
 // message store / key / gui
+
 var app = angular.module('envsApp',[]);
 
 app.directive('onReadFile', function ($parse) {
@@ -31,6 +32,14 @@ app.directive('onReadFile', function ($parse) {
 app.controller("envsCtrl", function($scope, $http, $location, $window) {
 
 	$scope.kafkaClusters = [ { label: 'Non-Aiven', value: 'nonaiven' }, { label: 'Aiven', value: 'aiven' }	];
+
+    $scope.kafkaFlavorToString = {
+        APACHE_KAFKA: "Apache Kafka",
+        AIVEN_FOR_APACHE_KAFKA: "Aiven for Apache Kafka",
+        CONFLUENT: "Confluent",
+        CONFLUENT_CLOUD: "Confluent Cloud",
+        OTHERS: "others",
+    };
 
 	// Set http service defaults
 	// We force the "Accept" header to be only "application/json"

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -7,7 +7,15 @@
 var app = angular.module('modifyEnvsApp',[]);
 
 app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
-	
+
+    $scope.kafkaFlavorToString = {
+        APACHE_KAFKA: "Apache Kafka",
+        AIVEN_FOR_APACHE_KAFKA: "Aiven for Apache Kafka",
+        CONFLUENT: "Confluent",
+        CONFLUENT_CLOUD: "Confluent Cloud",
+        OTHERS: "others",
+    };
+
 	// Set http service defaults
 	// We force the "Accept" header to be only "application/json"
 	// otherwise we risk the Accept header being set by default to:

--- a/core/src/main/resources/templates/clusters.html
+++ b/core/src/main/resources/templates/clusters.html
@@ -518,16 +518,16 @@
 										<td> {{ allenv.protocol}} </td>
 
 										<td ng-show="allenv.clusterType == 'KAFKA'" >
-											<span class="badge badge-success">{{ allenv.clusterType }}</span></td>
+											<span class="badge badge-success">Kafka</span></td>
 
 										<td ng-show="allenv.clusterType == 'SCHEMA_REGISTRY'" >
-											<span class="badge badge-info">{{ allenv.clusterType }}</span></td>
+											<span class="badge badge-info">Schema Registry</span></td>
 
 										<td ng-show="allenv.clusterType == 'KAFKA_CONNECT'" >
-											<span class="badge badge-warning">{{ allenv.clusterType }}</span></td>
+											<span class="badge badge-warning">Kafka Connect</span></td>
 
 
-										<td>{{ allenv.kafkaFlavor }}</td>
+										<td>{{ kafkaFlavorToString[allenv.kafkaFlavor] }}</td>
 
 										<td>{{ allenv.associatedServers }}</td>
 

--- a/core/src/main/resources/templates/modifyCluster.html
+++ b/core/src/main/resources/templates/modifyCluster.html
@@ -525,8 +525,8 @@
 									<div class="row">
 										<div class="col-md-6">
 											<div class="form-group">
-												<label class="control-label">Kafka Flavor : </label>
-												<label><span class="badge badge-info">{{ clusterDetails.kafkaFlavor }}</span> </label>
+												<label class="control-label">Kafka Flavor: </label>
+												<label><span class="badge badge-info">{{ kafkaFlavorToString[clusterDetails.kafkaFlavor] }}</span> </label>
 											</div>
 										</div>
 									</div>
@@ -636,8 +636,8 @@
 									<div class="row">
 										<div class="col-md-6">
 											<div class="form-group">
-												<label class="control-label">Kafka Flavor : </label>
-												<label><span class="badge badge-info">{{ clusterDetails.kafkaFlavor }}</span> </label>
+												<label class="control-label">Kafka Flavor: </label>
+												<label><span class="badge badge-info">{{ kafkaFlavorToString[clusterDetails.kafkaFlavor] }}</span> </label>
 											</div>
 										</div>
 									</div>
@@ -712,8 +712,8 @@
 									<div class="row">
 										<div class="col-md-6">
 											<div class="form-group">
-												<label class="control-label">Kafka Flavor : </label>
-												<label><span class="badge badge-info">{{ clusterDetails.kafkaFlavor }}</span> </label>
+												<label class="control-label">Kafka Flavor: </label>
+												<label><span class="badge badge-info">{{ kafkaFlavorToString[clusterDetails.kafkaFlavor] }}</span> </label>
 											</div>
 										</div>
 									</div>


### PR DESCRIPTION
# Linked issue

Relates to #2307 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

ENUMS are shown as is, e.g. 
<img width="1325" alt="cluster-user" src="https://github.com/Aiven-Open/klaw/assets/943800/b6177644-9796-464b-983f-537e5fce704e">

# What is the new behavior?

We show a string value instead of ENUM.

## Places changed

I only could find actual usage of the ENUM as string in `clusters.html` (for users as well as admin) and `modifyCluster.html`.

I hope that is correct!

