### PR TITLE
Support Claim ACL request in MySql

### DIFF
--- a/core/src/main/java/io/aiven/klaw/dao/Approval.java
+++ b/core/src/main/java/io/aiven/klaw/dao/Approval.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.dao;
 
+import io.aiven.klaw.helpers.ApprovalTypeConverter;
 import io.aiven.klaw.model.enums.ApprovalType;
 import jakarta.persistence.*;
 import java.io.Serializable;
@@ -15,6 +16,7 @@ public class Approval implements Serializable {
   private Integer approvalId;
 
   @Column(name = "approvaltype")
+  @Convert(converter = ApprovalTypeConverter.class)
   private ApprovalType approvalType;
 
   @Column(name = "requiredapprover")

--- a/core/src/main/java/io/aiven/klaw/helpers/ApprovalTypeConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/ApprovalTypeConverter.java
@@ -12,8 +12,8 @@ public class ApprovalTypeConverter implements AttributeConverter<ApprovalType, S
     if (approvalType == null) {
       return null;
     }
-
-    return approvalType.name();
+    // Pre existing code saves the ordinal as a string in Postgres and H2
+    return String.valueOf(approvalType.ordinal());
   }
 
   @Override
@@ -21,6 +21,12 @@ public class ApprovalTypeConverter implements AttributeConverter<ApprovalType, S
     if (approvalType == null) {
       return null;
     }
-    return ApprovalType.of(approvalType);
+    return switch (Integer.parseInt(approvalType)) {
+      case 0 -> ApprovalType.TOPIC_TEAM_OWNER;
+      case 1 -> ApprovalType.CONNECTOR_TEAM_OWNER;
+      case 2 -> ApprovalType.ACL_TEAM_OWNER;
+      case 3 -> ApprovalType.TEAM;
+      default -> null;
+    };
   }
 }

--- a/core/src/main/java/io/aiven/klaw/helpers/ApprovalTypeConverter.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/ApprovalTypeConverter.java
@@ -1,0 +1,26 @@
+package io.aiven.klaw.helpers;
+
+import io.aiven.klaw.model.enums.ApprovalType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class ApprovalTypeConverter implements AttributeConverter<ApprovalType, String> {
+
+  @Override
+  public String convertToDatabaseColumn(ApprovalType approvalType) {
+    if (approvalType == null) {
+      return null;
+    }
+
+    return approvalType.name();
+  }
+
+  @Override
+  public ApprovalType convertToEntityAttribute(String approvalType) {
+    if (approvalType == null) {
+      return null;
+    }
+    return ApprovalType.of(approvalType);
+  }
+}


### PR DESCRIPTION
To support mysql databases we need to manage the creation of enums as strings into the db and back out with converters

# Linked issue

MySql requires that we make an enum a string before persisting it into the database.

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
