### PR TITLE
feat(coral): Add cluster type filter to Clusters table 

### DIFF
--- a/coral/src/app/features/components/ClusterTypeFilter.test.tsx
+++ b/coral/src/app/features/components/ClusterTypeFilter.test.tsx
@@ -1,0 +1,115 @@
+import { customRender } from "src/services/test-utils/render-with-wrappers";
+import { ClusterTypeFilter } from "src/app/features/components/filters/ClusterTypeFilter";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { withFiltersContext } from "src/app/features/components/filters/useFiltersContext";
+import {
+  clusterTypeMapList,
+  clusterTypeToString,
+} from "src/services/formatter/cluster-type-formatter";
+
+const WrappedClusterTypeFilter = withFiltersContext({
+  element: <ClusterTypeFilter />,
+});
+
+describe("ClusterTypeFilter", () => {
+  const user = userEvent.setup();
+
+  const selectLabel = "Filter by cluster type";
+  const specialOptionNameForTypeAll = "All cluster types";
+
+  describe("renders default view when no clusterType is set", () => {
+    beforeAll(() => {
+      customRender(<WrappedClusterTypeFilter />, {
+        memoryRouter: true,
+      });
+    });
+
+    afterAll(cleanup);
+
+    it("shows a select element", () => {
+      const select = screen.getByRole("combobox", { name: selectLabel });
+
+      expect(select).toBeEnabled();
+    });
+
+    it("shows the ALL value as selected by default", () => {
+      const select = screen.getByRole("combobox", { name: selectLabel });
+
+      expect(select).toHaveValue("ALL");
+      expect(select).toHaveDisplayValue(specialOptionNameForTypeAll);
+    });
+
+    clusterTypeMapList.forEach((clusterTypeMapEntry) => {
+      it(`shows an option for ${clusterTypeMapEntry.value}`, () => {
+        const name =
+          clusterTypeMapEntry.value === "ALL"
+            ? specialOptionNameForTypeAll
+            : clusterTypeMapEntry.name;
+        const option = screen.getByRole("option", { name: name });
+
+        expect(option).toBeVisible();
+        expect(option).toHaveValue(clusterTypeMapEntry.value);
+      });
+    });
+  });
+
+  describe("selects the option based on a query param", () => {
+    const selectedClusterType = "KAFKA";
+    const routePath = `/cluster?clusterType=${selectedClusterType}`;
+
+    beforeAll(async () => {
+      customRender(<WrappedClusterTypeFilter />, {
+        memoryRouter: true,
+        customRoutePath: routePath,
+      });
+    });
+
+    afterAll(cleanup);
+
+    it("shows the KAFKA value as selected based on url query", () => {
+      const select = screen.getByRole("combobox", { name: selectLabel });
+
+      expect(select).toHaveValue(selectedClusterType);
+    });
+  });
+
+  describe("sets the clusterType search parameter when user changes selected option", () => {
+    const newOptionValue = "SCHEMA_REGISTRY";
+
+    beforeEach(() => {
+      customRender(<WrappedClusterTypeFilter />, {
+        browserRouter: true,
+      });
+    });
+
+    afterEach(() => {
+      // resets url to get to clean state again
+      window.history.pushState({}, "No page title", "/");
+      cleanup();
+    });
+
+    it("shows ALL as selected and no url query per default", () => {
+      const select = screen.getByRole("combobox", { name: selectLabel });
+
+      expect(select).toHaveValue("ALL");
+      expect(window.location.search).toEqual("");
+    });
+
+    it("enables user to select different type", async () => {
+      const select = screen.getByRole("combobox", { name: selectLabel });
+      const option = screen.getByRole("option", {
+        name: clusterTypeToString[newOptionValue],
+      });
+
+      await user.selectOptions(select, option);
+      expect(select).toHaveValue(newOptionValue);
+
+      await waitFor(() => {
+        expect(window.location.search).toEqual(
+          `?clusterType=${newOptionValue}&page=1`
+        );
+      });
+    });
+  });
+});

--- a/coral/src/app/features/components/filters/ClusterTypeFilter.tsx
+++ b/coral/src/app/features/components/filters/ClusterTypeFilter.tsx
@@ -1,0 +1,36 @@
+import { NativeSelect } from "@aivenio/aquarium";
+import { ChangeEvent } from "react";
+import { useFiltersContext } from "src/app/features/components/filters/useFiltersContext";
+import { ClusterType } from "src/domain/cluster";
+import { clusterTypeMapList } from "src/services/formatter/cluster-type-formatter";
+
+function ClusterTypeFilter() {
+  const { clusterType, setFilterValue } = useFiltersContext();
+
+  const handleChangeClusterType = (e: ChangeEvent<HTMLSelectElement>) => {
+    const nextOperationType = e.target.value as ClusterType;
+
+    setFilterValue({ name: "clusterType", value: nextOperationType });
+  };
+
+  return (
+    <NativeSelect
+      labelText={"Filter by cluster type"}
+      key={"filter-cluster-type"}
+      defaultValue={clusterType}
+      onChange={handleChangeClusterType}
+    >
+      {clusterTypeMapList.map((clusterType) => {
+        return (
+          <option key={clusterType.value} value={clusterType.value}>
+            {clusterType.value === "ALL"
+              ? "All cluster types"
+              : clusterType.name}
+          </option>
+        );
+      })}
+    </NativeSelect>
+  );
+}
+
+export { ClusterTypeFilter };

