### PR TITLE
Alter Register Users table primary key

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/RegisterUserInfo.java
+++ b/core/src/main/java/io/aiven/klaw/dao/RegisterUserInfo.java
@@ -2,6 +2,8 @@ package io.aiven.klaw.dao;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -19,6 +21,10 @@ import lombok.ToString;
 public class RegisterUserInfo implements Serializable {
 
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  private int id;
+
   @Column(name = "userid")
   private String username;
 

--- a/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/HandleDbRequests.java
@@ -292,6 +292,8 @@ public interface HandleDbRequests {
 
   RegisterUserInfo getRegisterUsersInfo(String username);
 
+  RegisterUserInfo getPendingRegisterUsersInfo(String username);
+
   AclRequests getAclRequest(int req_no, int tenantId);
 
   Optional<Acl> getAcl(int aclId, int tenantId);

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/HandleDbRequestsJdbc.java
@@ -657,6 +657,11 @@ public class HandleDbRequestsJdbc implements HandleDbRequests {
   }
 
   @Override
+  public RegisterUserInfo getPendingRegisterUsersInfo(String username) {
+    return jdbcSelectHelper.selectPendingRegisterUsersInfo(username);
+  }
+
+  @Override
   public AclRequests getAclRequest(int req_no, int tenantId) {
     return jdbcSelectHelper.selectAcl(req_no, tenantId);
   }

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -9,6 +9,7 @@ import io.aiven.klaw.dao.*;
 import io.aiven.klaw.model.enums.AclPatternType;
 import io.aiven.klaw.model.enums.AclType;
 import io.aiven.klaw.model.enums.KafkaClustersType;
+import io.aiven.klaw.model.enums.NewUserStatus;
 import io.aiven.klaw.model.enums.OperationalRequestType;
 import io.aiven.klaw.model.enums.OrderBy;
 import io.aiven.klaw.model.enums.RequestMode;
@@ -1121,8 +1122,13 @@ public class SelectDataJdbc {
   }
 
   public RegisterUserInfo selectRegisterUsersInfo(String username) {
-    Optional<RegisterUserInfo> registerUserRec = registerInfoRepo.findById(username);
+    Optional<RegisterUserInfo> registerUserRec = registerInfoRepo.findByUsername(username);
     return registerUserRec.orElse(null);
+  }
+
+  public RegisterUserInfo selectPendingRegisterUsersInfo(String username) {
+    return registerInfoRepo.findFirstByUsernameAndStatusIn(
+        username, List.of(NewUserStatus.PENDING.value, NewUserStatus.STAGING.value));
   }
 
   public List<Acl> getUniqueConsumerGroups(int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -98,13 +98,15 @@ public class UpdateDataJdbc {
       UserInfoRepo userInfoRepo,
       SchemaRequestRepo schemaRequestRepo,
       InsertDataJdbc insertDataJdbcHelper,
-      SelectDataJdbc selectDataJdbcHelper) {
+      SelectDataJdbc selectDataJdbcHelper,
+      RegisterInfoRepo registerInfoRepo) {
     this.topicRequestsRepo = topicRequestsRepo;
     this.aclRequestsRepo = aclRequestsRepo;
     this.userInfoRepo = userInfoRepo;
     this.schemaRequestRepo = schemaRequestRepo;
     this.insertDataJdbcHelper = insertDataJdbcHelper;
     this.selectDataJdbcHelper = selectDataJdbcHelper;
+    this.registerInfoRepo = registerInfoRepo;
   }
 
   public UpdateDataJdbc() {}
@@ -481,7 +483,8 @@ public class UpdateDataJdbc {
   public void updateNewUserRequest(String username, String approver, boolean isApprove) {
     log.debug("updateNewUserRequest {} {} {}", username, approver, isApprove);
     RegisterUserInfo registerUser =
-        registerInfoRepo.findFirstByUsernameAndStatus(username, NewUserStatus.PENDING.value);
+        registerInfoRepo.findFirstByUsernameAndStatusIn(
+            username, List.of(NewUserStatus.PENDING.value, NewUserStatus.STAGING.value));
     String status;
     if (isApprove) {
       status = NewUserStatus.APPROVED.value;

--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/UpdateDataJdbc.java
@@ -480,21 +480,21 @@ public class UpdateDataJdbc {
 
   public void updateNewUserRequest(String username, String approver, boolean isApprove) {
     log.debug("updateNewUserRequest {} {} {}", username, approver, isApprove);
-    Optional<RegisterUserInfo> registerUser = registerInfoRepo.findById(username);
+    RegisterUserInfo registerUser =
+        registerInfoRepo.findFirstByUsernameAndStatus(username, NewUserStatus.PENDING.value);
     String status;
     if (isApprove) {
       status = NewUserStatus.APPROVED.value;
     } else {
       status = NewUserStatus.DECLINED.value;
     }
-    if (registerUser.isPresent()) {
-      RegisterUserInfo registerUserInfo = registerUser.get();
-      if (NewUserStatus.PENDING.value.equals(registerUserInfo.getStatus())) {
-        registerUserInfo.setStatus(status);
-        registerUserInfo.setApprover(approver);
-        registerUserInfo.setRegisteredTime(new Timestamp(System.currentTimeMillis()));
+    if (registerUser != null) {
+      if (NewUserStatus.PENDING.value.equals(registerUser.getStatus())) {
+        registerUser.setStatus(status);
+        registerUser.setApprover(approver);
+        registerUser.setRegisteredTime(new Timestamp(System.currentTimeMillis()));
 
-        registerInfoRepo.save(registerUserInfo);
+        registerInfoRepo.save(registerUser);
       }
     }
   }

--- a/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
+++ b/core/src/main/java/io/aiven/klaw/repository/RegisterInfoRepo.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
 public interface RegisterInfoRepo extends CrudRepository<RegisterUserInfo, String> {
-  Optional<RegisterUserInfo> findById(String userid);
+  Optional<RegisterUserInfo> findByUsername(String userid);
 
   List<RegisterUserInfo> findAllByStatusAndTenantId(String status, int tenantId);
 
@@ -15,6 +15,8 @@ public interface RegisterInfoRepo extends CrudRepository<RegisterUserInfo, Strin
   List<RegisterUserInfo> findAllByStatus(String status);
 
   List<RegisterUserInfo> findAllByTenantId(int tenantId);
+
+  RegisterUserInfo findFirstByUsernameAndStatusIn(String userId, List<String> status);
 
   RegisterUserInfo findFirstByUsernameAndStatus(String userId, String status);
 

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -899,16 +899,11 @@ public class UsersTeamsControllerService {
                   || user.getUsername().equals(newUser.getMailid())) {
                 // if not equal to pending it has been previously declined or should have been
                 // caught by the above check if the user already exists.
-                log.info(
-                    "if {} or {} status {}",
-                    user.getUsername().equals(newUser.getUsername()),
-                    user.getUsername().equals(newUser.getMailid()),
-                    !Objects.equals(user.getStatus(), NewUserStatus.PENDING));
                 return !Objects.equals(user.getStatus(), NewUserStatus.PENDING);
               }
               return false;
             })) {
-      return ApiResponse.notOk(TEAMS_ERR_115);
+      return ApiResponse.notOk(TEAMS_ERR_117);
     }
     // get the user details from db
     RegisterUserInfo stagingRegisterUserInfo =

--- a/core/src/main/resources/db/changelog/changelog.yaml
+++ b/core/src/main/resources/db/changelog/changelog.yaml
@@ -1285,3 +1285,23 @@ databaseChangeLog:
                     type: VARCHAR2(10)
                     defaultValue: 'AVRO'
               tableName: kwavroschemas
+    - changeSet:
+        id: 25-03-2024 Alter primary key on registration table
+        author: aindriu-aiven
+        changes:
+        - dropPrimaryKey:
+            constraintName: CONSTRAINT_3
+            dropIndex: true
+            tableName: kwregisterusers
+        - addColumn:
+            tableName: kwregisterusers
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: REG_ID
+                  autoIncrement: true
+                  startWith: 1
+                  name: id
+                  type: INT


### PR DESCRIPTION
Add a new primary key to the register users table and alter queries to allow previously declined usernames to be approved or declined repeatedly.

# Linked issue

Resolves: #2364 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Currently once a username is declined it can never be used again in a future request.

# What is the new behavior?

Only if the username is already approved or in a pending or staging state will it not allow the creation of a new request.
Previously declined requests will be ignored.
# Other information

Upgrade scripts tested on a MySQL and Postgres DB.
Both had a mix of existing requests and had the new primary key automatically generated on the update.

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
