### PR TITLE
Use the environment Id from the topicDetails

### DIFF
--- a/coral/src/app/features/topics/details/messages/TopicMessages.test.tsx
+++ b/coral/src/app/features/topics/details/messages/TopicMessages.test.tsx
@@ -22,7 +22,7 @@ const mockGetTopicMessagesNoContentResponse = {
 };
 
 function DummyParent() {
-  return <Outlet context={{ topicName: "test" }} />;
+  return <Outlet context={{ topicName: "test", environmentId: "2" }} />;
 }
 
 describe("TopicMessages", () => {

--- a/coral/src/app/features/topics/details/messages/TopicMessages.tsx
+++ b/coral/src/app/features/topics/details/messages/TopicMessages.tsx
@@ -31,7 +31,7 @@ function isNoContentResult(
 }
 
 function TopicMessages() {
-  const { topicName } = useTopicDetails();
+  const { topicName, environmentId } = useTopicDetails();
 
   const {
     validateFilters,
@@ -61,7 +61,7 @@ function TopicMessages() {
       getTopicMessages({
         topicName,
         consumerGroupId: "notdefined",
-        envId: "2",
+        envId: environmentId,
         offsetId: defaultOffsetFilters.defaultOffset,
         selectedPartitionId: Number(partitionIdFilters.partitionId),
         selectedNumberOfOffsets: Number(customOffsetFilters.customOffset),


### PR DESCRIPTION
# Linked issue

Resolves: #2602

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

There is a harcoded environment id for checking the messages on a topic.

# What is the new behavior?

The value is now pulled from the topic context in coral.

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
