### PR TITLE
refactor(coral): Add failOnConsole for errors and warnings to test setup

### DIFF
--- a/coral/package.json
+++ b/coral/package.json
@@ -88,6 +88,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fail-on-console": "^3.1.2",
     "jest-transform-stub": "^2.0.0",
     "lint-staged": "^15.2.2",
     "lodash": "^4.17.21",

--- a/coral/pnpm-lock.yaml
+++ b/coral/pnpm-lock.yaml
@@ -151,6 +151,9 @@ devDependencies:
   jest-environment-jsdom:
     specifier: ^29.7.0
     version: 29.7.0
+  jest-fail-on-console:
+    specifier: ^3.1.2
+    version: 3.1.2
   jest-transform-stub:
     specifier: ^2.0.0
     version: 2.0.0
@@ -7248,6 +7251,10 @@ packages:
       '@types/node': 18.17.14
       jest-mock: 29.7.0
       jest-util: 29.7.0
+    dev: true
+
+  /jest-fail-on-console@3.1.2:
+    resolution: {integrity: sha512-Z4TDJn/QvhlGflxyh8JyqRU3ovEvR2OD8rIsZU8zHJxjC9rto9XeLdqH+RPHY65Tc6riSXq1HK93uLMABaRpbg==}
     dev: true
 
   /jest-get-type@29.6.3:

