### PR TITLE
Rename resourceNameId to resourceOwnerTeamId in ApprovalService.java

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/ApprovalService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ApprovalService.java
@@ -77,7 +77,7 @@ public class ApprovalService {
       RequestEntityType entityType,
       RequestOperationType operationType,
       String envName,
-      Integer resourceNameId,
+      Integer resourceOwnerTeamId,
       Integer aclOwnerId,
       int tenantId)
       throws KlawException {
@@ -85,7 +85,7 @@ public class ApprovalService {
     for (Approval app : approvals) {
       if (app.getApprovalType() == ApprovalType.TOPIC_TEAM_OWNER
           || app.getApprovalType() == ApprovalType.CONNECTOR_TEAM_OWNER) {
-        app.setRequiredApprover(manageDatabase.getTeamNameFromTeamId(tenantId, resourceNameId));
+        app.setRequiredApprover(manageDatabase.getTeamNameFromTeamId(tenantId, resourceOwnerTeamId));
       } else if (app.getApprovalType() == ApprovalType.ACL_TEAM_OWNER) {
         app.setRequiredApprover(manageDatabase.getTeamNameFromTeamId(tenantId, aclOwnerId));
       }


### PR DESCRIPTION

# Linked issue

Resolves: #2388 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

The variable name "resourceNameId" in method getApprovalsForRequest in java class "ApprovalService" is confusing.

# What is the new behavior?

Variable "resourceNameId" is changed to "resourceOwnerTeamId", describing the meaning of the variable well which is the teamId of the team that owns the resource.


# Other information

N/A

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
