### PR TITLE
fix: add a try-catch to handle DataIntegrityViolationException for lo…

### DIFF
--- a/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
+++ b/coral/src/app/features/topics/request/form-schemas/topic-request-form.ts
@@ -47,7 +47,7 @@ const formSchema = z
     topicname: topicNameField,
     advancedConfiguration: advancedConfigurationField,
     remarks: z.string(),
-    description: z.string().min(1),
+    description: z.string().min(1).max(100),
   })
   .superRefine(validateTopicPartitions)
   .superRefine(validateReplicationFactor)

--- a/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
@@ -405,7 +405,8 @@ public class KlawErrorMessages {
   public static final String TOPICS_VLD_ERR_124 =
       "Failure. This topic does not exist in the cluster.";
 
-  public static final String TOPICS_VLD_ERR_125 = "Failure. Topic values exceed allowed lengths.";
+  public static final String TOPICS_VLD_ERR_125 =
+      "Failure. Topic description exceeds allowed length.";
 
   public static final String TOPICS_VLD_ERR_126 = "Failure. Data integrity violation: ";
 

--- a/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
+++ b/core/src/main/java/io/aiven/klaw/error/KlawErrorMessages.java
@@ -405,6 +405,10 @@ public class KlawErrorMessages {
   public static final String TOPICS_VLD_ERR_124 =
       "Failure. This topic does not exist in the cluster.";
 
+  public static final String TOPICS_VLD_ERR_125 = "Failure. Topic values exceed allowed lengths.";
+
+  public static final String TOPICS_VLD_ERR_126 = "Failure. Data integrity violation: ";
+
   // Topic overview service
   public static final String TOPIC_OVW_ERR_101 = "Topic does not exist in any environment.";
 

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -226,26 +226,31 @@ public class TopicControllerServiceTest {
   @Test
   @Order(5)
   public void createTopicsFailureInvalidTopicDescriptionLength()
-          throws KlawException, KlawNotAuthorizedException {
+      throws KlawException, KlawNotAuthorizedException {
 
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
     when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-            .thenReturn(false);
+        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvListsIncorrect1());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
-            .thenReturn(Collections.singletonList("1"));
+        .thenReturn(Collections.singletonList("1"));
     when(commonUtilsService.getEnvProperty(anyInt(), anyString())).thenReturn("1");
 
-    SQLDataException causeException = new SQLDataException("Seed size for the object exceeds the\n" +
-            "column size in the database. Value too long for column...");
-    DataIntegrityViolationException exception = new DataIntegrityViolationException("Error message", causeException);
+    SQLDataException causeException =
+        new SQLDataException(
+            "Seed size for the object exceeds the\n"
+                + "column size in the database. Value too long for column...");
+    DataIntegrityViolationException exception =
+        new DataIntegrityViolationException("Error message", causeException);
     when(handleDbRequests.requestForTopic(any())).thenThrow(exception);
 
-    ApiResponse apiResponse = topicControllerService.createTopicsCreateRequest(getFailureTopicWithLongDescription());
-    assertThat(apiResponse.getMessage()).isEqualTo("Failure. Topic values exceed allowed lengths.");
+    ApiResponse apiResponse =
+        topicControllerService.createTopicsCreateRequest(getFailureTopicWithLongDescription());
+    assertThat(apiResponse.getMessage())
+        .isEqualTo("Failure. Topic description exceeds allowed length.");
   }
 
   @Test

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -39,6 +39,7 @@ import io.aiven.klaw.model.requests.TopicRequestModel;
 import io.aiven.klaw.model.response.TopicDetailsPerEnv;
 import io.aiven.klaw.model.response.TopicRequestsResponseModel;
 import io.aiven.klaw.model.response.TopicTeamResponse;
+import java.sql.SQLDataException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,6 +58,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -219,6 +221,31 @@ public class TopicControllerServiceTest {
 
     ApiResponse apiResponse = topicControllerService.createTopicsCreateRequest(getFailureTopic1());
     assertThat(apiResponse.getMessage()).isEqualTo(ApiResultStatus.FAILURE.value);
+  }
+
+  @Test
+  @Order(5)
+  public void createTopicsFailureInvalidTopicDescriptionLength()
+          throws KlawException, KlawNotAuthorizedException {
+
+    when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
+    when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
+    when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
+    stubUserInfo();
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+            .thenReturn(false);
+    when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvListsIncorrect1());
+    when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
+            .thenReturn(Collections.singletonList("1"));
+    when(commonUtilsService.getEnvProperty(anyInt(), anyString())).thenReturn("1");
+
+    SQLDataException causeException = new SQLDataException("Seed size for the object exceeds the\n" +
+            "column size in the database. Value too long for column...");
+    DataIntegrityViolationException exception = new DataIntegrityViolationException("Error message", causeException);
+    when(handleDbRequests.requestForTopic(any())).thenThrow(exception);
+
+    ApiResponse apiResponse = topicControllerService.createTopicsCreateRequest(getFailureTopicWithLongDescription());
+    assertThat(apiResponse.getMessage()).isEqualTo("Failure. Topic values exceed allowed lengths.");
   }
 
   @Test
@@ -1759,6 +1786,17 @@ public class TopicControllerServiceTest {
     topicRequest.setTopicname("newtopicname");
     topicRequest.setEnvironment(env.getId());
     topicRequest.setTopicpartitions(-1);
+    topicRequest.setRequestOperationType(RequestOperationType.CREATE);
+    return topicRequest;
+  }
+
+  private TopicRequestModel getFailureTopicWithLongDescription() {
+    TopicRequestModel topicRequest = new TopicRequestModel();
+    topicRequest.setTopicname("newtopicname");
+    int DESCRIPTION_COLUMN_LENGTH = 100; // VARCHAR(100) but can be other length.
+    topicRequest.setDescription("x".repeat(DESCRIPTION_COLUMN_LENGTH + 1));
+    topicRequest.setEnvironment(env.getId());
+    topicRequest.setTopicpartitions(2);
     topicRequest.setRequestOperationType(RequestOperationType.CREATE);
     return topicRequest;
   }


### PR DESCRIPTION
# Linked issue

Resolves: #2543 

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

After trying to add a reasonable "long" description for requesting to create a topic, the backend throws an unhandled exception because the description is too long for the column it's being inserted on. 

API response:
```json
{
    "timestamp": "2024-08-09T03:31:44.369+00:00",
    "status": 500,
    "error": "Internal Server Error",
    "path": "/createTopics"
}
```

<img width="614" alt="image" src="https://github.com/user-attachments/assets/83dcb455-6810-4cfb-ba0a-ec4309f306b7">


# What is the new behavior?

The backend handles the exception and returns a an `ApiResponse` informing the client about why the request could not be processed: 

```json
{
    "success":false,
    "message":"Failure. Topic values exceed allowed lengths."
}
```
<img width="614" alt="image" src="https://github.com/user-attachments/assets/51127534-8e22-4c2e-80a2-898c4c068383">

# Other information

I explored the idea of validating from `TopicRequestModel` with `jakarta.validation annotations` or from the `@Column` of the TopicRequest entity but it would make assumptions about the db schema. I also explored doing it from `TopicRequestValidatorImpl::isValid` but I lacked database schema information.

If this direction is viable, then it also captures the issue for long topic names, and remarks.

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