--- a/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
+++ b/coral/src/app/components/AsyncNativeSelectWrapper.test.tsx
@@ -41,17 +41,10 @@ describe("AsyncNativeSelectWrapper", () => {
   beforeAll(mockIntersectionObserver);
 
   describe("only accepts a <NativeSelect> or <ComplexNativeSelect> as child", () => {
-    const originalConsoleError = console.error;
-    beforeEach(() => {
-      console.error = jest.fn();
-    });
-
-    afterEach(() => {
-      console.error = originalConsoleError;
-      cleanup();
-    });
+    afterEach(cleanup);
 
     it("throws an error when child element is a html element", () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       expect(() =>
         render(
           <AsyncNativeSelectWrapper {...testProps}>
@@ -63,9 +56,11 @@ describe("AsyncNativeSelectWrapper", () => {
           " a" +
           " child."
       );
+      expect(console.error).toHaveBeenCalled();
     });
 
     it("throws an error when child element is a different DS component", () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       expect(() =>
         render(
           <AsyncNativeSelectWrapper {...testProps}>
@@ -77,6 +72,7 @@ describe("AsyncNativeSelectWrapper", () => {
           " a" +
           " child."
       );
+      expect(console.error).toHaveBeenCalled();
     });
 
     it("does not throw an error when child element is a DS NativeSelect", () => {

--- a/coral/src/app/components/StatsDisplay.test.tsx
+++ b/coral/src/app/components/StatsDisplay.test.tsx
@@ -69,16 +69,11 @@ describe("StatsDisplay", () => {
   });
 
   describe("handles no or double data", () => {
-    const consoleErrorOriginal = console.error;
-
     beforeEach(() => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
     });
 
-    afterEach(() => {
-      console.error = consoleErrorOriginal;
-      cleanup();
-    });
+    afterEach(cleanup);
 
     it("shows the right information for missing chip and number", () => {
       render(<StatsDisplay isLoading={false} entity={"Test"} />);

--- a/coral/src/app/features/activity-log/ActivityLog.test.tsx
+++ b/coral/src/app/features/activity-log/ActivityLog.test.tsx
@@ -82,12 +82,7 @@ describe("ActivityLog", () => {
   });
 
   describe("handles loading and error state when fetching the requests", () => {
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      // used to swallow a console.error that _should_ happen
-      // while making sure to not swallow other console.errors
-      console.error = jest.fn();
-
       mockGetAllEnvironments.mockResolvedValue(mockedEnvironmentResponse);
       mockGetActivityLog.mockResolvedValue({
         entries: [],
@@ -97,7 +92,6 @@ describe("ActivityLog", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.clearAllMocks();
     });
@@ -114,10 +108,10 @@ describe("ActivityLog", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(loading).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a error message in case of an error for fetching connector requests", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetActivityLog.mockRejectedValue("mock-error");
 
       customRender(<ActivityLog />, {

--- a/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
+++ b/coral/src/app/features/approvals/acls/AclApprovals.test.tsx
@@ -137,13 +137,10 @@ describe("AclApprovals", () => {
   });
 
   describe("shows loading or error state for fetching acls requests", () => {
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      console.error = jest.fn();
       mockGetEnvironments.mockResolvedValue([]);
     });
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
     });
 
@@ -159,10 +156,11 @@ describe("AclApprovals", () => {
       const skeleton = screen.getByTestId("skeleton-table");
 
       expect(skeleton).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows an error message when an error occurs", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockGetAclRequestsForApprover.mockRejectedValue(
         "Unexpected error. Please try again later!"
       );
@@ -482,10 +480,7 @@ describe("AclApprovals", () => {
   describe("enables user to approve a request with quick action", () => {
     const testRequest = mockGetAclRequestsForApproverResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );
@@ -501,7 +496,6 @@ describe("AclApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -518,7 +512,6 @@ describe("AclApprovals", () => {
       expect(mockApproveAclRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.req_no)],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user approves a acl request", async () => {
@@ -542,10 +535,11 @@ describe("AclApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockApproveAclRequest.mockRejectedValue("OH NO");
       expect(mockGetAclRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -574,11 +568,7 @@ describe("AclApprovals", () => {
   describe("enables user to approve a request through details modal", () => {
     const testRequest = mockGetAclRequestsForApproverResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
-      console.error = jest.fn();
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );
@@ -594,7 +584,6 @@ describe("AclApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -619,7 +608,6 @@ describe("AclApprovals", () => {
       expect(mockApproveAclRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.req_no)],
       });
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
@@ -652,11 +640,12 @@ describe("AclApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockApproveAclRequest.mockRejectedValue("OH NO");
       expect(mockGetAclRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -694,11 +683,7 @@ describe("AclApprovals", () => {
   describe("enables user to decline a request with quick action", () => {
     const testRequest = mockGetAclRequestsForApproverResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
-      console.error = jest.fn();
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );
@@ -714,7 +699,6 @@ describe("AclApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -742,7 +726,6 @@ describe("AclApprovals", () => {
 
       expect(mockDeclineAclRequest).not.toHaveBeenCalled();
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("send a decline request api call if user declines a ACL request", async () => {
@@ -776,7 +759,6 @@ describe("AclApprovals", () => {
         reason: "my reason",
       });
 
-      expect(console.error).not.toHaveBeenCalled();
       expect(declineModal).not.toBeInTheDocument();
     });
 
@@ -815,10 +797,10 @@ describe("AclApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeclineAclRequest.mockRejectedValue("Oh no");
 
       const declineButton = screen.getByRole("button", {
@@ -857,11 +839,7 @@ describe("AclApprovals", () => {
   describe("enables user to decline a request through details modal", () => {
     const testRequest = mockGetAclRequestsForApproverResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
-      console.error = jest.fn();
       mockGetAclRequestsForApprover.mockResolvedValue(
         mockGetAclRequestsForApproverResponse
       );
@@ -877,7 +855,6 @@ describe("AclApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -906,7 +883,6 @@ describe("AclApprovals", () => {
       });
 
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
+++ b/coral/src/app/features/approvals/components/ApprovalResourceTabs.test.tsx
@@ -41,16 +41,6 @@ const mockedPendingRequests: RequestsWaitingForApprovalWithTotal = {
 };
 
 describe("ApprovalResourceTabs", () => {
-  const originalConsoleError = console.error;
-
-  beforeAll(() => {
-    console.error = jest.fn();
-  });
-
-  afterAll(() => {
-    console.error = originalConsoleError;
-  });
-
   describe("Tab badges and navigation", () => {
     beforeAll(() => {
       mockGetRequestsWaitingForApproval.mockResolvedValue(
@@ -141,6 +131,7 @@ describe("ApprovalResourceTabs", () => {
     });
 
     it("calls useToast with correct error message", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetRequestsWaitingForApproval.mockRejectedValue(testError);
 
       customRender(
@@ -159,6 +150,7 @@ describe("ApprovalResourceTabs", () => {
           })
         )
       );
+      expect(console.error).toHaveBeenCalledWith(testError);
     });
   });
 });

--- a/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
+++ b/coral/src/app/features/approvals/connectors/ConnectorApprovals.test.tsx
@@ -127,13 +127,7 @@ describe("ConnectorApprovals", () => {
   // I'll add a helper for controlling api mocks better (get a loading state etc)
   // after this release cycle.
   describe("handles loading and error state when fetching the requests", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(() => {
-      // used to swallow a console.error that _should_ happen
-      // while making sure to not swallow other console.errors
-      console.error = jest.fn();
-
       mockGetConnectorRequestsForApprover.mockResolvedValue({
         entries: [],
         totalPages: 1,
@@ -142,11 +136,7 @@ describe("ConnectorApprovals", () => {
       mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
     });
 
-    afterEach(() => {
-      console.error = originalConsoleError;
-      cleanup();
-      // jest.clearAllMocks();
-    });
+    afterEach(cleanup);
 
     it("shows a loading state instead of a table while Kafka connector requests are being fetched", () => {
       customRender(<ConnectorApprovals />, {
@@ -160,10 +150,10 @@ describe("ConnectorApprovals", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(loading).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a error message in case of an error for fetching Kafka connector requests", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetConnectorRequestsForApprover.mockRejectedValue("mock-error");
 
       customRender(<ConnectorApprovals />, {
@@ -404,9 +394,7 @@ describe("ConnectorApprovals", () => {
   describe("enables user to decline a request", () => {
     const testRequest = mockedApiResponseConnectorRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetSyncConnectorsEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -424,7 +412,6 @@ describe("ConnectorApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.clearAllMocks();
       cleanup();
     });
@@ -454,7 +441,6 @@ describe("ConnectorApprovals", () => {
       await userEvent.tab();
 
       expect(confirmDeclineButton).toBeEnabled();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("send a decline request api call if user declines a Kafka connector request", async () => {
@@ -485,7 +471,6 @@ describe("ConnectorApprovals", () => {
         reqIds: [testRequest.connectorId.toString()],
         reason: "This is my message",
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user declined a Kafka connector request", async () => {
@@ -526,10 +511,10 @@ describe("ConnectorApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeclineConnectorRequest.mockRejectedValue("OH NO");
       expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -573,10 +558,7 @@ describe("ConnectorApprovals", () => {
   describe("enables user to approve a request", () => {
     const testRequest = mockedApiResponseConnectorRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
       mockGetSyncConnectorsEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -594,7 +576,6 @@ describe("ConnectorApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.clearAllMocks();
       cleanup();
     });
@@ -613,7 +594,6 @@ describe("ConnectorApprovals", () => {
       expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
         reqIds: [testRequest.connectorId.toString()],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user approves a Kafka connector request", async () => {
@@ -639,10 +619,10 @@ describe("ConnectorApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockApproveConnectorRequest.mockRejectedValue("OH NO");
       expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -671,9 +651,7 @@ describe("ConnectorApprovals", () => {
   describe("enables user to approve a request with quick action", () => {
     const testRequest = mockedApiResponseConnectorRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetSyncConnectorsEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -691,7 +669,6 @@ describe("ConnectorApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -710,7 +687,6 @@ describe("ConnectorApprovals", () => {
       expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.connectorId)],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user approves a connector request", async () => {
@@ -736,10 +712,10 @@ describe("ConnectorApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockApproveConnectorRequest.mockRejectedValue("OH NO");
       expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -768,9 +744,7 @@ describe("ConnectorApprovals", () => {
   describe("enables user to approve a request through details modal", () => {
     const testRequest = mockedApiResponseConnectorRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetSyncConnectorsEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -788,7 +762,6 @@ describe("ConnectorApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -815,7 +788,6 @@ describe("ConnectorApprovals", () => {
       expect(mockApproveConnectorRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.connectorId)],
       });
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
@@ -850,11 +822,12 @@ describe("ConnectorApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockApproveConnectorRequest.mockRejectedValue("OH NO");
       expect(mockGetConnectorRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -892,9 +865,7 @@ describe("ConnectorApprovals", () => {
   describe("enables user to decline a request with quick action", () => {
     const testRequest = mockedApiResponseConnectorRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetSyncConnectorsEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -912,7 +883,6 @@ describe("ConnectorApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -942,7 +912,6 @@ describe("ConnectorApprovals", () => {
 
       expect(mockDeclineConnectorRequest).not.toHaveBeenCalled();
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("send a decline request api call if user declines a connector request", async () => {
@@ -978,7 +947,6 @@ describe("ConnectorApprovals", () => {
         reason: "my reason",
       });
 
-      expect(console.error).not.toHaveBeenCalled();
       expect(declineModal).not.toBeInTheDocument();
     });
 
@@ -1019,10 +987,10 @@ describe("ConnectorApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeclineConnectorRequest.mockRejectedValue("Oh no");
 
       const declineButton = screen.getByRole("button", {
@@ -1061,9 +1029,7 @@ describe("ConnectorApprovals", () => {
   describe("enables user to decline a request through details modal", () => {
     const testRequest = mockedApiResponseConnectorRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetSyncConnectorsEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -1081,7 +1047,6 @@ describe("ConnectorApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -1110,7 +1075,6 @@ describe("ConnectorApprovals", () => {
       });
 
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
+++ b/coral/src/app/features/approvals/schemas/SchemaApprovals.test.tsx
@@ -124,12 +124,7 @@ describe("SchemaApprovals", () => {
   // I'll add a helper for controlling api mocks better (get a loading state etc)
   // after this release cycle.
   describe("handles loading and error state when fetching the requests", () => {
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      // used to swallow a console.error that _should_ happen
-      // while making sure to not swallow other console.errors
-      console.error = jest.fn();
-
       mockGetSchemaRequestsForApprover.mockResolvedValue({
         entries: [],
         totalPages: 1,
@@ -139,7 +134,6 @@ describe("SchemaApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.clearAllMocks();
     });
@@ -156,10 +150,10 @@ describe("SchemaApprovals", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(loading).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a error message in case of an error for fetching schema requests", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetSchemaRequestsForApprover.mockRejectedValue("mock-error");
 
       customRender(<SchemaApprovals />, {
@@ -628,11 +622,7 @@ describe("SchemaApprovals", () => {
   describe("enables user to approve a request with quick action", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
-      console.error = jest.fn();
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -650,7 +640,6 @@ describe("SchemaApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -669,7 +658,6 @@ describe("SchemaApprovals", () => {
       expect(mockApproveSchemaRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.req_no)],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user approves a schema request", async () => {
@@ -695,10 +683,10 @@ describe("SchemaApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockApproveSchemaRequest.mockRejectedValue("OH NO");
       expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -727,11 +715,7 @@ describe("SchemaApprovals", () => {
   describe("enables user to approve a request through details modal", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
-      console.error = jest.fn();
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -749,7 +733,6 @@ describe("SchemaApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -776,7 +759,6 @@ describe("SchemaApprovals", () => {
       expect(mockApproveSchemaRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.req_no)],
       });
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
@@ -811,11 +793,11 @@ describe("SchemaApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockApproveSchemaRequest.mockRejectedValue("OH NO");
       expect(mockGetSchemaRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -853,11 +835,7 @@ describe("SchemaApprovals", () => {
   describe("enables user to decline a request with quick action", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
-      console.error = jest.fn();
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -875,7 +853,6 @@ describe("SchemaApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -905,7 +882,6 @@ describe("SchemaApprovals", () => {
 
       expect(mockDeclineSchemaRequest).not.toHaveBeenCalled();
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("send a decline request api call if user declines a schema request", async () => {
@@ -941,7 +917,6 @@ describe("SchemaApprovals", () => {
         reason: "my reason",
       });
 
-      expect(console.error).not.toHaveBeenCalled();
       expect(declineModal).not.toBeInTheDocument();
     });
 
@@ -982,10 +957,10 @@ describe("SchemaApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeclineSchemaRequest.mockRejectedValue("Oh no");
 
       const declineButton = screen.getByRole("button", {
@@ -1024,11 +999,7 @@ describe("SchemaApprovals", () => {
   describe("enables user to decline a request through details modal", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
-      console.error = jest.fn();
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -1046,7 +1017,6 @@ describe("SchemaApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -1075,7 +1045,6 @@ describe("SchemaApprovals", () => {
       });
 
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
+++ b/coral/src/app/features/approvals/topics/TopicApprovals.test.tsx
@@ -152,16 +152,12 @@ describe("TopicApprovals", () => {
   });
 
   describe("handles loading and error state when fetching the requests", () => {
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      console.error = jest.fn();
       mockGetEnvironments.mockResolvedValue([]);
       mockGetTeams.mockResolvedValue([]);
     });
-    afterEach(() => {
-      console.error = originalConsoleError;
-      cleanup();
-    });
+
+    afterEach(cleanup);
 
     it("shows a loading state instead of a table while topic requests are being fetched", () => {
       mockGetTopicRequestsForApprover.mockResolvedValue(
@@ -179,10 +175,11 @@ describe("TopicApprovals", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(loading).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a error message in case of an error for fetching topic requests", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockGetTopicRequestsForApprover.mockRejectedValue(
         "Unexpected error. Please try again later!"
       );
@@ -685,10 +682,7 @@ describe("TopicApprovals", () => {
   describe("enables user to approve a request with quick action", () => {
     const testRequest = mockedApiResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
       mockGetTopicRequestsForApprover.mockResolvedValue(mockedApiResponse);
       mockGetEnvironments.mockResolvedValue(mockGetEnvironmentResponse);
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
@@ -703,7 +697,6 @@ describe("TopicApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -722,7 +715,6 @@ describe("TopicApprovals", () => {
       expect(mockApproveTopicRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.topicid)],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user approves a topic request", async () => {
@@ -748,10 +740,11 @@ describe("TopicApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockApproveTopicRequest.mockRejectedValue("OH NO");
       expect(mockGetTopicRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -780,10 +773,7 @@ describe("TopicApprovals", () => {
   describe("enables user to approve a request through details modal", () => {
     const testRequest = mockedApiResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
       mockGetTopicRequestsForApprover.mockResolvedValue(mockedApiResponse);
       mockGetEnvironments.mockResolvedValue(mockGetEnvironmentResponse);
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
@@ -798,7 +788,6 @@ describe("TopicApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -825,7 +814,6 @@ describe("TopicApprovals", () => {
       expect(mockApproveTopicRequest).toHaveBeenCalledWith({
         reqIds: [String(testRequest.topicid)],
       });
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
@@ -860,11 +848,12 @@ describe("TopicApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
       expect(modal).not.toBeInTheDocument();
     });
 
     it("informs user about error if approving request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockApproveTopicRequest.mockRejectedValue("OH NO");
       expect(mockGetTopicRequestsForApprover).toHaveBeenNthCalledWith(
         1,
@@ -902,10 +891,7 @@ describe("TopicApprovals", () => {
   describe("enables user to decline a request with quick action", () => {
     const testRequest = mockedApiResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
       mockGetTopicRequestsForApprover.mockResolvedValue(mockedApiResponse);
       mockGetEnvironments.mockResolvedValue(mockGetEnvironmentResponse);
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
@@ -920,7 +906,6 @@ describe("TopicApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -950,7 +935,6 @@ describe("TopicApprovals", () => {
 
       expect(mockDeclineTopicRequest).not.toHaveBeenCalled();
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("send a decline request api call if user declines a topic request", async () => {
@@ -986,7 +970,6 @@ describe("TopicApprovals", () => {
         reason: "my reason",
       });
 
-      expect(console.error).not.toHaveBeenCalled();
       expect(declineModal).not.toBeInTheDocument();
     });
 
@@ -1027,10 +1010,10 @@ describe("TopicApprovals", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if declining request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeclineTopicRequest.mockRejectedValue("Oh no");
 
       const declineButton = screen.getByRole("button", {
@@ -1069,10 +1052,7 @@ describe("TopicApprovals", () => {
   describe("enables user to decline a request through details modal", () => {
     const testRequest = mockedApiResponse.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
-
       mockGetTopicRequestsForApprover.mockResolvedValue(mockedApiResponse);
       mockGetEnvironments.mockResolvedValue(mockGetEnvironmentResponse);
       mockGetTeams.mockResolvedValue(mockedTeamsResponse);
@@ -1087,7 +1067,6 @@ describe("TopicApprovals", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -1116,7 +1095,6 @@ describe("TopicApprovals", () => {
       });
 
       expect(declineModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
+++ b/coral/src/app/features/components/filters/EnvironmentFilter.test.tsx
@@ -409,10 +409,8 @@ describe("EnvironmentFilter.tsx", () => {
       success: false,
     };
 
-    const originalConsoleError = jest.fn();
-
     beforeEach(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       mockGetEnvironments.mockRejectedValue(testError);
       mockGetSyncConnectorsEnvironments.mockResolvedValue([]);
 
@@ -427,7 +425,6 @@ describe("EnvironmentFilter.tsx", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.resetAllMocks();
     });

--- a/coral/src/app/features/components/filters/TeamFilter.test.tsx
+++ b/coral/src/app/features/components/filters/TeamFilter.test.tsx
@@ -375,10 +375,8 @@ describe("TeamFilter.tsx", () => {
       success: false,
     };
 
-    const originalConsoleError = jest.fn();
-
     beforeEach(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetTeams.mockRejectedValue(testError);
       customRender(<WrappedTeamFilter />, {
         memoryRouter: true,
@@ -391,7 +389,6 @@ describe("TeamFilter.tsx", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.clearAllMocks();
     });

--- a/coral/src/app/features/configuration/clusters/AddNewClusterForm.test.tsx
+++ b/coral/src/app/features/configuration/clusters/AddNewClusterForm.test.tsx
@@ -23,8 +23,6 @@ jest.mock("@aivenio/aquarium", () => ({
 }));
 
 describe("<AddNewClusterForm />", () => {
-  const originalConsoleError = console.error;
-
   beforeEach(() => {
     customRender(<AddNewClusterForm />, {
       queryClient: true,
@@ -285,9 +283,11 @@ describe("<AddNewClusterForm />", () => {
   });
 
   it("renders error message when submitting fails", async () => {
-    console.error = jest.fn();
+    jest.spyOn(console, "error").mockImplementationOnce((error) => error);
 
-    mockAddNewClusterRequest.mockRejectedValue(new Error("Request failed"));
+    const testError = new Error("Request failed");
+
+    mockAddNewClusterRequest.mockRejectedValue(testError);
 
     const clusterNameInput = screen.getByRole("textbox", {
       name: "Cluster name *",
@@ -324,7 +324,6 @@ describe("<AddNewClusterForm />", () => {
       position: "bottom-left",
     });
     expect(mockedUsedNavigate).not.toHaveBeenCalled();
-
-    console.error = originalConsoleError;
+    expect(console.error).toHaveBeenCalledWith(testError);
   });
 });

--- a/coral/src/app/features/configuration/clusters/Clusters.test.tsx
+++ b/coral/src/app/features/configuration/clusters/Clusters.test.tsx
@@ -109,34 +109,30 @@ describe("Clusters.tsx", () => {
       success: false,
     };
 
-    const originalConsoleError = console.error;
-
     beforeAll(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       mockGetClustersPaginated.mockRejectedValue(testError);
       customRender(<Clusters />, { queryClient: true, memoryRouter: true });
+
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+      expect(console.error).toHaveBeenCalledWith(testError);
     });
 
     afterAll(() => {
       cleanup();
-      jest.resetAllMocks();
-      console.error = originalConsoleError;
+      jest.clearAllMocks();
     });
 
     it("does not render the table", () => {
       const table = screen.queryByRole("table");
       expect(table).not.toBeInTheDocument();
-
-      expect(console.error).toHaveBeenCalled();
     });
 
-    it("shows an error alert", () => {
+    it("shows an error alert", async () => {
       const error = screen.getByRole("alert");
 
       expect(error).toBeVisible();
       expect(error).toHaveTextContent(testError.message);
-      expect(console.error).toHaveBeenCalledWith(testError);
     });
   });
 

--- a/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
+++ b/coral/src/app/features/configuration/environments/components/EnvironmentStatus.test.tsx
@@ -85,12 +85,9 @@ describe("EnvironmentStatus", () => {
   });
 
   describe("Refresh status", () => {
-    const originalConsoleError = console.error;
     const errorMessage = "Environment refresh error";
 
     beforeEach(() => {
-      console.error = jest.fn();
-
       customRender(
         <EnvironmentStatus
           envId="1"
@@ -104,7 +101,6 @@ describe("EnvironmentStatus", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.clearAllMocks();
 
       cleanup();
@@ -127,7 +123,6 @@ describe("EnvironmentStatus", () => {
       await userEvent.click(refreshButton);
 
       expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
-      expect(console.error).not.toHaveBeenCalled();
       expect(screen.getByText("Online")).toBeVisible();
     });
 
@@ -148,11 +143,12 @@ describe("EnvironmentStatus", () => {
       await userEvent.click(refreshButton);
 
       expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
-      expect(console.error).not.toHaveBeenCalled();
       expect(screen.getByText("Offline")).toBeVisible();
     });
 
     it("renders previous Status chip and toast when there is an error", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockGetUpdateEnvStatus.mockRejectedValue(errorMessage);
 
       expect(screen.getByText("Online")).toBeVisible();
@@ -194,19 +190,16 @@ describe("EnvironmentStatus", () => {
       await userEvent.click(refreshButton);
 
       expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
-      expect(console.error).not.toHaveBeenCalled();
       expect(screen.getByText("Offline")).toBeVisible();
 
       await userEvent.click(refreshButton);
 
       expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
-      expect(console.error).not.toHaveBeenCalled();
       expect(screen.getByText("Offline")).toBeVisible();
 
       await userEvent.click(refreshButton);
 
       expect(mockGetUpdateEnvStatus).toHaveBeenCalledWith({ envId: "1" });
-      expect(console.error).not.toHaveBeenCalled();
       expect(screen.getByText("Offline")).toBeVisible();
     });
   });

--- a/coral/src/app/features/configuration/teams/Teams.test.tsx
+++ b/coral/src/app/features/configuration/teams/Teams.test.tsx
@@ -86,26 +86,22 @@ describe("Teams.tsx", () => {
       success: false,
     };
 
-    const originalConsoleError = console.error;
-
     beforeAll(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetTeams.mockRejectedValue(testError);
       customRender(<Teams />, { queryClient: true });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+      expect(console.error).toHaveBeenCalledWith(testError);
     });
 
     afterAll(() => {
       cleanup();
       jest.resetAllMocks();
-      console.error = originalConsoleError;
     });
 
     it("does not render the table", () => {
       const table = screen.queryByRole("table");
       expect(table).not.toBeInTheDocument();
-
-      expect(console.error).toHaveBeenCalled();
     });
 
     it("shows an error alert", () => {
@@ -113,7 +109,6 @@ describe("Teams.tsx", () => {
 
       expect(error).toBeVisible();
       expect(error).toHaveTextContent(testError.message);
-      expect(console.error).toHaveBeenCalledWith(testError);
     });
   });
 

--- a/coral/src/app/features/configuration/users/Users.test.tsx
+++ b/coral/src/app/features/configuration/users/Users.test.tsx
@@ -137,10 +137,8 @@ describe("Users.tsx", () => {
       success: false,
     };
 
-    const originalConsoleError = console.error;
-
     beforeAll(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetTeams.mockResolvedValue([]);
       mockGetUsers.mockRejectedValue(testError);
       customRender(<Users />, {
@@ -149,19 +147,17 @@ describe("Users.tsx", () => {
         memoryRouter: true,
       });
       await waitForElementToBeRemoved(screen.getByTestId("skeleton-table"));
+      expect(console.error).toHaveBeenCalledWith(testError);
     });
 
     afterAll(() => {
       cleanup();
       jest.resetAllMocks();
-      console.error = originalConsoleError;
     });
 
     it("does not render the table", () => {
       const table = screen.queryByRole("table");
       expect(table).not.toBeInTheDocument();
-
-      expect(console.error).toHaveBeenCalled();
     });
 
     it("shows an error alert", () => {
@@ -169,7 +165,6 @@ describe("Users.tsx", () => {
 
       expect(error).toBeVisible();
       expect(error).toHaveTextContent(testError.message);
-      expect(console.error).toHaveBeenCalledWith(testError);
     });
   });
 

--- a/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
+++ b/coral/src/app/features/connectors/details/ConnectorDetails.test.tsx
@@ -320,10 +320,7 @@ describe("ConnectorDetails", () => {
   });
 
   describe("allows users to claim a connector when they are not connector owner", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(async () => {
-      console.error = jest.fn();
       mockMatches.mockImplementation(() => [
         {
           id: "CONNECTOR_OVERVIEW_TAB_ENUM_overview",
@@ -346,7 +343,6 @@ describe("ConnectorDetails", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.resetAllMocks();
     });
@@ -361,7 +357,6 @@ describe("ConnectorDetails", () => {
       const modal = screen.getByRole("dialog", { name: "Claim connector" });
 
       expect(modal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("sends a request when clicking the submit button without entering a message", async () => {
@@ -385,7 +380,6 @@ describe("ConnectorDetails", () => {
         connectorName: testConnectorOverview.connectorInfo.connectorName,
         env: testConnectorOverview.connectorInfo.environmentId,
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("closes the modal and renders a toast when request was successful", async () => {
@@ -416,7 +410,6 @@ describe("ConnectorDetails", () => {
           variant: "default",
         })
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("refetches connector overview after successful request", async () => {
@@ -438,7 +431,6 @@ describe("ConnectorDetails", () => {
           environmentId: "3",
         });
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("sends a request when clicking the submit button with the message entered by the user", async () => {
@@ -466,10 +458,10 @@ describe("ConnectorDetails", () => {
         env: testConnectorOverview.connectorInfo.environmentId,
         remark: "hello",
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("closes the modal displays an alert when request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       const mockErrorMessage = "There was an error";
       mockRequestConnectorClaim.mockRejectedValue(mockErrorMessage);
 

--- a/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
+++ b/coral/src/app/features/connectors/details/documentation/ConnectorDocumentation.test.tsx
@@ -414,9 +414,7 @@ describe("ConnectorDocumentation", () => {
     });
 
     describe("handles errors when transforming readme intro correct markdown from backend", () => {
-      const originalConsoleError = console.error;
       beforeEach(() => {
-        console.error = jest.fn();
         mockIsDocumentationTransformationError.mockReturnValue(true);
         mockUseConnectorDetails.mockReturnValue({
           ...mockConnectorDetails,
@@ -434,7 +432,6 @@ describe("ConnectorDocumentation", () => {
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         jest.resetAllMocks();
         cleanup();
       });
@@ -459,9 +456,7 @@ describe("ConnectorDocumentation", () => {
       const existingDocumentation = "# Hello" as ConnectorDocumentationMarkdown;
       const userInput = "**Hello world**";
 
-      const originalConsoleError = console.error;
       beforeEach(() => {
-        console.error = jest.fn();
         mockUseConnectorDetails.mockReturnValue({
           ...mockConnectorDetails,
           connectorOverview: {
@@ -481,12 +476,13 @@ describe("ConnectorDocumentation", () => {
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         jest.resetAllMocks();
         cleanup();
       });
 
       it("shows errors without saving readme when user clicks button", async () => {
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
         const editButton = screen.getByRole("button", {
           name: "Edit readme",
         });

--- a/coral/src/app/features/connectors/details/settings/ConnectorSettings.test.tsx
+++ b/coral/src/app/features/connectors/details/settings/ConnectorSettings.test.tsx
@@ -472,10 +472,7 @@ describe("ConnectorSettings", () => {
   });
 
   describe("enables user to delete a connector", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(() => {
-      console.error = jest.fn();
       mockDeleteConnector.mockImplementation(jest.fn());
       mockedUseConnectorDetails.mockReturnValue(mockConnectorDetails);
 
@@ -489,7 +486,6 @@ describe("ConnectorSettings", () => {
     afterEach(() => {
       jest.clearAllMocks();
       cleanup();
-      console.error = originalConsoleError;
     });
 
     it('shows a confirmation modal when user clicks "Request connector deletion"', async () => {
@@ -504,7 +500,6 @@ describe("ConnectorSettings", () => {
       const confirmationModal = screen.getByRole("dialog");
 
       expect(confirmationModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it('removes modal and does not Request connector deletion if user clicks "cancel"', async () => {
@@ -526,7 +521,6 @@ describe("ConnectorSettings", () => {
       expect(dialog).not.toBeInTheDocument();
       expect(mockedNavigate).not.toHaveBeenCalled();
       expect(mockDeleteConnector).not.toHaveBeenCalled();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("deletes connector successfully when user confirms deleting", async () => {
@@ -556,10 +550,11 @@ describe("ConnectorSettings", () => {
       });
       expect(mockedNavigate).toHaveBeenCalledWith("/connectors");
       expect(dialog).not.toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a message if deleting the connector resulted in an error", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockDeleteConnector.mockRejectedValue({
         success: false,
         message: "Oh no error",

--- a/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorPromotionRequest.test.tsx
@@ -131,15 +131,11 @@ describe("ConnectorPromotionRequest", () => {
   });
 
   describe("loads and handles available environments", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(() => {
       mockGetConnectorDetailsPerEnv.mockResolvedValue({});
-      console.error = jest.fn();
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.clearAllMocks();
       cleanup();
     });
@@ -150,7 +146,6 @@ describe("ConnectorPromotionRequest", () => {
       renderConnectorPromotionRequest({});
 
       expect(mockGetConnectorEnvironmentRequest).toHaveBeenCalledTimes(1);
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs and redirects user when sourceEnv does not exist", async () => {
@@ -174,7 +169,6 @@ describe("ConnectorPromotionRequest", () => {
         "/connector/test-connector-name",
         { replace: true }
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs and redirects user when targetEnv does not exist", async () => {
@@ -198,10 +192,10 @@ describe("ConnectorPromotionRequest", () => {
         "/connector/test-connector-name",
         { replace: true }
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs and redirects user when an error occurs with fetching", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetConnectorEnvironmentRequest.mockRejectedValue({
         message: "Oh no",
       });
@@ -227,16 +221,11 @@ describe("ConnectorPromotionRequest", () => {
   });
 
   describe("loads and handles connector details", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(() => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
-
-      console.error = jest.fn();
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.clearAllMocks();
       cleanup();
     });
@@ -251,7 +240,6 @@ describe("ConnectorPromotionRequest", () => {
         connectorName: testConnectorName,
         envSelected: defaultSourceEnv,
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs and redirects user when connector details does not exist", async () => {
@@ -272,10 +260,10 @@ describe("ConnectorPromotionRequest", () => {
       expect(mockedUsedNavigate).toHaveBeenCalledWith("/connector", {
         replace: true,
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs and redirects user when an error occurs with fetching", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetConnectorDetailsPerEnv.mockRejectedValue({
         message: "Oh no",
       });
@@ -512,10 +500,9 @@ describe("ConnectorPromotionRequest", () => {
 
   describe("handles errors when requesting promotion", () => {
     const testErrorMessage = "OH NO 😭";
-    const originalConsoleError = console.error;
 
     beforeEach(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetConnectorEnvironmentRequest.mockResolvedValue(defaultEnvironments);
       mockGetConnectorDetailsPerEnv.mockResolvedValue(testConnectorDetails);
       mockRequestConnectorPromotion.mockRejectedValue({
@@ -528,7 +515,6 @@ describe("ConnectorPromotionRequest", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.clearAllMocks();
       cleanup();
     });

--- a/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
+++ b/coral/src/app/features/connectors/request/ConnectorRequest.test.tsx
@@ -361,9 +361,7 @@ describe("<ConnectorRequest />", () => {
     });
 
     describe("handles an error from the api", () => {
-      const originalConsoleError = console.error;
       beforeEach(() => {
-        console.error = jest.fn();
         mockCreateConnectorRequest.mockRejectedValue({
           success: false,
           message: "Something went wrong",
@@ -371,12 +369,13 @@ describe("<ConnectorRequest />", () => {
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         jest.clearAllMocks();
         cleanup();
       });
 
       it("renders an error message", async () => {
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
         await user.click(
           screen.getByRole("button", { name: "Submit request" })
         );

--- a/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
+++ b/coral/src/app/features/requests/connectors/ConnectorRequests.test.tsx
@@ -107,12 +107,8 @@ describe("ConnectorRequests", () => {
   });
 
   describe("handles loading and error state when fetching the requests", () => {
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      // used to swallow a console.error that _should_ happen
-      // while making sure to not swallow other console.errors
-      console.error = jest.fn();
-
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetConnectorEnvironmentRequest.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -124,7 +120,6 @@ describe("ConnectorRequests", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.clearAllMocks();
     });
@@ -141,7 +136,6 @@ describe("ConnectorRequests", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(loading).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a error message in case of an error for fetching connector requests", async () => {
@@ -569,7 +563,6 @@ describe("ConnectorRequests", () => {
   });
 
   describe("user can filter connector requests by operation type", () => {
-    const originalConsoleError = console.error;
     beforeEach(async () => {
       mockGetConnectorEnvironmentRequest.mockResolvedValue(
         mockedEnvironmentResponse
@@ -589,7 +582,6 @@ describe("ConnectorRequests", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -628,9 +620,7 @@ describe("ConnectorRequests", () => {
   });
 
   describe("enables user to delete a request", () => {
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetConnectorEnvironmentRequest.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -648,7 +638,6 @@ describe("ConnectorRequests", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -674,7 +663,6 @@ describe("ConnectorRequests", () => {
       expect(mockDeleteConnectorRequest).toHaveBeenCalledWith({
         reqIds: ["1000"],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user deletes a Connector request", async () => {
@@ -716,10 +704,11 @@ describe("ConnectorRequests", () => {
         env: "ALL",
         operationType: "ALL",
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if deleting request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockDeleteConnectorRequest.mockRejectedValue({ message: "OH NO" });
       expect(mockGetConnectorRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
@@ -756,6 +745,8 @@ describe("ConnectorRequests", () => {
     });
 
     it("informs user about error if deleting request was not successful and error is hidden in success", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
+
       mockDeleteConnectorRequest.mockRejectedValue("OH NO");
       expect(mockGetConnectorRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",

--- a/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
+++ b/coral/src/app/features/requests/schemas/SchemaRequests.test.tsx
@@ -54,12 +54,7 @@ describe("SchemaRequest", () => {
   // due to its dependency on the async process of the api call
   // We'll add a helper for controlling api mocks better (get a loading state etc.)
   describe("handles loading and error state when fetching the requests", () => {
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      // used to swallow a console.error that _should_ happen
-      // while making sure to not swallow other console.errors
-      console.error = jest.fn();
-
       mockgetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -71,7 +66,6 @@ describe("SchemaRequest", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.clearAllMocks();
     });
@@ -88,10 +82,10 @@ describe("SchemaRequest", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(loading).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a error message in case of an error for fetching schema requests", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetSchemaRequests.mockRejectedValue("mock-error");
 
       customRender(<SchemaRequests />, {
@@ -107,7 +101,9 @@ describe("SchemaRequest", () => {
 
       expect(table).not.toBeInTheDocument();
       expect(errorMessage).toBeVisible();
-      expect(console.error).toHaveBeenCalledWith("mock-error");
+      await waitFor(() =>
+        expect(console.error).toHaveBeenCalledWith("mock-error")
+      );
     });
   });
 
@@ -682,9 +678,7 @@ describe("SchemaRequest", () => {
   describe("enables user to delete a request", () => {
     const testRequest = mockedApiResponseSchemaRequests.entries[0];
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockgetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -700,7 +694,6 @@ describe("SchemaRequest", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -726,7 +719,6 @@ describe("SchemaRequest", () => {
       expect(mockDeleteSchemaRequest).toHaveBeenCalledWith({
         reqIds: [testRequest.req_no.toString()],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user deletes a schema request", async () => {
@@ -760,10 +752,10 @@ describe("SchemaRequest", () => {
         2,
         defaultApiParams
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if deleting request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeleteSchemaRequest.mockRejectedValue({ message: "OH NO" });
       expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(
         1,
@@ -796,6 +788,7 @@ describe("SchemaRequest", () => {
     });
 
     it("informs user about error if deleting request was not successful and error is hidden in success", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeleteSchemaRequest.mockRejectedValue("OH NO");
       expect(mockGetSchemaRequests).toHaveBeenNthCalledWith(
         1,

--- a/coral/src/app/features/requests/topics/TopicRequests.test.tsx
+++ b/coral/src/app/features/requests/topics/TopicRequests.test.tsx
@@ -577,9 +577,7 @@ describe("TopicRequests", () => {
   });
 
   describe("enables user to delete a request", () => {
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetTopicRequestEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
       );
@@ -595,7 +593,6 @@ describe("TopicRequests", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
@@ -621,7 +618,6 @@ describe("TopicRequests", () => {
       expect(mockDeleteTopicRequest).toHaveBeenCalledWith({
         reqIds: ["1000"],
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("updates the the data for the table if user deletes a topic request", async () => {
@@ -663,10 +659,10 @@ describe("TopicRequests", () => {
         env: "ALL",
         operationType: "ALL",
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("informs user about error if deleting request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeleteTopicRequest.mockRejectedValue({ message: "OH NO" });
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
@@ -703,6 +699,7 @@ describe("TopicRequests", () => {
     });
 
     it("informs user about error if deleting request was not successful and error is hidden in success", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeleteTopicRequest.mockRejectedValue("OH NO");
       expect(mockGetTopicRequests).toHaveBeenNthCalledWith(1, {
         pageNo: "1",
@@ -741,7 +738,6 @@ describe("TopicRequests", () => {
   });
 
   describe("user can filter topic requests by operation type", () => {
-    const originalConsoleError = console.error;
     beforeEach(async () => {
       mockGetTopicRequestEnvironments.mockResolvedValue(
         mockedEnvironmentResponse
@@ -759,7 +755,6 @@ describe("TopicRequests", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });

--- a/coral/src/app/features/team-info/SwitchTeamsDropdown.test.tsx
+++ b/coral/src/app/features/team-info/SwitchTeamsDropdown.test.tsx
@@ -259,9 +259,8 @@ describe("SwitchTeamsDropdown", () => {
       success: false,
     };
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       mockGetTeamsOfUser.mockResolvedValue(testTeams);
       mockUpdateTeam.mockRejectedValue(mockError);
 
@@ -280,7 +279,6 @@ describe("SwitchTeamsDropdown", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.resetAllMocks();
     });

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest_consumer.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest_consumer.test.tsx
@@ -489,13 +489,12 @@ describe("<TopicAclRequest />", () => {
     });
 
     describe("when API returns an error", () => {
-      const originalConsoleError = console.error;
-      beforeEach(async () => {
-        console.error = jest.fn();
+      beforeEach(() => {
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
+        jest.clearAllMocks();
       });
 
       it("renders an error message", async () => {
@@ -561,11 +560,6 @@ describe("<TopicAclRequest />", () => {
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
 
-        // it's not important that the console.error is called,
-        // but it makes sure that 1) the console.error does not
-        // show up in the test logs while 2) flagging an error
-        // in case a console.error with a different message
-        // gets called - which could be hinting to a problem
         expect(console.error).toHaveBeenCalledWith({
           message: "Error message example",
         });
@@ -1121,13 +1115,12 @@ describe("<TopicAclRequest />", () => {
     });
 
     describe("when API returns an error", () => {
-      const originalConsoleError = console.error;
-      beforeEach(async () => {
-        console.error = jest.fn();
+      beforeEach(() => {
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
+        jest.clearAllMocks();
       });
 
       it("renders an error message", async () => {
@@ -1204,11 +1197,6 @@ describe("<TopicAclRequest />", () => {
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
 
-        // it's not important that the console.error is called,
-        // but it makes sure that 1) the console.error does not
-        // show up in the test logs while 2) flagging an error
-        // in case a console.error with a different message
-        // gets called - which could be hinting to a problem
         expect(console.error).toHaveBeenCalledWith({
           message: "Error message example",
         });

--- a/coral/src/app/features/topics/acl-request/TopicAclRequest_producer.test.tsx
+++ b/coral/src/app/features/topics/acl-request/TopicAclRequest_producer.test.tsx
@@ -518,13 +518,11 @@ describe("<TopicAclRequest />", () => {
     });
 
     describe("when API returns an error", () => {
-      const originalConsoleError = console.error;
       beforeEach(async () => {
-        console.error = jest.fn();
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         jest.clearAllMocks();
       });
 
@@ -577,11 +575,6 @@ describe("<TopicAclRequest />", () => {
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
 
-        // it's not important that the console.error is called,
-        // but it makes sure that 1) the console.error does not
-        // show up in the test logs while 2) flagging an error
-        // in case a console.error with a different message
-        // gets called - which could be hinting to a problem
         expect(console.error).toHaveBeenCalledWith({
           message: "Error message example",
         });
@@ -1172,13 +1165,12 @@ describe("<TopicAclRequest />", () => {
     });
 
     describe("when API returns an error", () => {
-      const originalConsoleError = console.error;
       beforeEach(async () => {
-        console.error = jest.fn();
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
+        jest.clearAllMocks();
       });
 
       it("renders an error message", async () => {
@@ -1230,11 +1222,6 @@ describe("<TopicAclRequest />", () => {
         const alert = await screen.findByRole("alert");
         expect(alert).toHaveTextContent("Error message example");
 
-        // it's not important that the console.error is called,
-        // but it makes sure that 1) the console.error does not
-        // show up in the test logs while 2) flagging an error
-        // in case a console.error with a different message
-        // gets called - which could be hinting to a problem
         expect(console.error).toHaveBeenCalledWith({
           message: "Error message example",
         });

--- a/coral/src/app/features/topics/acl-request/fields/IpOrPrincipalField.test.tsx
+++ b/coral/src/app/features/topics/acl-request/fields/IpOrPrincipalField.test.tsx
@@ -26,16 +26,9 @@ describe("IpOrPrincipalField", () => {
   const onSubmit = jest.fn();
   const onError = jest.fn();
 
-  const originalConsoleError = console.error;
-  beforeEach(() => {
-    console.error = jest.fn();
-  });
-
   afterEach(() => {
     cleanup();
-    onSubmit.mockClear();
-    onError.mockClear();
-    console.error = originalConsoleError;
+    jest.clearAllMocks();
   });
 
   it("renders a field for Service accounts with options for existing service accounts (Aiven cluster)", async () => {
@@ -43,7 +36,7 @@ describe("IpOrPrincipalField", () => {
       mockedAivenServiceAccountsResponse
     );
 
-    const result = renderForm(
+    renderForm(
       <IpOrPrincipalField
         aclIpPrincipleType={"PRINCIPAL"}
         isAivenCluster={true}
@@ -58,7 +51,7 @@ describe("IpOrPrincipalField", () => {
 
     await waitForElementToBeRemoved(screen.getByTestId("acl_ssl-skeleton"));
 
-    const multiInput = result.getByRole("combobox", {
+    const multiInput = screen.getByRole("combobox", {
       name: "Service accounts *",
     });
     expect(multiInput).toBeVisible();
@@ -73,7 +66,6 @@ describe("IpOrPrincipalField", () => {
 
       expect(option).toBeEnabled();
     });
-    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a field for Service accounts which allows adding new service accounts (Aiven cluster)", async () => {
@@ -81,7 +73,7 @@ describe("IpOrPrincipalField", () => {
       mockedAivenServiceAccountsResponse
     );
 
-    const result = renderForm(
+    renderForm(
       <IpOrPrincipalField
         aclIpPrincipleType={"PRINCIPAL"}
         isAivenCluster={true}
@@ -96,7 +88,7 @@ describe("IpOrPrincipalField", () => {
 
     await waitForElementToBeRemoved(screen.getByTestId("acl_ssl-skeleton"));
 
-    const multiInput = result.getByRole("combobox", {
+    const multiInput = screen.getByRole("combobox", {
       name: "Service accounts *",
     });
     expect(multiInput).toBeVisible();
@@ -108,13 +100,14 @@ describe("IpOrPrincipalField", () => {
     const newOption = screen.getByRole("button", { name: "Remove hello" });
     expect(newOption).toBeVisible();
     expect(newOption).toBeEnabled();
-    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a textbox field for Service accounts when getAivenServiceAccounts errors (Aiven cluster)", async () => {
-    mockGetAivenServiceAccounts.mockRejectedValue("mock-error");
+    jest.spyOn(console, "error").mockImplementationOnce((error) => error);
 
-    const result = renderForm(
+    mockGetAivenServiceAccounts.mockRejectedValueOnce("mock-error");
+
+    renderForm(
       <IpOrPrincipalField
         aclIpPrincipleType={"PRINCIPAL"}
         isAivenCluster={true}
@@ -129,7 +122,7 @@ describe("IpOrPrincipalField", () => {
 
     await waitForElementToBeRemoved(screen.getByTestId("acl_ssl-skeleton"));
 
-    const multiInput = result.getByRole("textbox", {
+    const multiInput = screen.getByRole("textbox", {
       name: "Service accounts *",
     });
     expect(multiInput).toBeVisible();
@@ -138,7 +131,7 @@ describe("IpOrPrincipalField", () => {
   });
 
   it("renders a field for SSL DN strings / Usernames (not Aiven cluster)", () => {
-    const result = renderForm(
+    renderForm(
       <IpOrPrincipalField
         aclIpPrincipleType={"PRINCIPAL"}
         isAivenCluster={false}
@@ -150,14 +143,13 @@ describe("IpOrPrincipalField", () => {
         onError,
       }
     );
-    const multiInput = result.getByLabelText("SSL DN strings / Usernames*");
+    const multiInput = screen.getByLabelText("SSL DN strings / Usernames*");
     expect(multiInput).toBeVisible();
     expect(multiInput).toBeEnabled();
-    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a field for IP addresses (Aiven cluster)", () => {
-    const result = renderForm(
+    renderForm(
       <IpOrPrincipalField
         aclIpPrincipleType={"IP_ADDRESS"}
         isAivenCluster={true}
@@ -169,14 +161,13 @@ describe("IpOrPrincipalField", () => {
         onError,
       }
     );
-    const multiInput = result.getByLabelText("IP addresses*");
+    const multiInput = screen.getByLabelText("IP addresses*");
     expect(multiInput).toBeVisible();
     expect(multiInput).toBeEnabled();
-    expect(console.error).not.toHaveBeenCalled();
   });
 
   it("renders a field for IP addresses (not Aiven cluster)", () => {
-    const result = renderForm(
+    renderForm(
       <IpOrPrincipalField
         aclIpPrincipleType={"IP_ADDRESS"}
         isAivenCluster={false}
@@ -188,9 +179,8 @@ describe("IpOrPrincipalField", () => {
         onError,
       }
     );
-    const multiInput = result.getByLabelText("IP addresses*");
+    const multiInput = screen.getByLabelText("IP addresses*");
     expect(multiInput).toBeVisible();
     expect(multiInput).toBeEnabled();
-    expect(console.error).not.toHaveBeenCalled();
   });
 });

--- a/coral/src/app/features/topics/details/TopicDetails.test.tsx
+++ b/coral/src/app/features/topics/details/TopicDetails.test.tsx
@@ -446,10 +446,7 @@ describe("TopicDetails", () => {
   });
 
   describe("allows users to claim a topic when they are not topic owner", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(() => {
-      console.error = jest.fn();
       mockMatches.mockImplementation(() => [
         {
           id: "TOPIC_OVERVIEW_TAB_ENUM_overview",
@@ -468,7 +465,6 @@ describe("TopicDetails", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.clearAllMocks();
     });
@@ -485,7 +481,6 @@ describe("TopicDetails", () => {
       const modal = screen.getByRole("dialog");
 
       expect(modal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("sends a request when clicking the submit button without entering a message", async () => {
@@ -511,7 +506,6 @@ describe("TopicDetails", () => {
         topicName: testTopicOverview.topicInfo.topicName,
         env: testTopicOverview.topicInfo.envId,
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("sends a request when clicking the submit button with the message entered by the user", async () => {
@@ -541,7 +535,6 @@ describe("TopicDetails", () => {
         env: testTopicOverview.topicInfo.envId,
         remark: "hello",
       });
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("closes the modal and renders a toast when request was successful", async () => {
@@ -572,10 +565,10 @@ describe("TopicDetails", () => {
           variant: "default",
         })
       );
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("closes the modal displays an alert when request was not successful", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       const mockErrorMessage = "There was an error";
       await waitForElementToBeRemoved(screen.getByPlaceholderText("Loading"));
 

--- a/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
+++ b/coral/src/app/features/topics/details/components/PromotionBanner.test.tsx
@@ -578,14 +578,11 @@ describe("PromotionBanner", () => {
   });
 
   describe("handles error for promotion (type schema, topic and connector)", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(() => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });

--- a/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
+++ b/coral/src/app/features/topics/details/documentation/TopicDocumentation.test.tsx
@@ -417,9 +417,7 @@ describe("TopicDocumentation", () => {
     });
 
     describe("handles errors when transforming readme intro correct markdown from backend", () => {
-      const originalConsoleError = console.error;
       beforeEach(() => {
-        console.error = jest.fn();
         mockIsDocumentationTransformationError.mockReturnValue(true);
         mockUseTopicDetails.mockReturnValue({
           ...mockTopicDetails,
@@ -437,7 +435,6 @@ describe("TopicDocumentation", () => {
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         jest.resetAllMocks();
         cleanup();
       });
@@ -462,9 +459,8 @@ describe("TopicDocumentation", () => {
       const existingReadme = "# Hello" as TopicDocumentationMarkdown;
       const userInput = "**Hello world**";
 
-      const originalConsoleError = console.error;
       beforeEach(() => {
-        console.error = jest.fn();
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
         mockUseTopicDetails.mockReturnValue({
           ...mockTopicDetails,
           topicOverview: {
@@ -484,7 +480,6 @@ describe("TopicDocumentation", () => {
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         jest.resetAllMocks();
         cleanup();
       });

--- a/coral/src/app/features/topics/details/overview/components/ClusterDetails.test.tsx
+++ b/coral/src/app/features/topics/details/overview/components/ClusterDetails.test.tsx
@@ -192,15 +192,11 @@ describe("ClusterDetails", () => {
   });
 
   describe("logs error for developers if they pass wrong props", () => {
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementation((error) => error);
     });
 
-    afterEach(() => {
-      console.error = originalConsoleError;
-      cleanup();
-    });
+    afterEach(cleanup);
 
     it("logs no error if isUpdating is true and cluster details undefined", () => {
       render(<ClusterDetails clusterDetails={undefined} isUpdating={true} />);

--- a/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
+++ b/coral/src/app/features/topics/details/schema/TopicDetailsSchema.test.tsx
@@ -843,11 +843,7 @@ describe("TopicDetailsSchema", () => {
     });
 
     describe("enables topic owner to promote a schema", () => {
-      const originalConsoleError = console.error;
-
       beforeEach(() => {
-        console.error = jest.fn();
-
         mockedUseTopicDetails.mockReturnValue({
           topicOverviewIsRefetching: false,
           topicSchemasIsRefetching: false,
@@ -866,7 +862,6 @@ describe("TopicDetailsSchema", () => {
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         cleanup();
         jest.clearAllMocks();
       });
@@ -896,11 +891,10 @@ describe("TopicDetailsSchema", () => {
           targetEnvironment: "2",
           topicName: "topic-name",
         });
-
-        expect(console.error).not.toHaveBeenCalled();
       });
 
       it("shows an error if promotion did fail", async () => {
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
         mockPromoteSchemaRequest.mockRejectedValue({
           success: false,
           message: "Oh no",
@@ -930,11 +924,8 @@ describe("TopicDetailsSchema", () => {
     });
 
     describe("enables topic owner to promote a schema even if it's not compatible", () => {
-      const originalConsoleError = console.error;
-
       beforeEach(() => {
-        console.error = jest.fn();
-
+        jest.spyOn(console, "error").mockImplementation((error) => error);
         mockedUseTopicDetails.mockReturnValue({
           topicOverviewIsRefetching: false,
           topicSchemasIsRefetching: false,
@@ -953,7 +944,6 @@ describe("TopicDetailsSchema", () => {
       });
 
       afterEach(() => {
-        console.error = originalConsoleError;
         cleanup();
         jest.clearAllMocks();
       });
@@ -1076,6 +1066,11 @@ describe("TopicDetailsSchema", () => {
         });
 
         await user.click(buttonRequest);
+
+        expect(console.error).toHaveBeenCalledWith({
+          message: "failure: Schema is not compatible",
+          success: false,
+        });
 
         const checkboxToForceRegister = screen.getByRole("checkbox");
 

--- a/coral/src/app/features/topics/details/settings/TopicSettings.test.tsx
+++ b/coral/src/app/features/topics/details/settings/TopicSettings.test.tsx
@@ -465,10 +465,7 @@ describe("TopicSettings", () => {
   });
 
   describe("enables user to delete a topic", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(() => {
-      console.error = jest.fn();
       mockDeleteTopic.mockImplementation(jest.fn());
       mockedUseTopicDetails.mockReturnValue(mockTopicDetails);
 
@@ -482,7 +479,6 @@ describe("TopicSettings", () => {
     afterEach(() => {
       jest.clearAllMocks();
       cleanup();
-      console.error = originalConsoleError;
     });
 
     it('shows a confirmation modal when user clicks "Request topic deletion"', async () => {
@@ -497,7 +493,6 @@ describe("TopicSettings", () => {
       const confirmationModal = screen.getByRole("dialog");
 
       expect(confirmationModal).toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it('removes modal and does not delete topic if user clicks "cancel"', async () => {
@@ -519,7 +514,6 @@ describe("TopicSettings", () => {
       expect(dialog).not.toBeInTheDocument();
       expect(mockedNavigate).not.toHaveBeenCalled();
       expect(mockDeleteTopic).not.toHaveBeenCalled();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("deletes topic successfully when user confirms deleting", async () => {
@@ -549,7 +543,6 @@ describe("TopicSettings", () => {
       });
       expect(mockedNavigate).toHaveBeenCalledWith("/topics");
       expect(dialog).not.toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("deletes topic and associates schemas successfully when user confirms deleting", async () => {
@@ -585,10 +578,10 @@ describe("TopicSettings", () => {
       });
       expect(mockedNavigate).toHaveBeenCalledWith("/topics");
       expect(dialog).not.toBeVisible();
-      expect(console.error).not.toHaveBeenCalled();
     });
 
     it("shows a message if deleting the topic resulted in an error", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockDeleteTopic.mockRejectedValue({
         success: false,
         message: "Oh no error",

--- a/coral/src/app/features/topics/request/TopicRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicRequest.test.tsx
@@ -928,10 +928,7 @@ describe("<TopicRequest />", () => {
   });
 
   describe("form submission", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(async () => {
-      console.error = jest.fn();
       // this need to be reset in beforeEach
       // because they are async and resetting them
       // afterEach may lead to false results when
@@ -976,13 +973,13 @@ describe("<TopicRequest />", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });
 
     describe("handles an error from the api", () => {
       it("renders an error message", async () => {
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
         const testError = {
           data: { message: "Topic with such name already exists!" },
           status: 400,
@@ -1057,10 +1054,10 @@ describe("<TopicRequest />", () => {
           remarks: "",
         });
         await waitFor(() => expect(mockedUseToast).toHaveBeenCalled());
-        expect(console.error).not.toHaveBeenCalled();
       });
 
       it("errors and does not create a new topic request when input was invalid", async () => {
+        jest.spyOn(console, "error").mockImplementationOnce((error) => error);
         await user.clear(screen.getByLabelText("Topic name*"));
 
         await user.click(
@@ -1100,7 +1097,6 @@ describe("<TopicRequest />", () => {
           position: "bottom-left",
           variant: "default",
         });
-        expect(console.error).not.toHaveBeenCalled();
       });
     });
   });

--- a/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
+++ b/coral/src/app/features/topics/schema-request/TopicSchemaRequest.test.tsx
@@ -87,7 +87,7 @@ describe("TopicSchemaRequest", () => {
       useQuerySpy.mockRestore();
     });
 
-    it("does not redirect user if topicName prop does is part of list of topicNames", async () => {
+    it("does not redirect user if topicName prop does is part of list of topicNames", () => {
       mockGetTopicNames.mockResolvedValue([
         "topic-1",
         "topic-2",
@@ -604,10 +604,8 @@ describe("TopicSchemaRequest", () => {
   });
 
   describe("handles errors from the api", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedGetAllEnvironmentsForTopicAndAclResponse
       );
@@ -634,7 +632,7 @@ describe("TopicSchemaRequest", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
+      jest.clearAllMocks();
       cleanup();
     });
 
@@ -666,11 +664,6 @@ describe("TopicSchemaRequest", () => {
       const errorMessage = within(alert).getByText("Error in request");
 
       expect(errorMessage).toBeVisible();
-      // it's not important that the console.error is called,
-      // but it makes sure that 1) the console.error does not
-      // show up in the test logs while 2) flagging an error
-      // in case a console.error with a different message
-      // gets called - which could be hinting to a problem
       expect(console.error).toHaveBeenCalledWith({
         status: "400 BAD_REQUEST",
         data: { message: "Error in request" },
@@ -704,7 +697,6 @@ describe("TopicSchemaRequest", () => {
       );
 
       expect(mockedUsedNavigate).not.toHaveBeenCalled();
-
       expect(console.error).toHaveBeenCalledWith({
         status: "400 BAD_REQUEST",
         data: { message: "Error in request" },
@@ -939,9 +931,8 @@ describe("TopicSchemaRequest", () => {
       message: "Oh no 😢",
     };
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedGetAllEnvironmentsForTopicAndAclResponse
       );
@@ -965,7 +956,6 @@ describe("TopicSchemaRequest", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       mockedUseToast.mockReset();
       cleanup();
     });
@@ -1007,10 +997,8 @@ describe("TopicSchemaRequest", () => {
   });
 
   describe("enables user to send a schema request even if it's not compatible", () => {
-    const originalConsoleError = console.error;
-
     beforeEach(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue(
         mockedGetAllEnvironmentsForTopicAndAclResponse
       );
@@ -1045,7 +1033,6 @@ describe("TopicSchemaRequest", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       mockedUseToast.mockReset();
       cleanup();
     });
@@ -1116,6 +1103,11 @@ describe("TopicSchemaRequest", () => {
       await user.upload(fileInput, testFile);
       await user.click(submitButton);
 
+      expect(console.error).toHaveBeenCalledWith({
+        message: "failure: Schema is not compatible",
+        success: false,
+      });
+
       const checkboxForceRegister = within(form).getByRole("checkbox", {
         name: "Force register schema creation/changes Warning: This will override standard validation process of the schema registry. Learn more",
       });
@@ -1148,6 +1140,11 @@ describe("TopicSchemaRequest", () => {
       await user.tab();
       await user.upload(fileInput, testFile);
       await user.click(submitButton);
+
+      expect(console.error).toHaveBeenCalledWith({
+        message: "failure: Schema is not compatible",
+        success: false,
+      });
 
       const checkboxForceRegister = within(form).getByRole("checkbox", {
         name: "Force register schema creation/changes Warning: This will override standard validation process of the schema registry. Learn more",

--- a/coral/src/app/features/topics/schema-request/components/TopicSchema.test.tsx
+++ b/coral/src/app/features/topics/schema-request/components/TopicSchema.test.tsx
@@ -261,6 +261,6 @@ describe("TopicSchema", () => {
   // link to issue above
   // alternative: test in browse environment
   // Will leave this in as reminder
-  test.todo("submits the form if input is valid");
-  test.todo("validates content of the uploaded file");
+  // test.todo("submits the form if input is valid");
+  // test.todo("validates content of the uploaded file");
 });

--- a/coral/src/app/features/topics/schema-request/components/TopicSchema.tsx
+++ b/coral/src/app/features/topics/schema-request/components/TopicSchema.tsx
@@ -110,7 +110,7 @@ function TopicSchema(props: TopicSchemaProps) {
         return (
           <div>
             <FileInput
-              {...props}
+              name={name}
               buttonText={`Upload ${schemaType} schema`}
               labelText={`Upload ${schemaType} schema file`}
               helperText={error?.message || ""}

--- a/coral/src/app/features/user-information/profile/Profile.test.tsx
+++ b/coral/src/app/features/user-information/profile/Profile.test.tsx
@@ -69,29 +69,25 @@ describe("Profile.tsx", () => {
       success: false,
     };
 
-    const originalConsoleError = console.error;
-
     beforeAll(async () => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       mockGetUser.mockRejectedValue(testError);
       customRender(<Profile />, { queryClient: true, memoryRouter: true });
 
       await waitForElementToBeRemoved(
         screen.getByText("User profile loading.")
       );
+      expect(console.error).toHaveBeenCalledWith(testError);
     });
 
     afterAll(() => {
       cleanup();
       jest.resetAllMocks();
-      console.error = originalConsoleError;
     });
 
-    it("shows an error message", () => {
+    it("shows an error message", async () => {
       const error = screen.getByRole("alert");
       expect(error).toBeVisible();
-
-      expect(console.error).toHaveBeenCalledWith(testError);
     });
 
     it("does not show when there is an error", () => {
@@ -251,9 +247,7 @@ describe("Profile.tsx", () => {
   });
 
   describe("handles form validation and prevents changes on invalid forms", () => {
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockGetUser.mockResolvedValue({
         ...testUser,
         switchTeams: true,
@@ -267,7 +261,6 @@ describe("Profile.tsx", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.resetAllMocks();
     });
@@ -292,6 +285,7 @@ describe("Profile.tsx", () => {
     });
 
     it("does not update profile when full name is empty", async () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       const submitButton = screen.getByRole("button", {
         name: "Update profile",
       });
@@ -302,7 +296,13 @@ describe("Profile.tsx", () => {
       await user.click(submitButton);
 
       expect(mockUpdateProfile).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fullName: expect.objectContaining({
+            message: "Full name must contain at least 4 characters.",
+          }),
+        })
+      );
     });
 
     it("shows error when full name does not match restriction", async () => {
@@ -326,6 +326,7 @@ describe("Profile.tsx", () => {
     });
 
     it("does not update profile when full name does not match restriction", async () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       const submitButton = screen.getByRole("button", {
         name: "Update profile",
       });
@@ -336,7 +337,15 @@ describe("Profile.tsx", () => {
       await user.click(submitButton);
 
       expect(mockUpdateProfile).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fullName: expect.objectContaining({
+            message: expect.stringContaining(
+              "Invalid input. Full name can only include uppercase and lowercase letters"
+            ),
+          }),
+        })
+      );
     });
 
     it("shows error when email is empty", async () => {
@@ -359,6 +368,7 @@ describe("Profile.tsx", () => {
     });
 
     it("does not update profile when email is empty", async () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       const submitButton = screen.getByRole("button", {
         name: "Update profile",
       });
@@ -369,7 +379,13 @@ describe("Profile.tsx", () => {
       await user.click(submitButton);
 
       expect(mockUpdateProfile).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: expect.objectContaining({
+            message: "Email address can not be empty.",
+          }),
+        })
+      );
     });
 
     it("shows error when email is invalid format", async () => {
@@ -393,6 +409,7 @@ describe("Profile.tsx", () => {
     });
 
     it("does not update profile when email is invalid", async () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       const submitButton = screen.getByRole("button", {
         name: "Update profile",
       });
@@ -404,7 +421,13 @@ describe("Profile.tsx", () => {
       await user.click(submitButton);
 
       expect(mockUpdateProfile).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: expect.objectContaining({
+            message: "Email address is invalid.",
+          }),
+        })
+      );
     });
   });
 
@@ -493,9 +516,7 @@ describe("Profile.tsx", () => {
       message: "Oh no 😭",
     };
 
-    const originalConsoleError = console.error;
     beforeEach(async () => {
-      console.error = jest.fn();
       mockUpdateProfile.mockRejectedValue(error);
       mockGetUser.mockResolvedValue({
         ...testUser,
@@ -510,12 +531,12 @@ describe("Profile.tsx", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       cleanup();
       jest.resetAllMocks();
     });
 
     it("shows error when updating profile fails", async () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       const submitButton = screen.getByRole("button", {
         name: "Update profile",
       });
@@ -538,6 +559,7 @@ describe("Profile.tsx", () => {
     });
 
     it("does not refetches the user profile after when update failed", async () => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       const submitButton = screen.getByRole("button", {
         name: "Update profile",
       });

--- a/coral/src/app/features/user-information/tenant-information/TenantInformation.test.tsx
+++ b/coral/src/app/features/user-information/tenant-information/TenantInformation.test.tsx
@@ -22,16 +22,6 @@ const mockGetMyTenantInfoResponseUser = {
 };
 
 describe("TenantInformation.tsx", () => {
-  const originalConsoleError = console.error;
-
-  beforeAll(() => {
-    console.error = jest.fn();
-  });
-
-  afterAll(() => {
-    console.error = originalConsoleError;
-  });
-
   describe("renders tenant information data", () => {
     beforeEach(() => {
       mockGetMyTenantInfo.mockResolvedValue(mockGetMyTenantInfoResponseUser);
@@ -56,6 +46,7 @@ describe("TenantInformation.tsx", () => {
 
   describe("renders error if fetching the tenant info failed", () => {
     beforeEach(() => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       mockGetMyTenantInfo.mockRejectedValue({
         success: false,
         message: "error",
@@ -76,6 +67,10 @@ describe("TenantInformation.tsx", () => {
 
       expect(errorBox).toBeVisible();
       expect(errorBox).toHaveTextContent("error");
+      expect(console.error).toHaveBeenCalledWith({
+        message: "error",
+        success: false,
+      });
     });
   });
 });

--- a/coral/src/app/layout/header/ProfileDropdown.test.tsx
+++ b/coral/src/app/layout/header/ProfileDropdown.test.tsx
@@ -250,12 +250,10 @@ describe("ProfileDropdown", () => {
       status: 500,
       message: "bad error",
     };
-    const originalConsoleError = console.error;
 
     beforeEach(() => {
+      jest.spyOn(console, "error").mockImplementation((error) => error);
       mockLogoutUser.mockRejectedValue(testError);
-
-      console.error = jest.fn();
       Object.defineProperty(window, "location", {
         value: {
           assign: jest.fn(),
@@ -266,7 +264,6 @@ describe("ProfileDropdown", () => {
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
       cleanup();
     });

--- a/coral/src/app/layout/header/RequestsDropdown.test.tsx
+++ b/coral/src/app/layout/header/RequestsDropdown.test.tsx
@@ -46,15 +46,6 @@ const mockGetRequestsWaitingForApproval =
 
 describe("RequestsDropdown", () => {
   const user = userEvent.setup();
-  const originalConsoleError = console.error;
-
-  beforeAll(() => {
-    console.error = jest.fn();
-  });
-
-  afterAll(() => {
-    console.error = originalConsoleError;
-  });
 
   describe("has no pending requests", () => {
     beforeAll(() => {
@@ -407,6 +398,7 @@ describe("RequestsDropdown", () => {
     });
 
     it("calls useToast with correct error message", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetRequestsWaitingForApproval.mockRejectedValue(testError);
 
       customRender(<RequestsDropdown />, {

--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -478,23 +478,18 @@ describe("MainNavigation.tsx", () => {
   });
 
   describe("shows an toast error notification when fetching pending requests fails", () => {
-    const originalConsoleError = console.error;
     const testError: KlawApiError = {
       message: "Oh no, this did not work",
       success: false,
     };
 
-    beforeEach(() => {
-      console.error = jest.fn();
-    });
-
     afterEach(() => {
       cleanup();
-      console.error = originalConsoleError;
       jest.resetAllMocks();
     });
 
     it("calls useToast with correct error message", async () => {
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
       mockGetRequestsWaitingForApproval.mockRejectedValue(testError);
 
       customRender(<MainNavigation />, {

--- a/coral/src/app/pages/topics/schema-request.test.tsx
+++ b/coral/src/app/pages/topics/schema-request.test.tsx
@@ -1,13 +1,10 @@
-import { Context as AquariumContext } from "@aivenio/aquarium";
 import { cleanup, screen } from "@testing-library/react/pure";
 import SchemaRequest from "src/app/pages/topics/schema-request";
-import { getQueryClientForTests } from "src/services/test-utils/query-client-tests";
-import { render } from "@testing-library/react";
-import { QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { getAllEnvironmentsForTopicAndAcl } from "src/domain/environment";
 import { requestSchemaCreation } from "src/domain/schema-request";
 import { getTopicNames } from "src/domain/topic";
+import { customRender } from "src/services/test-utils/render-with-wrappers";
 
 jest.mock("src/domain/schema-request/schema-request-api.ts");
 jest.mock("src/domain/environment/environment-api.ts");
@@ -32,24 +29,17 @@ describe("SchemaRequest", () => {
       mockGetAllEnvironmentsForTopicAndAcl.mockResolvedValue([]);
       mockCreateSchemaRequest.mockImplementation(jest.fn());
       mockGetTopicNames.mockResolvedValue([topicName]);
-      // @TODO if we decide to go with this kind of dynamic routes,
-      // this should be enabled by customRender!
-      const queryClient = getQueryClientForTests();
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter initialEntries={[`/topic/${topicName}/request-schema`]}>
-            <Routes>
-              <Route
-                path={`/topic/:topicName/request-schema`}
-                element={
-                  <AquariumContext>
-                    <SchemaRequest />
-                  </AquariumContext>
-                }
-              />
-            </Routes>
-          </MemoryRouter>
-        </QueryClientProvider>
+
+      customRender(
+        <MemoryRouter initialEntries={[`/topic/${topicName}/request-schema`]}>
+          <Routes>
+            <Route
+              path={`/topic/:topicName/request-schema`}
+              element={<SchemaRequest />}
+            />
+          </Routes>
+        </MemoryRouter>,
+        { queryClient: true, aquariumContext: true }
       );
     });
 

--- a/coral/src/services/url-coral-klaw-enabled.test.ts
+++ b/coral/src/services/url-coral-klaw-enabled.test.ts
@@ -11,13 +11,11 @@ describe("url-coral-klaw-enabled.ts", () => {
   describe('"buildUrl" creates a href string enabling our Angular/React switch', () => {
     const testHref = "/topics/test/me/please";
 
-    const originalConsoleError = console.error;
     beforeEach(() => {
-      console.error = jest.fn();
+      jest.spyOn(console, "error").mockImplementationOnce((error) => error);
     });
 
     afterEach(() => {
-      console.error = originalConsoleError;
       jest.resetAllMocks();
     });
 

--- a/coral/test-setup/setup-files-after-env.ts
+++ b/coral/test-setup/setup-files-after-env.ts
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import "whatwg-fetch";
 import * as process from "process";
 import "src/services/test-utils/mock-documenation-helper";
+import failOnConsole from "jest-fail-on-console";
 
 // Mocking crypto.randomUUID in tests which use it
 // ie: components using useToast
@@ -17,3 +18,8 @@ process.env.FEATURE_FLAG_TOPIC_REQUEST = "true";
 jest.mock("src/services/is-dev-mode", () => ({
   isDevMode: () => true,
 }));
+
+failOnConsole({
+  shouldFailOnWarn: true,
+  shouldFailOnError: true,
+});


### PR DESCRIPTION
# Description

`fail-on-console` is a package I've used in the past & aquarium as well as console are using it, too. I

This PR: 
- add package
- adds config to setup after env for jest setup
- updates the mocks we did until now
- fixed real console error failures

⚠️  Unfortunately when we use `customRender` the console.error seems to happen async (?) or at leat in a way that `failOnConsole` is not able to catch it. We can see if we fix that in the future.

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

