### PR TITLE
Setting the default schema version on promote to be an information message

### DIFF
--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -975,7 +975,7 @@
 																			required
 																			ng-model="schema.versionSelected"
 																			ng-options="schemaVersion for schemaVersion in schemaVersions">
-																		<option schemaPromotionDetails="" selected="selected">
+																		<option value="" >
 																			Select Version to Promote</option>
 																	</select>
 																</div>


### PR DESCRIPTION

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The information message to select a version to promote is not displaying.
# What is the new behavior?

This message is now displayed correctly. 
![image](https://github.com/Aiven-Open/klaw/assets/121855584/8bc9e0e6-2da9-42aa-9f23-0caff4dc350d)


# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
