### PR TITLE
Fix validation to parse partitions as ints first

### DIFF
--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -707,8 +707,8 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
 
                 var defRepFactor = parseInt($scope.addNewEnv.defrepfctr,10)
                 var maxRepFactor = parseInt($scope.addNewEnv.maxrepfctr,10)
-                var defPartitionFactor = parseInt($scope.addNewEnv.defparts,10)
-                var maxPartitionFactor = parseInt($scope.addNewEnv.defmaxparts,10)
+                var defPartitions = parseInt($scope.addNewEnv.defparts,10)
+                var maxPartitions = parseInt($scope.addNewEnv.defmaxparts,10)
 
                 // Validation partitions
                 if($scope.addNewEnv.defparts.length<=0 || $scope.addNewEnv.defparts<=0)
@@ -718,7 +718,7 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                 	return;
                 }
 
-                if(isNaN(defPartitionFactor)){
+                if(isNaN(defPartitions)){
                     $scope.alertnote = "Default partitions should be a valid number";
                     $scope.showAlertToast();
                     return;
@@ -731,13 +731,13 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                 	return;
                 }
 
-                if(isNaN(maxPartitionFactor)){
+                if(isNaN(maxPartitions)){
                     $scope.alertnote = "Maximum partitions should be a valid number";
                     $scope.showAlertToast();
                     return;
                 }
 
-                if(defPartitionFactor > maxPartitionFactor){
+                if(defPartitions > maxPartitions){
                     $scope.alertnote = "Default partitions should be less than Maximum partitions";
                     $scope.showAlertToast();
                     return;

--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -705,6 +705,11 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
 
         $scope.addNewEnv = function() {
 
+                var defRepFactor = parseInt($scope.addNewEnv.defrepfctr,10)
+                var maxRepFactor = parseInt($scope.addNewEnv.maxrepfctr,10)
+                var defPartitionFactor = parseInt($scope.addNewEnv.defparts,10)
+                var maxPartitionFactor = parseInt($scope.addNewEnv.defmaxparts,10)
+
                 // Validation partitions
                 if($scope.addNewEnv.defparts.length<=0 || $scope.addNewEnv.defparts<=0)
                 {
@@ -713,7 +718,7 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                 	return;
                 }
 
-                if(isNaN($scope.addNewEnv.defparts)){
+                if(isNaN(defPartitionFactor)){
                     $scope.alertnote = "Default partitions should be a valid number";
                     $scope.showAlertToast();
                     return;
@@ -726,13 +731,13 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                 	return;
                 }
 
-                if(isNaN($scope.addNewEnv.defmaxparts)){
+                if(isNaN(maxPartitionFactor)){
                     $scope.alertnote = "Maximum partitions should be a valid number";
                     $scope.showAlertToast();
                     return;
                 }
 
-                if($scope.addNewEnv.defparts > $scope.addNewEnv.defmaxparts){
+                if(defPartitionFactor > maxPartitionFactor){
                     $scope.alertnote = "Default partitions should be less than Maximum partitions";
                     $scope.showAlertToast();
                     return;
@@ -747,26 +752,26 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
                 	return;
                 }
 
-                if(isNaN($scope.addNewEnv.defrepfctr)){
+                if(isNaN(defRepFactor)){
                     $scope.alertnote = "Default replication factor should be a valid number";
                     $scope.showAlertToast();
                     return;
                 }
 
-                if($scope.addNewEnv.maxrepfctr.length<=0 || $scope.addNewEnv.maxrepfctr<=0)
+                if(defRepFactor<=0 || maxRepFactor<=0)
                 {
                     $scope.alertnote = "Maximum Replication factor should not be empty and should be greater than 0";
                     $scope.showAlertToast();
                     return;
                 }
 
-                if(isNaN($scope.addNewEnv.maxrepfctr)){
+                if(isNaN(maxRepFactor)){
                     $scope.alertnote = "Maximum Replication factor should be a valid number";
                     $scope.showAlertToast();
                     return;
                 }
 
-                if($scope.addNewEnv.defrepfctr > $scope.addNewEnv.maxrepfctr){
+                if(defRepFactor > maxRepFactor){
                     $scope.alertnote = "Default Replication factor should be less than Maximum Replication factor";
                     $scope.showAlertToast();
                     return;


### PR DESCRIPTION
# Linked issue

Resolves: #2508 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

Strings are compared to each other for default and max paritions and replication
# What is the new behavior?

Strings are parsed to ints then compared to each other for default and max paritions and replication

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
