### PR TITLE
feat: Add support for clusterType param in getClustersPaginated endpoint

### DIFF
--- a/coral/src/domain/cluster/cluster-api.ts
+++ b/coral/src/domain/cluster/cluster-api.ts
@@ -37,7 +37,7 @@ async function getClustersPaginated({
   "clusterType"
 >): Promise<ClustersPaginatedApiResponse> {
   const params: KlawApiRequestQueryParameters<"getClustersPaginated"> = {
-    clusterType: "all",
+    clusterType: "ALL",
     pageNo,
     ...(searchClusterParam && { searchClusterParam: searchClusterParam }),
   };

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -4013,7 +4013,7 @@ export type operations = {
   getClustersPaginated: {
     parameters: {
       query: {
-        clusterType: string;
+        clusterType: "ALL" | "KAFKA" | "SCHEMA_REGISTRY" | "KAFKA_CONNECT";
         pageNo: string;
         clusterId?: string;
         searchClusterParam?: string;

--- a/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/EnvsClustersTenantsController.java
@@ -48,7 +48,7 @@ public class EnvsClustersTenantsController {
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<List<KwClustersModelResponse>> getClustersPaginated(
-      @RequestParam(value = "clusterType") String clusterType,
+      @RequestParam(value = "clusterType") KafkaClustersType clusterType,
       @RequestParam("pageNo") String pageNo,
       @RequestParam(value = "clusterId", defaultValue = "") String clusterId,
       @RequestParam(value = "searchClusterParam", defaultValue = "") String searchClusterParam) {

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -169,8 +169,10 @@ public class EnvsClustersTenantsControllerService {
   }
 
   public List<KwClustersModelResponse> getClustersPaginated(
-      String typeOfCluster, String clusterId, String pageNo, String searchClusterParam) {
-    List<KwClustersModelResponse> kwClustersModelList = getClusters("all");
+      KafkaClustersType typeOfCluster, String clusterId, String pageNo, String searchClusterParam) {
+
+    String clusterTypeValue = typeOfCluster.value;
+    List<KwClustersModelResponse> kwClustersModelList = getClusters(clusterTypeValue);
 
     if (clusterId != null && !clusterId.equals("")) {
       kwClustersModelList =

--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -247,9 +247,9 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                         method: "GET",
                         url: "getClustersPaginated",
                         headers : { 'Content-Type' : 'application/json' },
-                        params: {'clusterType' : 'all', 'clusterId' : $scope.clusterIdFromUrl,
+                        params: {'clusterType' : 'ALL', 'clusterId' : $scope.clusterIdFromUrl,
                          'pageNo' : pageNo, 'searchClusterParam' : $scope.searchClusterParam},
-                        data: {'clusterType' : 'all'}
+                        data: {'clusterType' : 'ALL'}
                     }).success(function(output) {
                         $scope.allclustersset = output;
                         if(output && output.length > 0 && output[0] != null){

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4827,7 +4827,8 @@
           "in" : "query",
           "required" : true,
           "schema" : {
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "ALL", "KAFKA", "SCHEMA_REGISTRY", "KAFKA_CONNECT" ]
           }
         }, {
           "name" : "pageNo",


### PR DESCRIPTION
# Linked issue

Resolves to: #2314

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

While `getClustersPaginated`  has a parameter `typeOfCluster`, it uses:

`List<KwClustersModelResponse> kwClustersModelList = getClusters("all");` 


# What is the new behavior?

To enabed filtering by `clusterType` in coral later: 

- `getClustersPaginated` now expects `typeOfCluster` being oft type `KafkaClustersType` 
- 

`getClustersPaginated` does take a string (representing the enum of `KafkaClustersType`  `typeOfCluster` 
- it passes `String clusterTypeValue = typeOfCluster.value;` to `getClusters` (this way, there are no further changes needed related to `getClusters`
- it changes "all" to "ALL" for the call to `getClustersPaginated` in `env.js` in Angular (that's the only place I've found it used)
- changes "all" to "ALL" in the same call in coral 

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
