### PR TITLE
Incorrect team identifier added for topic owner id on acl claim request

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -538,7 +538,8 @@ public class AclControllerService {
     if (aclOp.isEmpty()) {
       return ApiResponse.notOk("Acl does not exist.");
     }
-    //topic is owned across all environments so it doesnt matter which one is selected to get the team Id
+    // topic is owned across all environments so it doesnt matter which one is selected to get the
+    // team Id
     List<Topic> topic =
         manageDatabase.getHandleDbRequests().getTopics(aclOp.get().getTopicname(), tenantId);
     if (topic.isEmpty()) {

--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -534,8 +534,15 @@ public class AclControllerService {
 
     // Get ACL
     Optional<Acl> aclOp = manageDatabase.getHandleDbRequests().getAcl(aclId, tenantId);
+
     if (aclOp.isEmpty()) {
       return ApiResponse.notOk("Acl does not exist.");
+    }
+    //topic is owned across all environments so it doesnt matter which one is selected to get the team Id
+    List<Topic> topic =
+        manageDatabase.getHandleDbRequests().getTopics(aclOp.get().getTopicname(), tenantId);
+    if (topic.isEmpty()) {
+      return ApiResponse.notOk("Unable to find the topic related to this ACL.");
     }
 
     if (manageDatabase
@@ -568,7 +575,8 @@ public class AclControllerService {
             RequestEntityType.ACL,
             RequestOperationType.CLAIM,
             aclOp.get().getEnvironment(),
-            aclOp.get().getReq_no(),
+            topic.get(0).getTeamId(),
+            // This is the Acl Team Id
             aclOp.get().getTeamId(),
             tenantId);
 


### PR DESCRIPTION
# Linked issue

Resolves: #2375 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The Claim ACL was providing the ACL Id instead of the topic owner id to the ACL Claim request meaning that the team would be unknown preventing the claim from being able to be approved.

# What is the new behavior?

The topic owner id is now provided so that it may be added to the multi approval.

# Other information

N/A

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
