### PR TITLE
ci: Add explicit permission to gh workflow for openapi types

### DIFF
--- a/.github/workflows/workflow-check-openapi-changes.yaml
+++ b/.github/workflows/workflow-check-openapi-changes.yaml
@@ -29,6 +29,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: write
+
 jobs:
   check-for-changes-openapi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Since permissions etc settings are controlled by the organisation, our github workflow to autogenerate and commit the updated TS types file for openapi changes needs an explict permission to be able to work. 

This PR adds this permission. 

✅ I comitted an openapi change that causes an update for our ts file withoug breaking, and the commit went trough successfully: https://github.com/Aiven-Open/klaw/actions/runs/8165890825/job/22323766564

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [x] CI update

