### PR TITLE
feat(coral): Adapt superadmin preview banner and add tenants link

### DIFF
--- a/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.test.tsx
@@ -260,6 +260,10 @@ describe("MainNavigation.tsx", () => {
             linkTo: `/configuration/teams`,
           },
           {
+            name: "Tenants",
+            linkTo: "/tenants",
+          },
+          {
             name: "Environments",
             linkTo: "/configuration/environments",
           },

--- a/coral/src/app/layout/main-navigation/MainNavigation.tsx
+++ b/coral/src/app/layout/main-navigation/MainNavigation.tsx
@@ -164,6 +164,9 @@ function MainNavigation() {
               active={pathname.startsWith(Routes.TEAMS)}
             />
             {showNavigationForSuperAdmin && (
+              <MainNavigationLink linkText={"Tenants"} to={"/tenants"} />
+            )}
+            {showNavigationForSuperAdmin && (
               <MainNavigationLink
                 linkText={"Approve user request"}
                 to={"/execUsers"}

--- a/core/src/main/resources/templates/browseAcls.html
+++ b/core/src/main/resources/templates/browseAcls.html
@@ -429,7 +429,7 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
-			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true' && userrole != 'SUPERADMIN'">
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">

--- a/core/src/main/resources/templates/clusters.html
+++ b/core/src/main/resources/templates/clusters.html
@@ -460,7 +460,7 @@
 
 			<!-- Row -->
 
-			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true' && userrole != 'SUPERADMIN'">
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">

--- a/core/src/main/resources/templates/connectorOverview.html
+++ b/core/src/main/resources/templates/connectorOverview.html
@@ -430,7 +430,7 @@
 		<div class="container-fluid">
 			<div class="row page-titles">
 			</div>
-			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true' && userrole != 'SUPERADMIN'">
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">

--- a/core/src/main/resources/templates/envs.html
+++ b/core/src/main/resources/templates/envs.html
@@ -437,7 +437,7 @@
 			<div class="row page-titles">
 			</div>
 
-			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true' && userrole != 'SUPERADMIN'">
+			<div class="row" ng-if="dashboardDetails.coralEnabled === 'true'">
 				<div class="ribbon-wrapper card col-lg-6 col-md-6 col-xlg-2 col-xs-6">
 					<div class="ribbon ribbon-success">New user interface available</div>
 					<p class="ribbon-content">


### PR DESCRIPTION
# Description

This PR:

- removes the preview banner link for topic overview (details to a topic) and connector overview for superadmins
- adds "tenants" as navigation link to coral, redirecting to Klaw

# What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

