### PR TITLE
Improve Claim experience

### DIFF
--- a/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/db/rdbms/SelectDataJdbc.java
@@ -186,8 +186,12 @@ public class SelectDataJdbc {
 
         if (RequestOperationType.DELETE.value.equals(rowRequestOperationType)) {
           teamId = row.getRequestingteam();
-        } else if (RequestOperationType.CLAIM.value.equals(rowRequestOperationType)) {
-
+        } else if (RequestOperationType.CLAIM.value.equals(rowRequestOperationType)
+            && row.getApprovals().stream()
+                .anyMatch(approval -> requestor.equals(approval.getApproverName()))) {
+          // Multi Approval filtering remove this row as it is an approval that has already been
+          // approved by this user.
+          continue;
         }
 
       } else {

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -16,6 +16,7 @@ import io.aiven.klaw.model.enums.AclType;
 import io.aiven.klaw.model.enums.KafkaClustersType;
 import io.aiven.klaw.model.enums.KafkaFlavors;
 import io.aiven.klaw.model.enums.PromotionStatusType;
+import io.aiven.klaw.model.enums.RequestStatus;
 import io.aiven.klaw.model.response.AclOverviewInfo;
 import io.aiven.klaw.model.response.PromotionStatus;
 import io.aiven.klaw.model.response.TopicOverview;
@@ -260,7 +261,16 @@ public abstract class BaseOverviewService {
         // Claim Acl is available to teams that are unable to delete the Acl as they do not own the
         // ACL.
         // Will need to add an extra check when an acl claim is opened.
-        mp.setShowClaimAcl(!mp.isShowDeleteAcl());
+        mp.setShowClaimAcl(
+            !mp.isShowDeleteAcl()
+                && !manageDatabase
+                    .getHandleDbRequests()
+                    .existsSpecificAclRequest(
+                        mp.getTopicname(),
+                        RequestStatus.CREATED.value,
+                        mp.getEnvironment(),
+                        tenantId,
+                        Integer.valueOf(mp.getReq_no())));
         aclList.add(mp);
       }
     }

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -270,7 +270,7 @@ public abstract class BaseOverviewService {
                         RequestStatus.CREATED.value,
                         mp.getEnvironment(),
                         tenantId,
-                        Integer.valueOf(mp.getReq_no())));
+                        Integer.parseInt(mp.getReq_no())));
         aclList.add(mp);
       }
     }


### PR DESCRIPTION
# Linked issue

Improves user experience, when an acl is claimed now it will no longer render the button to others who try to claim the ACL.
Improves user experience by removing the approval from your approvals table when you have approved it.


# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?
Currently the claim button is always available even though an existing claim request might be open.
Currently if two approvals are required from the same team it stays even though you are unable to apply the second approval
# What is the new behavior?

Claim button is removed after a claim is opened.
Approval Request is removed after you give your approval

# Other information

NA

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