--- a/coral/src/app/features/components/filters/useFiltersContext.test.tsx
+++ b/coral/src/app/features/components/filters/useFiltersContext.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "src/app/features/components/filters/useFiltersContext";
 
 describe("useFiltersValues.tsx", () => {
-  describe("should get correct filter values from search params", () => {
+  describe("gets correct filter values from search params", () => {
     afterEach(() => {
       cleanup();
     });
@@ -24,6 +24,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(current.environment).toBe("1");
     });
+
     it("gets the correct aclType filter value", () => {
       const {
         result: { current },
@@ -37,6 +38,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(current.aclType).toBe("PRODUCER");
     });
+
     it("gets the correct status filter value", () => {
       const {
         result: { current },
@@ -50,6 +52,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(current.status).toBe("CREATED");
     });
+
     it("gets the correct team filter value", () => {
       const {
         result: { current },
@@ -63,6 +66,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(current.teamId).toBe("1");
     });
+
     it("gets the correct showOnlyMyRequests filter value", () => {
       const {
         result: { current },
@@ -76,6 +80,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(current.showOnlyMyRequests).toBe(true);
     });
+
     it("gets the correct operationType filter value", () => {
       const {
         result: { current },
@@ -104,124 +109,155 @@ describe("useFiltersValues.tsx", () => {
       expect(current.search).toBe("abc");
     });
 
-    describe("should get correct filter values when default value is passed", () => {
-      afterEach(() => {
-        cleanup();
+    it("gets the correct clusterType filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter initialEntries={["/?clusterType=KAFKA"]}>
+            <FiltersProvider>{children}</FiltersProvider>
+          </MemoryRouter>
+        ),
       });
 
-      it("gets the correct environment filter value", () => {
-        const {
-          result: { current },
-        } = renderHook(() => useFiltersContext(), {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <FiltersProvider defaultValues={{ environment: "2" }}>
-                {children}
-              </FiltersProvider>
-            </MemoryRouter>
-          ),
-        });
-
-        expect(current.environment).toBe("2");
-      });
-
-      it("gets the correct aclType filter value", () => {
-        const {
-          result: { current },
-        } = renderHook(() => useFiltersContext(), {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <FiltersProvider defaultValues={{ aclType: "CONSUMER" }}>
-                {children}
-              </FiltersProvider>
-            </MemoryRouter>
-          ),
-        });
-
-        expect(current.aclType).toBe("CONSUMER");
-      });
-
-      it("gets the correct status filter value", () => {
-        const {
-          result: { current },
-        } = renderHook(() => useFiltersContext(), {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <FiltersProvider defaultValues={{ status: "DELETED" }}>
-                {children}
-              </FiltersProvider>
-            </MemoryRouter>
-          ),
-        });
-
-        expect(current.status).toBe("DELETED");
-      });
-
-      it("gets the correct team filter value", () => {
-        const {
-          result: { current },
-        } = renderHook(() => useFiltersContext(), {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <FiltersProvider defaultValues={{ teamId: "2" }}>
-                {children}
-              </FiltersProvider>
-            </MemoryRouter>
-          ),
-        });
-
-        expect(current.teamId).toBe("2");
-      });
-
-      it("gets the correct showOnlyMyRequests filter value", () => {
-        const {
-          result: { current },
-        } = renderHook(() => useFiltersContext(), {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <FiltersProvider defaultValues={{ showOnlyMyRequests: false }}>
-                {children}
-              </FiltersProvider>
-            </MemoryRouter>
-          ),
-        });
-
-        expect(current.showOnlyMyRequests).toBe(false);
-      });
-
-      it("gets the correct operationType filter value", () => {
-        const {
-          result: { current },
-        } = renderHook(() => useFiltersContext(), {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <FiltersProvider defaultValues={{ requestType: "CREATE" }}>
-                {children}
-              </FiltersProvider>
-            </MemoryRouter>
-          ),
-        });
-
-        expect(current.requestType).toBe("CREATE");
-      });
-
-      it("gets the correct search filter value", () => {
-        const {
-          result: { current },
-        } = renderHook(() => useFiltersContext(), {
-          wrapper: ({ children }) => (
-            <MemoryRouter>
-              <FiltersProvider defaultValues={{ search: "abc" }}>
-                {children}
-              </FiltersProvider>
-            </MemoryRouter>
-          ),
-        });
-
-        expect(current.search).toBe("abc");
-      });
+      expect(current.clusterType).toBe("KAFKA");
     });
   });
+
+  describe("gets correct filter values when default value is passed", () => {
+    afterEach(() => {
+      cleanup();
+    });
+
+    it("gets the correct environment filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ environment: "2" }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.environment).toBe("2");
+    });
+
+    it("gets the correct aclType filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ aclType: "CONSUMER" }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.aclType).toBe("CONSUMER");
+    });
+
+    it("gets the correct status filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ status: "DELETED" }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.status).toBe("DELETED");
+    });
+
+    it("gets the correct team filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ teamId: "2" }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.teamId).toBe("2");
+    });
+
+    it("gets the correct showOnlyMyRequests filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ showOnlyMyRequests: false }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.showOnlyMyRequests).toBe(false);
+    });
+
+    it("gets the correct operationType filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ requestType: "CREATE" }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.requestType).toBe("CREATE");
+    });
+
+    it("gets the correct search filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ search: "abc" }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.search).toBe("abc");
+    });
+
+    it("gets the correct clusterType filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter>
+            <FiltersProvider defaultValues={{ clusterType: "SCHEMA_REGISTRY" }}>
+              {children}
+            </FiltersProvider>
+          </MemoryRouter>
+        ),
+      });
+
+      expect(current.clusterType).toBe("SCHEMA_REGISTRY");
+    });
+  });
+
   describe("should set correct filter values when using setFilterValue", () => {
     afterEach(() => {
       window.history.pushState({}, "", "/");
@@ -246,6 +282,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(window.location.search).toBe("?environment=1&page=1");
     });
+
     it("sets the correct aclType filter value", () => {
       const {
         result: { current },
@@ -264,6 +301,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(window.location.search).toBe("?aclType=PRODUCER&page=1");
     });
+
     it("sets the correct status filter value", () => {
       const {
         result: { current },
@@ -282,6 +320,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(window.location.search).toBe("?status=CREATED&page=1");
     });
+
     it("sets the correct team filter value", () => {
       const {
         result: { current },
@@ -300,6 +339,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(window.location.search).toBe("?teamId=2&page=1");
     });
+
     it("sets the correct showOnlyMyRequests filter value", () => {
       const {
         result: { current },
@@ -318,6 +358,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(window.location.search).toBe("?showOnlyMyRequests=true&page=1");
     });
+
     it("sets the correct operationType filter value", () => {
       const {
         result: { current },
@@ -336,6 +377,7 @@ describe("useFiltersValues.tsx", () => {
 
       expect(window.location.search).toBe("?requestType=CREATE&page=1");
     });
+
     it("sets the correct search filter value", () => {
       const {
         result: { current },
@@ -353,6 +395,25 @@ describe("useFiltersValues.tsx", () => {
       });
 
       expect(window.location.search).toBe("?search=abc&page=1");
+    });
+
+    it("sets the correct clusterType filter value", () => {
+      const {
+        result: { current },
+      } = renderHook(() => useFiltersContext(), {
+        wrapper: ({ children }) => (
+          <BrowserRouter>
+            <FiltersProvider>{children}</FiltersProvider>
+          </BrowserRouter>
+        ),
+      });
+
+      current.setFilterValue({
+        name: "clusterType",
+        value: "KAFKA_CONNECT",
+      });
+
+      expect(window.location.search).toBe("?clusterType=KAFKA_CONNECT&page=1");
     });
   });
 });

--- a/coral/src/app/features/components/filters/useFiltersContext.tsx
+++ b/coral/src/app/features/components/filters/useFiltersContext.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, createContext, useContext } from "react";
 import { useSearchParams } from "react-router-dom";
 import { AclType } from "src/domain/acl/acl-types";
+import { ClusterType } from "src/domain/cluster";
 import { RequestOperationType, RequestStatus } from "src/domain/requests";
 import { TopicType } from "src/domain/topic";
 
@@ -13,7 +14,8 @@ type SetFiltersParams =
   | { name: "requestType"; value: RequestOperationType }
   | { name: "search"; value: string }
   | { name: "teamName"; value: string }
-  | { name: "topicType"; value: TopicType | "ALL" };
+  | { name: "topicType"; value: TopicType | "ALL" }
+  | { name: "clusterType"; value: ClusterType };
 
 interface UseFiltersDefaultValues {
   environment: string;
@@ -26,6 +28,7 @@ interface UseFiltersDefaultValues {
   paginated: boolean;
   teamName: string;
   topicType: TopicType | "ALL";
+  clusterType: ClusterType;
 }
 
 interface UseFiltersReturnedValues
@@ -44,6 +47,7 @@ const emptyValues: UseFiltersDefaultValues = {
   search: "",
   paginated: true,
   topicType: "ALL",
+  clusterType: "ALL",
 };
 
 const FiltersContext = createContext<UseFiltersReturnedValues>({
@@ -80,6 +84,9 @@ const FiltersProvider = ({
   const teamName = searchParams.get("teamName") ?? initialValues.teamName;
   const topicType =
     (searchParams.get("topicType") as TopicType) ?? initialValues.topicType;
+  const clusterType =
+    (searchParams.get("clusterType") as ClusterType) ??
+    initialValues.clusterType;
 
   const setFilterValue = ({ name, value }: SetFiltersParams) => {
     const parsedValue = typeof value === "boolean" ? String(value) : value;
@@ -106,6 +113,7 @@ const FiltersProvider = ({
     requestType,
     search,
     topicType,
+    clusterType,
     setFilterValue,
   };
 
@@ -129,4 +137,4 @@ const withFiltersContext = ({
   return WrappedElement;
 };
 
-export { useFiltersContext, FiltersProvider, withFiltersContext };
+export { FiltersProvider, useFiltersContext, withFiltersContext };

--- a/coral/src/app/features/configuration/clusters/Clusters.tsx
+++ b/coral/src/app/features/configuration/clusters/Clusters.tsx
@@ -12,6 +12,7 @@ import { TableLayout } from "src/app/features/components/layouts/TableLayout";
 import ClusterConnectHelpModal from "src/app/features/configuration/clusters/components/ClusterConnectHelpModal";
 import { ClustersTable } from "src/app/features/configuration/clusters/components/ClustersTable";
 import { ClusterDetails, getClustersPaginated } from "src/domain/cluster";
+import { ClusterTypeFilter } from "src/app/features/components/filters/ClusterTypeFilter";
 
 // We add this default data to avoid dealing with the fact that it may be undefined when closing the modal...
 // ... and resetting the state
@@ -30,16 +31,17 @@ function Clusters() {
     ? Number(searchParams.get("page"))
     : 1;
 
-  const { search } = useFiltersContext();
+  const { search, clusterType } = useFiltersContext();
 
   const {
     data: clusters,
     isLoading,
     isError,
     error,
-  } = useQuery(["get-clusters-paginated", currentPage, search], {
+  } = useQuery(["get-clusters-paginated", currentPage, search, clusterType], {
     queryFn: () =>
       getClustersPaginated({
+        clusterType,
         pageNo: currentPage.toString(),
         searchClusterParam: search.length === 0 ? undefined : search,
       }),
@@ -125,7 +127,10 @@ function Clusters() {
       )}
 
       <TableLayout
-        filters={[<SearchClusterParamFilter key={"search"} />]}
+        filters={[
+          <ClusterTypeFilter key={"clusterType"} />,
+          <SearchClusterParamFilter key={"search"} />,
+        ]}
         table={
           <ClustersTable
             clusters={clusters?.entries || []}

--- a/coral/src/domain/cluster/cluster-api.ts
+++ b/coral/src/domain/cluster/cluster-api.ts
@@ -32,12 +32,10 @@ function getClusterDetails(clusterId: string) {
 async function getClustersPaginated({
   pageNo,
   searchClusterParam,
-}: Omit<
-  KlawApiRequestQueryParameters<"getClustersPaginated">,
-  "clusterType"
->): Promise<ClustersPaginatedApiResponse> {
+  clusterType,
+}: KlawApiRequestQueryParameters<"getClustersPaginated">): Promise<ClustersPaginatedApiResponse> {
   const params: KlawApiRequestQueryParameters<"getClustersPaginated"> = {
-    clusterType: "ALL",
+    clusterType,
     pageNo,
     ...(searchClusterParam && { searchClusterParam: searchClusterParam }),
   };

--- a/coral/src/services/formatter/cluster-type-formatter.ts
+++ b/coral/src/services/formatter/cluster-type-formatter.ts
@@ -8,4 +8,11 @@ const clusterTypeToString: ClusterTypeMap = {
   KAFKA_CONNECT: "Kafka Connect",
 };
 
-export { clusterTypeToString };
+const clusterTypeMapList: { value: ClusterType; name: string }[] = Object.keys(
+  clusterTypeToString
+).map((clusterTypeKey) => {
+  const value = clusterTypeKey as ClusterType;
+  return { value, name: clusterTypeToString[value] };
+});
+
+export { clusterTypeToString, clusterTypeMapList };


### PR DESCRIPTION
# Linked issue

Resolves: #2316

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# Description

User now can filter clusters based on cluster type.

## Recording


https://github.com/Aiven-Open/klaw/assets/943800/e1bad025-d75b-4838-8c40-6c6197b37033




# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
