### PR TITLE
maintenance: Add showUsers, getMyProfileInfo, updateUserTeamFromSwitc…

### DIFF
--- a/core/src/test/java/io/aiven/klaw/UtilMethods.java
+++ b/core/src/test/java/io/aiven/klaw/UtilMethods.java
@@ -172,6 +172,20 @@ public class UtilMethods {
     return userInfoList;
   }
 
+  public List<UserInfo> getUserInfoList(int count, String usernamePrefix) {
+    List<UserInfo> userInfoList = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      UserInfo userInfo = new UserInfo();
+      userInfo.setTeamId(i % 2);
+      userInfo.setSwitchAllowedTeamIds(Set.of((i + 1) % 2));
+      userInfo.setSwitchTeams(true);
+      userInfo.setUsername(usernamePrefix + i);
+      userInfoList.add(userInfo);
+    }
+
+    return userInfoList;
+  }
+
   public List<UserInfoModelResponse> getUserInfoListModel(String username, String role) {
     List<UserInfoModelResponse> userInfoList = new ArrayList<>();
     UserInfoModelResponse userInfo = new UserInfoModelResponse();


### PR DESCRIPTION
# Linked issue

Resolves: #2485 

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_UsersTeamsControllerService.java lacks unit tests for showUsers, getMyProfileInfo, updateUserTeamFromSwitchTeams and getSwitchTeams_

# What is the new behavior?

_Unit tests added for showUsers, getMyProfileInfo, updateUserTeamFromSwitchTeams and getSwitchTeams in UsersTeamsControllerServiceTest_

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
