### PR TITLE
deps: Add proxy and e2e dir to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
     directory: "/coral"
     schedule:
       interval: "weekly"
+  - package-ecosystem: npm # for whatever reason, the YAML value for pnpm is npm
+    directory: "/coral/proxy"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: npm # for whatever reason, the YAML value for pnpm is npm
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Description

- add `/coral/proxy` as well as `/e2e` to dependabot config