### PR TITLE
maintenance: Refactor getPrincipal method logic into common class

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclControllerService.java
@@ -60,7 +60,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -100,7 +99,7 @@ public class AclControllerService {
     aclRequestsModel.setRequestingteam(commonUtilsService.getTeamId(currentUserName));
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -454,7 +453,7 @@ public class AclControllerService {
 
     // get requests relevant to your teams or all teams
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS)) {
       createdAclReqs =
           manageDatabase
               .getHandleDbRequests()
@@ -521,7 +520,7 @@ public class AclControllerService {
   public ApiResponse deleteAclRequests(String req_no) throws KlawException {
     try {
       if (commonUtilsService.isNotAuthorizedUser(
-          getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
+          commonUtilsService.getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
         return ApiResponse.NOT_AUTHORIZED;
       }
       String userName = getCurrentUserName();
@@ -544,7 +543,7 @@ public class AclControllerService {
     log.info("claimAcl {}", aclId);
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_CREATE_SUBSCRIPTIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -619,7 +618,7 @@ public class AclControllerService {
     log.info("createDeleteAclSubscriptionRequest {}", req_no);
     final String userName = getCurrentUserName();
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_DELETE_SUBSCRIPTIONS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_DELETE_SUBSCRIPTIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -677,7 +676,7 @@ public class AclControllerService {
     final String userDetails = getCurrentUserName();
     int tenantId = commonUtilsService.getTenantId(userDetails);
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_SUBSCRIPTIONS)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_SUBSCRIPTIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1033,7 +1032,7 @@ public class AclControllerService {
 
     String userDetails = getCurrentUserName();
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_SUBSCRIPTIONS)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_SUBSCRIPTIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1109,10 +1108,6 @@ public class AclControllerService {
       log.error("Ignoring error while retrieving consumer offsets {} ", e.toString());
     }
     return consumerOffsetInfoList;
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
   public ServiceAccountDetails getAivenServiceAccountDetails(

--- a/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AclSyncControllerService.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -82,7 +81,8 @@ public class AclSyncControllerService {
     String userName = getUserName();
     int tenantId = commonUtilsService.getTenantId(userName);
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_SUBSCRIPTIONS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_SUBSCRIPTIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -179,7 +179,7 @@ public class AclSyncControllerService {
     logArray.add("Type of Sync " + syncBackAcls.getTypeOfSync());
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.SYNC_BACK_SUBSCRIPTIONS)) {
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_BACK_SUBSCRIPTIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -395,7 +395,8 @@ public class AclSyncControllerService {
       topicNameSearch = topicNameSearch.trim();
     }
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_SUBSCRIPTIONS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_SUBSCRIPTIONS)) {
       return null;
     }
 
@@ -440,7 +441,7 @@ public class AclSyncControllerService {
 
     int tenantId = commonUtilsService.getTenantId(userName);
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.SYNC_BACK_SUBSCRIPTIONS)) {
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_BACK_SUBSCRIPTIONS)) {
       return null;
     }
 
@@ -698,7 +699,7 @@ public class AclSyncControllerService {
 
   private List<String> tenantFiltering(List<String> teamList) {
     if (!commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(),
+        commonUtilsService.getPrincipal(),
         Set.of(
             PermissionType.SYNC_BACK_SUBSCRIPTIONS,
             PermissionType.SYNC_TOPICS,
@@ -726,7 +727,7 @@ public class AclSyncControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public Env getEnvDetails(String envId, int tenantId) {
@@ -736,9 +737,5 @@ public class AclSyncControllerService {
             .filter(env -> Objects.equals(env.getId(), envId))
             .findFirst();
     return envFound.orElse(null);
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/AnalyticsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/AnalyticsControllerService.java
@@ -36,7 +36,6 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -343,7 +342,8 @@ public class AnalyticsControllerService {
     final String currentUserName = getCurrentUserName();
     Integer userTeamId = commonUtilsService.getTeamId(currentUserName);
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
       int tenantId = commonUtilsService.getTenantId(currentUserName);
 
       teamOverview.setProducerAclsPerTeamsOverview(
@@ -593,7 +593,8 @@ public class AnalyticsControllerService {
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(getCurrentUserName());
 
     Map<String, List<String>> topicsPerEnv = new HashMap<>();
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
       // normal user
       Integer userTeamId = commonUtilsService.getTeamId(getCurrentUserName());
       List<Topic> topics =
@@ -630,7 +631,8 @@ public class AnalyticsControllerService {
     final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(getCurrentUserName());
 
     Map<String, List<String>> aclsPerEnv = new HashMap<>();
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
       // normal user
       Integer userTeamId = commonUtilsService.getTeamId(getCurrentUserName());
       List<Acl> acls =
@@ -664,9 +666,5 @@ public class AnalyticsControllerService {
     }
 
     return aclsPerEnv;
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
+++ b/core/src/main/java/io/aiven/klaw/service/BaseOverviewService.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -333,11 +332,7 @@ public abstract class BaseOverviewService {
   }
 
   protected String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  protected Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   protected Env getEnvDetails(String envId, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -107,7 +107,7 @@ public class EnvsClustersTenantsControllerService {
   }
 
   private boolean isAuthorizedFor(PermissionType type) {
-    return !commonUtilsService.isNotAuthorizedUser(getPrincipal(), type);
+    return !commonUtilsService.isNotAuthorizedUser(commonUtilsService.getPrincipal(), type);
   }
 
   public synchronized EnvModelResponse getEnvDetails(String envSelected, String clusterType) {
@@ -392,7 +392,8 @@ public class EnvsClustersTenantsControllerService {
     int tenantId = getUserDetails(userName).getTenantId();
     List<Env> listEnvs = manageDatabase.getKafkaConnectEnvList(tenantId);
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), ADD_EDIT_DELETE_ENVS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), ADD_EDIT_DELETE_ENVS)) {
       final Set<String> allowedEnvIdSet = commonUtilsService.getEnvsFromUserId(userName);
       listEnvs =
           listEnvs.stream().filter(env -> allowedEnvIdSet.contains(env.getId())).collect(toList());
@@ -730,7 +731,7 @@ public class EnvsClustersTenantsControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   private Boolean isUserSuperAdmin() {
@@ -858,10 +859,6 @@ public class EnvsClustersTenantsControllerService {
     return kwTenantModel;
   }
 
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-  }
-
   public ApiResponse deleteTenant() throws KlawException {
     if (!isAuthorizedFor(UPDATE_DELETE_MY_TENANT)) {
       return ApiResponse.NOT_AUTHORIZED;
@@ -907,7 +904,7 @@ public class EnvsClustersTenantsControllerService {
 
   public ApiResponse updateTenant(KwTenantModel kwTenantModel) throws KlawException {
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.UPDATE_DELETE_MY_TENANT)) {
+        commonUtilsService.getPrincipal(), PermissionType.UPDATE_DELETE_MY_TENANT)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectControllerService.java
@@ -72,7 +72,6 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.jasypt.util.text.BasicTextEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -111,7 +110,7 @@ public class KafkaConnectControllerService {
     String userName = getUserName();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_CREATE_CONNECTORS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_CREATE_CONNECTORS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -504,7 +503,7 @@ public class KafkaConnectControllerService {
     int tenantId = commonUtilsService.getTenantId(getUserName());
     try {
       if (commonUtilsService.isNotAuthorizedUser(
-          getPrincipal(), PermissionType.MANAGE_CONNECTORS)) {
+          commonUtilsService.getPrincipal(), PermissionType.MANAGE_CONNECTORS)) {
         return ApiResponse.NOT_AUTHORIZED;
       }
       return clusterApiService.restartConnector(kafkaConnectorRestartModel, tenantId);
@@ -528,7 +527,7 @@ public class KafkaConnectControllerService {
 
     // get requests relevant to your teams or all teams
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS))
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS))
       createdTopicReqList =
           manageDatabase
               .getHandleDbRequests()
@@ -637,7 +636,8 @@ public class KafkaConnectControllerService {
     String userDetails = getUserName();
     int tenantId = commonUtilsService.getTenantId(getUserName());
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.APPROVE_CONNECTORS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_CONNECTORS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -788,7 +788,8 @@ public class KafkaConnectControllerService {
       throws KlawException {
     log.info("declineConnectorRequests {} {}", connectorId, reasonForDecline);
     String userDetails = getUserName();
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.APPROVE_CONNECTORS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_CONNECTORS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -837,7 +838,7 @@ public class KafkaConnectControllerService {
     String userDetails = getUserName();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_DELETE_CONNECTORS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_DELETE_CONNECTORS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1553,11 +1554,7 @@ public class KafkaConnectControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public Env getKafkaConnectEnvDetails(String envId) {

--- a/core/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/KafkaConnectSyncControllerService.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -81,7 +80,8 @@ public class KafkaConnectSyncControllerService {
     log.info("updateSyncConnectors {}", updatedSyncTopics);
     String userName = getUserName();
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_CONNECTORS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_CONNECTORS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -477,7 +477,8 @@ public class KafkaConnectSyncControllerService {
   }
 
   private List<String> tenantFilterTeams(List<String> teamList) {
-    if (!commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_CONNECTORS)) {
+    if (!commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_CONNECTORS)) {
       // tenant filtering
       int tenantId = commonUtilsService.getTenantId(getUserName());
       List<Team> teams = manageDatabase.getHandleDbRequests().getAllTeams(tenantId);
@@ -492,11 +493,7 @@ public class KafkaConnectSyncControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public Env getKafkaConnectorEnvDetails(String envId) {

--- a/core/src/main/java/io/aiven/klaw/service/MetricsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/MetricsControllerService.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,7 +30,7 @@ public class MetricsControllerService {
   @Autowired private CommonUtilsService commonUtilsService;
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   // default 1 min
@@ -108,9 +107,5 @@ public class MetricsControllerService {
         "DateTime",
         "Messages",
         commonUtilsService.getTenantId(getUserName()));
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/OperationalRequestsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/OperationalRequestsService.java
@@ -42,7 +42,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -264,7 +263,7 @@ public class OperationalRequestsService {
     int tenantId = commonUtilsService.getTenantId(userName);
     // get requests relevant to your teams or all teams
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS)) {
       operationalRequestList =
           manageDatabase
               .getHandleDbRequests()
@@ -400,7 +399,7 @@ public class OperationalRequestsService {
     final String userName = getUserName();
     int tenantId = commonUtilsService.getTenantId(userName);
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_OPERATIONAL_CHANGES)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_OPERATIONAL_CHANGES)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -477,17 +476,13 @@ public class OperationalRequestsService {
   }
 
   private void checkIsAuthorized(PermissionType permission) throws KlawNotAuthorizedException {
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), permission)) {
+    if (commonUtilsService.isNotAuthorizedUser(commonUtilsService.getPrincipal(), permission)) {
       throw new KlawNotAuthorizedException(TOPICS_ERR_101);
     }
   }
 
   private String getUserName() {
     return mailService.getCurrentUserName();
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
   public EnvIdInfo validateOffsetRequestDetails(
@@ -520,7 +515,7 @@ public class OperationalRequestsService {
     log.info("deleteOperationalRequest {}", operationalRequestId);
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_CREATE_OPERATIONAL_CHANGES)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_CREATE_OPERATIONAL_CHANGES)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
     String userName = getUserName();
@@ -546,7 +541,7 @@ public class OperationalRequestsService {
       throws KlawException {
     log.debug("declineOperationalRequest {} {}", reqId, reasonForDecline);
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_OPERATIONAL_CHANGES)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_OPERATIONAL_CHANGES)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 

--- a/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RequestStatisticsService.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -118,10 +117,6 @@ public class RequestStatisticsService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/RolesPermissionsControllerService.java
@@ -13,7 +13,6 @@ import io.aiven.klaw.model.requests.KwRolesPermissionsModel;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -37,14 +36,14 @@ public class RolesPermissionsControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public List<String> getRoles() {
     int tenantId = commonUtilsService.getTenantId(getUserName());
     try {
       if (commonUtilsService.isNotAuthorizedUser(
-          getPrincipal(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES))
+          commonUtilsService.getPrincipal(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES))
         return Arrays.asList(
             manageDatabase.getKwPropertyValue("klaw.adduser.roles", tenantId).split(","));
       else {
@@ -68,7 +67,7 @@ public class RolesPermissionsControllerService {
 
     if (isExternalCall
         && commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.UPDATE_PERMISSIONS)) {
+            commonUtilsService.getPrincipal(), PermissionType.UPDATE_PERMISSIONS)) {
       return null;
     }
 
@@ -110,7 +109,8 @@ public class RolesPermissionsControllerService {
 
   public ApiResponse updatePermissions(KwRolesPermissionsModel[] permissionsSet)
       throws KlawException {
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.UPDATE_PERMISSIONS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.UPDATE_PERMISSIONS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -166,7 +166,7 @@ public class RolesPermissionsControllerService {
 
   public ApiResponse deleteRole(String roleId) throws KlawException {
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.ADD_EDIT_DELETE_ROLES)) {
+        commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_ROLES)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -191,7 +191,7 @@ public class RolesPermissionsControllerService {
 
   public ApiResponse addRoleId(String roleId) throws KlawException {
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.ADD_EDIT_DELETE_ROLES)) {
+        commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_ROLES)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -214,10 +214,6 @@ public class RolesPermissionsControllerService {
       log.error(e.getMessage());
       throw new KlawException(e.getMessage());
     }
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
   protected Set<String> getApproverRoles(String requestType, int tenantId) {

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegistryControllerService.java
@@ -45,7 +45,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -102,7 +101,8 @@ public class SchemaRegistryControllerService {
                 search,
                 isApproval
                     && !commonUtilsService.isNotAuthorizedUser(
-                        getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS),
+                        commonUtilsService.getPrincipal(),
+                        PermissionType.APPROVE_ALL_REQUESTS_TEAMS),
                 isMyRequest);
 
     // tenant filtering
@@ -205,7 +205,7 @@ public class SchemaRegistryControllerService {
     log.info("deleteSchemaRequests {}", avroSchemaId);
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_DELETE_SCHEMAS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_DELETE_SCHEMAS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
     String userName = getUserName();
@@ -231,7 +231,8 @@ public class SchemaRegistryControllerService {
     log.info("execSchemaRequests {}", avroSchemaId);
     String userDetails = getUserName();
     int tenantId = commonUtilsService.getTenantId(getUserName());
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.APPROVE_SCHEMAS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_SCHEMAS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -415,7 +416,8 @@ public class SchemaRegistryControllerService {
       throws KlawException {
     log.info("execSchemaRequestsDecline {}", avroSchemaId);
     String userDetails = getUserName();
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.APPROVE_SCHEMAS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_SCHEMAS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
     int tenantId = commonUtilsService.getTenantId(getUserName());
@@ -452,7 +454,7 @@ public class SchemaRegistryControllerService {
     String userDetails = getUserName();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_CREATE_SCHEMAS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_CREATE_SCHEMAS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -542,7 +544,7 @@ public class SchemaRegistryControllerService {
     String userName = getUserName();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.REQUEST_CREATE_SCHEMAS)) {
+        commonUtilsService.getPrincipal(), PermissionType.REQUEST_CREATE_SCHEMAS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
     schemaRequest.setRequestor(userName);
@@ -732,10 +734,6 @@ public class SchemaRegistryControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/SchemaRegistrySyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/SchemaRegistrySyncControllerService.java
@@ -42,7 +42,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -106,7 +105,8 @@ public class SchemaRegistrySyncControllerService {
       Integer teamId) {
     SyncSchemasList syncSchemasList = new SyncSchemasList();
     List<SchemaSubjectInfoResponse> schemaInfoList;
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_BACK_SCHEMAS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_BACK_SCHEMAS)) {
       return syncSchemasList;
     }
 
@@ -229,7 +229,8 @@ public class SchemaRegistrySyncControllerService {
       boolean showAllTopics)
       throws KlawException {
     SyncSchemasList syncSchemasList = new SyncSchemasList();
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_SCHEMAS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_SCHEMAS)) {
       return syncSchemasList;
     }
 
@@ -440,7 +441,8 @@ public class SchemaRegistrySyncControllerService {
   private ApiResponse updateSyncSchemasToCluster(SyncSchemaUpdates syncSchemaUpdates)
       throws KlawException {
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_BACK_SCHEMAS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_BACK_SCHEMAS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
     List<String> logArray = new ArrayList<>();
@@ -546,7 +548,8 @@ public class SchemaRegistrySyncControllerService {
   private ApiResponse updateSyncSchemasToMetadata(SyncSchemaUpdates syncSchemaUpdates)
       throws Exception {
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_SCHEMAS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_SCHEMAS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
     String userDetails = getUserName();
@@ -705,11 +708,7 @@ public class SchemaRegistrySyncControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public ApiResponse resetCacheClusterApi(SchemaResetCache schemaResetCache) throws KlawException {

--- a/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
+++ b/core/src/main/java/io/aiven/klaw/service/ServerConfigService.java
@@ -50,7 +50,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -125,7 +124,7 @@ public class ServerConfigService {
 
   public Collection<ServerConfigProperties> getAllProps() {
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.UPDATE_SERVERCONFIG)) {
+        commonUtilsService.getPrincipal(), PermissionType.UPDATE_SERVERCONFIG)) {
       return new ArrayList<>();
     }
     return key2Props.values();
@@ -136,7 +135,7 @@ public class ServerConfigService {
     KwPropertiesResponse propertiesResponse = new KwPropertiesResponse();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.UPDATE_SERVERCONFIG)) {
+        commonUtilsService.getPrincipal(), PermissionType.UPDATE_SERVERCONFIG)) {
       propertiesResponse.setResult(ApiResultStatus.NOT_AUTHORIZED.value);
       listMap.add(propertiesResponse);
       return listMap;
@@ -194,7 +193,7 @@ public class ServerConfigService {
     String kwVal = kwPropertiesModel.getKwValue().trim();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.UPDATE_SERVERCONFIG)) {
+        commonUtilsService.getPrincipal(), PermissionType.UPDATE_SERVERCONFIG)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -552,10 +551,6 @@ public class ServerConfigService {
     return connectivityStatus;
   }
 
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-  }
-
   private Integer getTenantIdFromName(String tenantName) {
     return manageDatabase.getTenantMap().entrySet().stream()
         .filter(obj -> Objects.equals(obj.getValue(), tenantName))
@@ -565,6 +560,6 @@ public class ServerConfigService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicControllerService.java
@@ -82,7 +82,6 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -525,7 +524,7 @@ public class TopicControllerService {
     int tenantId = commonUtilsService.getTenantId(userName);
     // get requests relevant to your teams or all teams
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_ALL_REQUESTS_TEAMS)) {
       createdTopicReqList =
           manageDatabase
               .getHandleDbRequests()
@@ -717,10 +716,10 @@ public class TopicControllerService {
     if (topicRequest.getRequestOperationType().equals(RequestOperationType.CREATE.value)
         && Boolean.parseBoolean(isOptionalExtraPermissionForPromote)
         && commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.APPROVE_TOPICS_CREATE)) {
+            commonUtilsService.getPrincipal(), PermissionType.APPROVE_TOPICS_CREATE)) {
       return ApiResponse.notOk(ApiResultStatus.NOT_AUTHORIZED.value + ". " + TOPICS_ERR_116);
     } else if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.APPROVE_TOPICS)) {
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_TOPICS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -882,7 +881,8 @@ public class TopicControllerService {
   public ApiResponse declineTopicRequests(String topicId, String reasonForDecline)
       throws KlawException {
     log.info("declineTopicRequests {} {}", topicId, reasonForDecline);
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.APPROVE_TOPICS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.APPROVE_TOPICS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1301,11 +1301,7 @@ public class TopicControllerService {
   }
 
   public String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  public Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public Env getEnvDetails(String envId) {

--- a/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/TopicSyncControllerService.java
@@ -68,7 +68,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @EnableScheduling
@@ -287,7 +286,8 @@ public class TopicSyncControllerService {
     log.info("getSyncTopics {} {} {}", env, pageNo, topicNameSearch);
 
     if (!"-1".equals(pageNo)) { // ignore check for scheduler
-      if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_TOPICS)) {
+      if (commonUtilsService.isNotAuthorizedUser(
+          commonUtilsService.getPrincipal(), PermissionType.SYNC_TOPICS)) {
         return null;
       }
     }
@@ -586,7 +586,7 @@ public class TopicSyncControllerService {
   private List<String> tenantFilterTeams(Integer tenantId, boolean scheduledThread) {
     if (!scheduledThread
         && (!commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(),
+            commonUtilsService.getPrincipal(),
             Set.of(
                 PermissionType.SYNC_BACK_SUBSCRIPTIONS,
                 PermissionType.SYNC_TOPICS,
@@ -619,7 +619,8 @@ public class TopicSyncControllerService {
         "Target Environment " + getEnvDetails(syncBackTopics.getTargetEnv(), tenantId).getName());
     logArray.add("Type of Sync " + syncBackTopics.getTypeOfSync());
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_BACK_TOPICS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_BACK_TOPICS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -914,7 +915,8 @@ public class TopicSyncControllerService {
     logArray.add("Assigned to Team " + syncTopicsBulk.getSelectedTeam());
     logArray.add("Type of Sync " + syncTopicsBulk.getTypeOfSync());
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_TOPICS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_TOPICS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1055,7 +1057,8 @@ public class TopicSyncControllerService {
     log.info("updateSyncTopics {}", updatedSyncTopics);
     String userDetails = getUserName();
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.SYNC_TOPICS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.SYNC_TOPICS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1244,11 +1247,7 @@ public class TopicSyncControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public Env getEnvDetails(String envId, Integer tenantId) {

--- a/core/src/main/java/io/aiven/klaw/service/UiConfigControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UiConfigControllerService.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -45,7 +44,7 @@ public class UiConfigControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   public List<ActivityLogModel> showActivityLog(
@@ -55,7 +54,8 @@ public class UiConfigControllerService {
     List<ActivityLog> origActivityList;
     int tenantId = commonUtilsService.getTenantId(getUserName());
 
-    if (commonUtilsService.isNotAuthorizedUser(getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
+    if (commonUtilsService.isNotAuthorizedUser(
+        commonUtilsService.getPrincipal(), PermissionType.ALL_TEAMS_REPORTS)) {
       origActivityList =
           manageDatabase
               .getHandleDbRequests()
@@ -123,9 +123,5 @@ public class UiConfigControllerService {
 
   public List<String> getRequestTypeStatuses() {
     return manageDatabase.getRequestStatusList();
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 }

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -57,7 +57,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jasypt.util.text.BasicTextEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -425,7 +424,7 @@ public class UsersTeamsControllerService {
     String userName = getUserName();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {
+        commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -469,7 +468,7 @@ public class UsersTeamsControllerService {
     int tenantId = commonUtilsService.getTenantId(getUserName());
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
+        commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -484,7 +483,7 @@ public class UsersTeamsControllerService {
       // user to be deleted has superuser permissions.
       // check if you (logged in user who is deleting) have superuser permissions to delete user
       if (commonUtilsService.isNotAuthorizedUser(
-          getPrincipal(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES)) {
+          commonUtilsService.getPrincipal(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES)) {
         return ApiResponse.notOk(TEAMS_ERR_106);
       }
     }
@@ -574,7 +573,7 @@ public class UsersTeamsControllerService {
 
     if (isExternal
         && commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
+            commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -662,7 +661,7 @@ public class UsersTeamsControllerService {
 
     if (isExternal
         && commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {
+            commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -707,7 +706,7 @@ public class UsersTeamsControllerService {
     log.info("updateTeam {}", updatedTeam);
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {
+        commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_TEAMS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -836,7 +835,7 @@ public class UsersTeamsControllerService {
   }
 
   private String getUserName() {
-    return mailService.getUserName(getPrincipal());
+    return mailService.getUserName(commonUtilsService.getPrincipal());
   }
 
   Map<String, String> addTwoDefaultTeams(
@@ -977,7 +976,7 @@ public class UsersTeamsControllerService {
   public List<RegisterUserInfoModelResponse> getNewUserRequests()
       throws KlawNotAuthorizedException {
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
+        commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
       throw new KlawNotAuthorizedException("You are not authorized to view this information.");
     }
     int tenantId = commonUtilsService.getTenantId(getUserName());
@@ -1008,7 +1007,7 @@ public class UsersTeamsControllerService {
 
     if (isExternal
         && commonUtilsService.isNotAuthorizedUser(
-            getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
+            commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1050,7 +1049,7 @@ public class UsersTeamsControllerService {
     String userDetails = getUserName();
 
     if (commonUtilsService.isNotAuthorizedUser(
-        getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
+        commonUtilsService.getPrincipal(), PermissionType.ADD_EDIT_DELETE_USERS)) {
       return ApiResponse.NOT_AUTHORIZED;
     }
 
@@ -1084,10 +1083,6 @@ public class UsersTeamsControllerService {
             .filter(env -> Objects.equals(env.getId(), envId))
             .findFirst();
     return envFound.orElse(null);
-  }
-
-  private Object getPrincipal() {
-    return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
   private boolean userNamePatternValidation(String userName) {

--- a/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
@@ -78,7 +78,7 @@ public class AclSyncControllerServiceTest {
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
     when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
     when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
+        .thenReturn(true);
   }
 
   @Test
@@ -177,6 +177,8 @@ public class AclSyncControllerServiceTest {
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
+            .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "1", topicNameSearch, "");
@@ -207,6 +209,8 @@ public class AclSyncControllerServiceTest {
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
+            .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "1", topicNameSearch, "");
@@ -253,6 +257,8 @@ public class AclSyncControllerServiceTest {
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
+            .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "1", topicNameSearch, "");
@@ -281,6 +287,8 @@ public class AclSyncControllerServiceTest {
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
+            .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "", topicNameSearch, "");

--- a/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
@@ -42,12 +42,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -80,15 +76,9 @@ public class AclSyncControllerServiceTest {
     ReflectionTestUtils.setField(
         aclSyncControllerService, "commonUtilsService", commonUtilsService);
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
-  }
-
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(false);
   }
 
   @Test
@@ -96,7 +86,7 @@ public class AclSyncControllerServiceTest {
   public void updateSyncAcls() throws KlawException {
     stubUserInfo();
     when(handleDbRequests.addToSyncacls(anyList())).thenReturn(ApiResultStatus.SUCCESS.value);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
         .thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
@@ -110,7 +100,7 @@ public class AclSyncControllerServiceTest {
   @Order(2)
   public void updateSyncAclsFailure1() throws KlawException {
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
         .thenReturn(false);
 
     ApiResponse resultResp =
@@ -122,7 +112,7 @@ public class AclSyncControllerServiceTest {
   @Order(3)
   public void updateSyncAclsFailure2() {
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
         .thenReturn(false);
     when(handleDbRequests.addToSyncacls(anyList())).thenThrow(new RuntimeException("Error"));
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
@@ -140,7 +130,7 @@ public class AclSyncControllerServiceTest {
   public void updateSyncAclsFailure3() throws KlawException {
     List<SyncAclUpdates> updates = new ArrayList<>();
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
         .thenReturn(false);
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -153,7 +143,7 @@ public class AclSyncControllerServiceTest {
   public void updateSyncAclsFailure4() {
     when(handleDbRequests.addToSyncacls(anyList())).thenThrow(new RuntimeException("Error"));
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
         .thenReturn(false);
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -324,7 +314,8 @@ public class AclSyncControllerServiceTest {
         .thenReturn(clustersHashMap);
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getKafkaFlavor()).thenReturn(KafkaFlavors.AIVEN_FOR_APACHE_KAFKA.value);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.SYNC_BACK_SUBSCRIPTIONS))
         .thenReturn(false);
     when(handleDbRequests.getSyncAclsFromReqNo(anyInt(), anyInt()))
         .thenReturn(getAclsSOT0().get(0));
@@ -407,6 +398,6 @@ public class AclSyncControllerServiceTest {
   private void stubUserInfo() {
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(userInfo.getTeamId()).thenReturn(101);
-    when(mailService.getUserName(any())).thenReturn("kwusera");
+    when(mailService.getUserName(userDetails)).thenReturn("kwusera");
   }
 }

--- a/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AclSyncControllerServiceTest.java
@@ -77,8 +77,7 @@ public class AclSyncControllerServiceTest {
         aclSyncControllerService, "commonUtilsService", commonUtilsService);
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
     when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(true);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
   }
 
   @Test
@@ -178,7 +177,7 @@ public class AclSyncControllerServiceTest {
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
     when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
-            .thenReturn(false);
+        .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "1", topicNameSearch, "");
@@ -210,7 +209,7 @@ public class AclSyncControllerServiceTest {
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
     when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
-            .thenReturn(false);
+        .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "1", topicNameSearch, "");
@@ -258,7 +257,7 @@ public class AclSyncControllerServiceTest {
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
     when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
-            .thenReturn(false);
+        .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "1", topicNameSearch, "");
@@ -288,7 +287,7 @@ public class AclSyncControllerServiceTest {
     when(clustersHashMap.get(any())).thenReturn(kwClusters);
     when(kwClusters.getBootstrapServers()).thenReturn("clusters");
     when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SUBSCRIPTIONS))
-            .thenReturn(false);
+        .thenReturn(false);
 
     List<AclInfo> aclList =
         aclSyncControllerService.getSyncAcls(envSelected, pageNo, "", topicNameSearch, "");

--- a/core/src/test/java/io/aiven/klaw/service/AnalyticsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/AnalyticsControllerServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 import io.aiven.klaw.UtilMethods;
 import io.aiven.klaw.config.ManageDatabase;
@@ -30,19 +29,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
 class AnalyticsControllerServiceTest {
   public static final int NUMBER_OF_DAYS = 30;
   @Mock private ManageDatabase manageDatabase;
@@ -52,12 +49,11 @@ class AnalyticsControllerServiceTest {
   @Mock private HandleDbRequestsJdbc handleDbRequestsJdbc;
   @Mock private UserDetails userDetails;
 
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
+  @BeforeEach
+  public void setUp() {
+    Mockito.when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
+    Mockito.when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+        .thenReturn(true);
   }
 
   @Test
@@ -460,13 +456,9 @@ class AnalyticsControllerServiceTest {
     teamOverview.setTopicsPerTeamsOverview(chartsJsOverview);
     List<TeamOverview> expected = List.of(teamOverview);
 
-    loginMock();
     Mockito.when(commonUtilsService.getCurrentUserName()).thenReturn(TestConstants.USERNAME);
     Mockito.when(commonUtilsService.getTeamId(TestConstants.USERNAME))
         .thenReturn(TestConstants.TEAM_ID);
-    Mockito.when(
-            commonUtilsService.isNotAuthorizedUser(any(), eq(PermissionType.ALL_TEAMS_REPORTS)))
-        .thenReturn(true);
     Mockito.when(commonUtilsService.getTenantId(TestConstants.USERNAME))
         .thenReturn(TestConstants.TENANT_ID);
     Mockito.doReturn(chartsJsOverview)
@@ -509,12 +501,11 @@ class AnalyticsControllerServiceTest {
     teamOverview.setTopicsPerTeamsOverview(chartsJsOverview);
     List<TeamOverview> expected = List.of(teamOverview);
 
-    loginMock();
     Mockito.when(commonUtilsService.getCurrentUserName()).thenReturn(TestConstants.USERNAME);
     Mockito.when(commonUtilsService.getTeamId(TestConstants.USERNAME))
         .thenReturn(TestConstants.TEAM_ID);
     Mockito.when(
-            commonUtilsService.isNotAuthorizedUser(any(), eq(PermissionType.ALL_TEAMS_REPORTS)))
+            commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.ALL_TEAMS_REPORTS))
         .thenReturn(false);
     Mockito.when(commonUtilsService.getTenantId(TestConstants.USERNAME))
         .thenReturn(TestConstants.TENANT_ID);
@@ -577,7 +568,6 @@ class AnalyticsControllerServiceTest {
     Topic topic = UtilMethods.getDummyTopic();
     Acl acl = UtilMethods.getDummyAcl();
 
-    loginMock();
     Mockito.when(commonUtilsService.getCurrentUserName()).thenReturn(TestConstants.USERNAME);
     Mockito.when(commonUtilsService.getTenantId(TestConstants.USERNAME))
         .thenReturn(TestConstants.TENANT_ID);
@@ -593,9 +583,6 @@ class AnalyticsControllerServiceTest {
     Mockito.doReturn(TestConstants.ENV_NAME)
         .when(analyticsControllerService)
         .getEnvName(TestConstants.ENV_ID);
-    Mockito.when(
-            commonUtilsService.isNotAuthorizedUser(any(), eq(PermissionType.ALL_TEAMS_REPORTS)))
-        .thenReturn(true);
     Mockito.when(commonUtilsService.getTeamId(TestConstants.USERNAME))
         .thenReturn(TestConstants.TEAM_ID);
     Mockito.when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequestsJdbc);
@@ -620,7 +607,6 @@ class AnalyticsControllerServiceTest {
     Topic topic = UtilMethods.getDummyTopic();
     Acl acl = UtilMethods.getDummyAcl();
 
-    loginMock();
     Mockito.when(commonUtilsService.getCurrentUserName()).thenReturn(TestConstants.USERNAME);
     Mockito.when(commonUtilsService.getTenantId(TestConstants.USERNAME))
         .thenReturn(TestConstants.TENANT_ID);
@@ -637,7 +623,7 @@ class AnalyticsControllerServiceTest {
         .when(analyticsControllerService)
         .getEnvName(TestConstants.ENV_ID);
     Mockito.when(
-            commonUtilsService.isNotAuthorizedUser(any(), eq(PermissionType.ALL_TEAMS_REPORTS)))
+            commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.ALL_TEAMS_REPORTS))
         .thenReturn(false);
     Mockito.when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequestsJdbc);
     Mockito.when(handleDbRequestsJdbc.getAllTopics(TestConstants.TENANT_ID))

--- a/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/KafkaConnectControllerServiceTest.java
@@ -51,10 +51,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -109,15 +105,8 @@ public class KafkaConnectControllerServiceTest {
         rolesPermissionsControllerService);
 
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
-  }
-
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
   }
 
   @Test
@@ -127,7 +116,8 @@ public class KafkaConnectControllerServiceTest {
     resultMap.put("result", ApiResultStatus.SUCCESS.value);
 
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_CONNECTORS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(TENANT_ID);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
@@ -155,7 +145,8 @@ public class KafkaConnectControllerServiceTest {
     KafkaConnectorRequestModel kafkaConnectorRequestModel = getConnectRequestModel();
     kafkaConnectorRequestModel.setConnectorConfig("plain string"); // Invalid json
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_CONNECTORS))
         .thenReturn(false);
     when(handleDbRequests.requestForConnector(any()))
         .thenThrow(new RuntimeException("Unrecognized token"));
@@ -173,7 +164,8 @@ public class KafkaConnectControllerServiceTest {
     KafkaConnectorRequestModel kafkaConnectorRequestModel = getConnectRequestModel();
     kafkaConnectorRequestModel.setConnectorConfig(getInvalidValidConnConfig());
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_CONNECTORS))
         .thenReturn(false);
 
     ApiResponse apiResponse =
@@ -189,7 +181,8 @@ public class KafkaConnectControllerServiceTest {
     KafkaConnectorRequestModel kafkaConnectorRequestModel = getConnectRequestModel();
     kafkaConnectorRequestModel.setConnectorConfig(getInvalidValidConnConfigTopicsTopicsRegex());
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_CONNECTORS))
         .thenReturn(false);
 
     ApiResponse apiResponse =
@@ -204,8 +197,6 @@ public class KafkaConnectControllerServiceTest {
     Set<String> envListIds = new HashSet<>();
     envListIds.add("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
     when(handleDbRequests.getConnectorsFromName(eq("ConnectorOne"), eq(TENANT_ID)))
         .thenReturn(List.of(getKwKafkaConnector()));
@@ -227,8 +218,6 @@ public class KafkaConnectControllerServiceTest {
     Set<String> envListIds = new HashSet<>();
     envListIds.add("DEV");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
     when(handleDbRequests.existsConnectorRequest(
             "ConnectorOne", "1", RequestStatus.CREATED.value, TENANT_ID))
@@ -247,8 +236,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -291,8 +278,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -335,8 +320,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -380,8 +363,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
 
     when(handleDbRequests.getAllConnectorRequests(
             anyString(),
@@ -425,8 +406,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     List<KafkaConnectorRequest> connectorRequests = generateKafkaConnectorRequests(9);
     connectorRequests.addAll(generateKafkaConnectorRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllConnectorRequests(
@@ -473,8 +452,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     List<KafkaConnectorRequest> connectorRequests = generateKafkaConnectorRequests(9);
     connectorRequests.addAll(generateKafkaConnectorRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllConnectorRequests(
@@ -524,8 +501,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -542,8 +517,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -588,8 +561,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -621,8 +592,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(3));
@@ -655,8 +624,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -690,8 +657,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -775,8 +740,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -810,8 +773,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -855,8 +816,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -897,8 +856,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -923,8 +880,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -954,8 +909,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -1005,8 +958,6 @@ public class KafkaConnectControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(TENANT_ID);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTeamId(eq(USERNAME))).thenReturn(8);
     when(handleDbRequests.getConnectors(eq(CONNECTOR_NAME), eq(TENANT_ID)))
         .thenReturn(generateKafkaConnectors(2));
@@ -1158,7 +1109,7 @@ public class KafkaConnectControllerServiceTest {
   private void stubUserInfo() {
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(userInfo.getTeamId()).thenReturn(TENANT_ID);
-    when(mailService.getUserName(any())).thenReturn(USERNAME);
+    when(mailService.getUserName(userDetails)).thenReturn(USERNAME);
     Env e = new Env();
     e.setId("1");
     e.setName("DEV");

--- a/core/src/test/java/io/aiven/klaw/service/OperationalRequestsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/OperationalRequestsServiceTest.java
@@ -41,10 +41,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -94,15 +90,8 @@ public class OperationalRequestsServiceTest {
     env.setName("DEV");
 
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
-  }
-
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
   }
 
   @Test
@@ -110,7 +99,8 @@ public class OperationalRequestsServiceTest {
   public void createConsumerOffsetsResetRequestDoesNotOwnGroup() throws KlawNotAuthorizedException {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_SUBSCRIPTIONS))
         .thenReturn(false);
 
     ApiResponse apiResponse =
@@ -125,7 +115,8 @@ public class OperationalRequestsServiceTest {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
     consumerOffsetResetRequestModel.setOffsetResetType(OffsetResetType.TO_DATE_TIME);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_SUBSCRIPTIONS))
         .thenReturn(false);
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt(), anyString(), anyInt()))
         .thenReturn(utilMethods.getAcls());
@@ -141,7 +132,8 @@ public class OperationalRequestsServiceTest {
   public void createRequestWhichAlreadyExists() throws KlawNotAuthorizedException {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_SUBSCRIPTIONS))
         .thenReturn(false);
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt(), anyString(), anyInt()))
         .thenReturn(utilMethods.getAcls());
@@ -169,7 +161,8 @@ public class OperationalRequestsServiceTest {
   public void createRequestSuccess() throws KlawNotAuthorizedException {
     ConsumerOffsetResetRequestModel consumerOffsetResetRequestModel =
         utilMethods.getConsumerOffsetResetRequest(1001);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.REQUEST_CREATE_SUBSCRIPTIONS))
         .thenReturn(false);
     when(handleDbRequests.getSyncAcls(anyString(), anyString(), anyInt(), anyString(), anyInt()))
         .thenReturn(utilMethods.getAcls());
@@ -203,7 +196,8 @@ public class OperationalRequestsServiceTest {
         UtilMethods.getOffsetsTimingMapMap();
     ApiResponse apiResponse =
         ApiResponse.builder().success(true).data(offsetPositionsBeforeAndAfter).build();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.APPROVE_OPERATIONAL_CHANGES))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getCurrentUserName()).thenReturn("testuser");
@@ -220,7 +214,8 @@ public class OperationalRequestsServiceTest {
   @Order(6)
   public void approveOperationalRequestsFailure() throws KlawException {
     ApiResponse apiResponse = ApiResponse.builder().success(false).build();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails, PermissionType.APPROVE_OPERATIONAL_CHANGES))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(mailService.getCurrentUserName()).thenReturn("testuser");

--- a/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/RequestStatisticsServiceTest.java
@@ -1,7 +1,6 @@
 package io.aiven.klaw.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -24,10 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -56,7 +51,7 @@ public class RequestStatisticsServiceTest {
         requestStatisticsService, "commonUtilsService", commonUtilsService);
     ReflectionTestUtils.setField(requestStatisticsService, "mailService", mailService);
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
   }
 
   @Test
@@ -124,18 +119,10 @@ public class RequestStatisticsServiceTest {
         .hasSize(2);
   }
 
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
-  }
-
   private void stubUserInfo() {
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(userInfo.getTeamId()).thenReturn(101);
-    when(mailService.getUserName(any())).thenReturn("kwusera");
+    when(mailService.getUserName(userDetails)).thenReturn("kwusera");
     when(mailService.getCurrentUserName()).thenReturn("kwusera");
   }
 }

--- a/core/src/test/java/io/aiven/klaw/service/SchemaRegistrySyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/SchemaRegistrySyncControllerServiceTest.java
@@ -51,12 +51,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -98,15 +94,8 @@ public class SchemaRegistrySyncControllerServiceTest {
         schemaRegistrySyncControllerService, "commonUtilsService", commonUtilsService);
 
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
-  }
-
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
   }
 
   @Test
@@ -124,7 +113,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
@@ -159,7 +148,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
@@ -220,7 +209,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     List<Topic> topics = utilMethods.generateTopics(14);
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
@@ -252,7 +241,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     List<Topic> topics = utilMethods.generateTopics(14);
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
@@ -287,7 +276,7 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
 
@@ -330,7 +319,7 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_SCHEMAS))
         .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
 
@@ -388,7 +377,7 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
     when(clusterApiService.getAvroSchema(anyString(), any(), anyString(), anyString(), anyInt()))
@@ -416,7 +405,7 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_SCHEMAS))
         .thenReturn(false);
     MessageSchema schema = utilMethods.getMSchemas().get(0);
     schema.setTopicname(topicName);
@@ -453,7 +442,7 @@ public class SchemaRegistrySyncControllerServiceTest {
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);
 
@@ -492,7 +481,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
@@ -537,7 +526,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     kwClustersMap.put(1, utilMethods.getKwClusters());
 
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(3))).thenReturn("Team1");
@@ -589,7 +578,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     clusterResp.setSchemaInfoOfTopicList(new ArrayList<>());
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(3))).thenReturn("Team1");
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
@@ -642,7 +631,7 @@ public class SchemaRegistrySyncControllerServiceTest {
     SchemasInfoOfClusterResponse clusterResp = new SchemasInfoOfClusterResponse();
     clusterResp.setSchemaInfoOfTopicList(new ArrayList<>());
     when(handleDbRequests.getEnvDetails(anyString(), anyInt())).thenReturn(env);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_SCHEMAS))
         .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(manageDatabase.getClusters(any(), anyInt())).thenReturn(kwClustersMap);

--- a/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/ServerConfigServiceTest.java
@@ -38,12 +38,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.env.Environment;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -70,15 +66,15 @@ public class ServerConfigServiceTest {
   public void setUp() {
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
     this.env = context.getEnvironment();
-    loginMock();
 
     serverConfigService = new ServerConfigService(env, commonUtilsService, mailService, managedb);
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
   }
 
   @Test
   @Order(1)
   public void getAllPropsNotAuthorized() {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
     serverConfigService.getAllProperties();
     Collection<ServerConfigProperties> collection = serverConfigService.getAllProps();
     assertThat(collection).isEmpty(); // filtering for spring. and klaw.
@@ -87,19 +83,11 @@ public class ServerConfigServiceTest {
   @Test
   @Order(2)
   public void getAllProps() {
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
         .thenReturn(false);
     serverConfigService.getAllProperties();
     Collection<ServerConfigProperties> collection = serverConfigService.getAllProps();
     assertThat(collection).isEmpty(); // filtering for spring. and klaw.
-  }
-
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
   }
 
   @Test
@@ -129,6 +117,9 @@ public class ServerConfigServiceTest {
     config.setTenantModel(prop);
     KwPropertiesModel request =
         createKwPropertiesModel(KLAW_TENANT_CONFIG, mapper.writeValueAsString(config));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
+
     // Execute
     ApiResponse response = serverConfigService.updateKwCustomProperty(request);
 
@@ -167,6 +158,9 @@ public class ServerConfigServiceTest {
     config.setTenantModel(prop);
     KwPropertiesModel request =
         createKwPropertiesModel(KLAW_TENANT_CONFIG, mapper.writeValueAsString(config));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
+
     // Execute
     ApiResponse response = serverConfigService.updateKwCustomProperty(request);
 
@@ -212,6 +206,9 @@ public class ServerConfigServiceTest {
     config.setTenantModel(prop);
     KwPropertiesModel request =
         createKwPropertiesModel(KLAW_TENANT_CONFIG, mapper.writeValueAsString(config));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
+
     // Execute
     ApiResponse response = serverConfigService.updateKwCustomProperty(request);
 
@@ -246,6 +243,9 @@ public class ServerConfigServiceTest {
     config.setTenantModel(prop);
     KwPropertiesModel request =
         createKwPropertiesModel(KLAW_TENANT_CONFIG, mapper.writeValueAsString(config));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
+
     // Execute
     ApiResponse response = serverConfigService.updateKwCustomProperty(request);
 
@@ -261,6 +261,9 @@ public class ServerConfigServiceTest {
   public void givenInvalidJson_returnFailure() throws KlawException {
     stubValidateTests();
     KwPropertiesModel request = createKwPropertiesModel(KLAW_TENANT_CONFIG, "{}");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
+
     // Execute
     ApiResponse response = serverConfigService.updateKwCustomProperty(request);
 
@@ -289,6 +292,9 @@ public class ServerConfigServiceTest {
     config.setTenantModel(prop);
     KwPropertiesModel request =
         createKwPropertiesModel(KLAW_TENANT_CONFIG, mapper.writeValueAsString(config));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
+
     // Execute
     ApiResponse response = serverConfigService.updateKwCustomProperty(request);
 
@@ -304,6 +310,8 @@ public class ServerConfigServiceTest {
     stubValidateTests();
 
     when(managedb.getKwPropertiesMap(101)).thenReturn(buildFullDbObject());
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
 
     // Execute
     List<KwPropertiesResponse> response = serverConfigService.getAllEditableProps();
@@ -350,6 +358,8 @@ public class ServerConfigServiceTest {
     dbObject.put(KLAW_TENANT_CONFIG, map);
 
     when(managedb.getKwPropertiesMap(101)).thenReturn(dbObject);
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
 
     // Execute
     List<KwPropertiesResponse> response = serverConfigService.getAllEditableProps();
@@ -373,6 +383,9 @@ public class ServerConfigServiceTest {
     config.setTenantModel(prop);
     KwPropertiesModel request =
         createKwPropertiesModel(KLAW_TENANT_CONFIG, mapper.writeValueAsString(config));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.UPDATE_SERVERCONFIG))
+        .thenReturn(false);
+
     // Execute
     ApiResponse response = serverConfigService.updateKwCustomProperty(request);
 

--- a/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicControllerServiceTest.java
@@ -61,13 +61,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -122,15 +118,8 @@ public class TopicControllerServiceTest {
         rolesPermissionsControllerService);
 
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
-  }
-
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
   }
 
   @Test
@@ -144,8 +133,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -167,8 +154,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -192,8 +177,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -213,8 +196,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvListsIncorrect1());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -236,8 +217,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvListsIncorrect1());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -262,8 +241,6 @@ public class TopicControllerServiceTest {
   public void createTopicDeleteRequestFailureTopicAlreadyExists() {
     String topicName = "testtopic1";
     String envId = "1";
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(getListTopicRequests());
@@ -285,8 +262,6 @@ public class TopicControllerServiceTest {
     String topicName = "testtopic1";
     String envId = "1";
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -312,8 +287,6 @@ public class TopicControllerServiceTest {
     String envId = "1";
     stubUserInfo();
     when(commonUtilsService.getTeamId(anyString())).thenReturn(1);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -339,8 +312,6 @@ public class TopicControllerServiceTest {
     String envId = "2";
     stubUserInfo();
     when(userInfo.getTeamId()).thenReturn(1);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -366,8 +337,6 @@ public class TopicControllerServiceTest {
     String envId = "1";
     stubUserInfo();
     when(commonUtilsService.getTeamId(anyString())).thenReturn(1);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
     when(handleDbRequests.getTopicRequests(anyString(), anyString(), anyString(), anyInt()))
         .thenReturn(Collections.emptyList());
@@ -666,8 +635,6 @@ public class TopicControllerServiceTest {
     when(handleDbRequests.deleteTopicRequest(anyInt(), anyString(), anyInt()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
     when(mailService.getUserName(any())).thenReturn("uiuser1");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     ApiResponse resultResp = topicControllerService.deleteTopicRequests("1001");
     assertThat(resultResp.getMessage()).isEqualTo(ApiResultStatus.SUCCESS.value);
   }
@@ -681,6 +648,8 @@ public class TopicControllerServiceTest {
     ApiResponse apiResponse = ApiResponse.SUCCESS;
 
     stubUserInfo();
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
+        .thenReturn(false);
     when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(
@@ -718,6 +687,8 @@ public class TopicControllerServiceTest {
             CRUDResponse.<Topic>builder().resultStatus(ApiResultStatus.SUCCESS.value).build());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
+        .thenReturn(false);
     when(clusterApiService.approveTopicRequests(
             anyString(),
             anyString(),
@@ -756,6 +727,8 @@ public class TopicControllerServiceTest {
             CRUDResponse.<Topic>builder().resultStatus(ApiResultStatus.SUCCESS.value).build());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
+        .thenReturn(false);
     when(clusterApiService.approveTopicRequests(
             anyString(),
             anyString(),
@@ -788,6 +761,8 @@ public class TopicControllerServiceTest {
     when(handleDbRequests.updateTopicRequest(any(), anyString()))
         .thenReturn(
             CRUDResponse.<Topic>builder().resultStatus(ApiResultStatus.SUCCESS.value).build());
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
+        .thenReturn(false);
     when(clusterApiService.approveTopicRequests(
             anyString(),
             anyString(),
@@ -815,6 +790,8 @@ public class TopicControllerServiceTest {
 
     stubUserInfo();
     when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
+        .thenReturn(false);
 
     ApiResponse apiResponse1 = topicControllerService.approveTopicRequests("" + topicId);
     assertThat(apiResponse1.getMessage())
@@ -1050,7 +1027,7 @@ public class TopicControllerServiceTest {
 
     stubUserInfo();
     when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
         .thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
@@ -1071,7 +1048,7 @@ public class TopicControllerServiceTest {
 
     stubUserInfo();
     when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
         .thenReturn(false);
     when(handleDbRequests.declineTopicRequest(any(), anyString()))
         .thenReturn(ApiResultStatus.SUCCESS.value);
@@ -1136,8 +1113,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1159,8 +1134,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1184,8 +1157,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1205,8 +1176,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvListsIncorrect1());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1327,8 +1296,6 @@ public class TopicControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     List<TopicRequest> topicRequests = generateRequests(9);
     topicRequests.addAll(generateRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllTopicRequests(
@@ -1375,8 +1342,6 @@ public class TopicControllerServiceTest {
     envListIds.add("DEV");
     stubUserInfo();
     when(commonUtilsService.getTenantId(any())).thenReturn(101);
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     List<TopicRequest> topicRequests = generateRequests(9);
     topicRequests.addAll(generateRequests(1, 7, RequestOperationType.CLAIM));
     when(handleDbRequests.getAllTopicRequests(
@@ -1440,6 +1405,8 @@ public class TopicControllerServiceTest {
         .thenReturn(new ResponseEntity<>(apiResponse, HttpStatus.OK));
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
+        .thenReturn(false);
     when(handleDbRequests.addToSynctopics(any()))
         .thenReturn(
             CRUDResponse.<Topic>builder().resultStatus(ApiResultStatus.SUCCESS.value).build());
@@ -1472,6 +1439,8 @@ public class TopicControllerServiceTest {
             CRUDResponse.<Topic>builder().resultStatus(ApiResultStatus.SUCCESS.value).build());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(getTopic(topicName)));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
+        .thenReturn(false);
     when(clusterApiService.approveTopicRequests(
             anyString(),
             anyString(),
@@ -1512,8 +1481,6 @@ public class TopicControllerServiceTest {
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
-        .thenReturn(false);
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(utilMethods.getEnvLists());
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -1773,10 +1740,9 @@ public class TopicControllerServiceTest {
     TopicRequest topicRequest = getTopicRequest(TOPIC_1);
     topicRequest.setRequestOperationType(RequestOperationType.CREATE.value);
 
-    when(commonUtilsService.isNotAuthorizedUser("userDetails", PermissionType.APPROVE_TOPICS))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS))
         .thenReturn(false);
-    when(commonUtilsService.isNotAuthorizedUser(
-            "userDetails", PermissionType.APPROVE_TOPICS_CREATE))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.APPROVE_TOPICS_CREATE))
         .thenReturn(true);
     when(handleDbRequests.getTopicRequestsForTopic(anyInt(), anyInt())).thenReturn(topicRequest);
     when(manageDatabase.getKwPropertyValue(KLAW_OPTIONAL_PERMISSION_NEW_TOPIC_CREATION_KEY, 0))

--- a/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/TopicSyncControllerServiceTest.java
@@ -55,12 +55,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -124,7 +120,8 @@ public class TopicSyncControllerServiceTest {
         topicSyncControllerService, "clusterApiService", clusterApiService);
 
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
+    when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
   }
 
   private void environmentSetUp() {
@@ -184,14 +181,6 @@ public class TopicSyncControllerServiceTest {
     when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
   }
 
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
-  }
-
   @Test
   @Order(1)
   public void updateSyncTopicsSuccess() throws KlawException {
@@ -199,7 +188,7 @@ public class TopicSyncControllerServiceTest {
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
         .thenReturn(false);
     when(commonUtilsService.getEnvsFromUserId(anyString()))
         .thenReturn(new HashSet<>(Collections.singletonList("1")));
@@ -221,7 +210,7 @@ public class TopicSyncControllerServiceTest {
     when(manageDatabase.getTenantConfig()).thenReturn(tenantConfig);
     when(tenantConfig.get(anyInt())).thenReturn(tenantConfigModel);
     when(tenantConfigModel.getBaseSyncEnvironment()).thenReturn("1");
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
         .thenReturn(false);
     when(manageDatabase.getTeamsAndAllowedEnvs(anyInt(), anyInt()))
         .thenReturn(Collections.singletonList("1"));
@@ -262,6 +251,8 @@ public class TopicSyncControllerServiceTest {
     when(kwClusters.getClusterName()).thenReturn("cluster");
     when(kwClusters.getClusterId()).thenReturn(1);
     when(kwClusters.getKafkaFlavor()).thenReturn("");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList topicRequests =
         topicSyncControllerService.getSyncTopics(
@@ -297,6 +288,9 @@ public class TopicSyncControllerServiceTest {
                 .resultStatus(ApiResultStatus.SUCCESS.value)
                 .entities(List.of(new Topic()))
                 .build());
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_TOPICS))
+        .thenReturn(false);
+
     // execute
     ApiResponse retval =
         topicSyncControllerService.updateSyncBackTopics(
@@ -347,6 +341,8 @@ public class TopicSyncControllerServiceTest {
                 .build());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(createTopic(1, TOPIC_NAME_1, env.getId())));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_TOPICS))
+        .thenReturn(false);
 
     // execute
     ApiResponse retval =
@@ -401,6 +397,8 @@ public class TopicSyncControllerServiceTest {
                 .build());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(createTopic(1, TOPIC_NAME_1, env.getId())));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_TOPICS))
+        .thenReturn(false);
 
     ApiResponse retval =
         topicSyncControllerService.updateSyncBackTopics(
@@ -452,6 +450,8 @@ public class TopicSyncControllerServiceTest {
                 .build());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(createTopic(1, TOPIC_NAME_1, env.getId())));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_TOPICS))
+        .thenReturn(false);
 
     ApiResponse retval =
         topicSyncControllerService.updateSyncBackTopics(
@@ -505,6 +505,8 @@ public class TopicSyncControllerServiceTest {
                 .build());
     when(commonUtilsService.getTopicsForTopicName(anyString(), anyInt()))
         .thenReturn(List.of(createTopic(1, TOPIC_NAME_1, env.getId())));
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_BACK_TOPICS))
+        .thenReturn(false);
 
     ApiResponse retval =
         topicSyncControllerService.updateSyncBackTopics(
@@ -551,6 +553,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getSyncTopics(
@@ -587,6 +591,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getReconTopics(
@@ -619,6 +625,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getSyncTopics(
@@ -656,6 +664,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getReconTopics(
@@ -692,6 +702,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getSyncTopics(
@@ -729,6 +741,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getReconTopics(
@@ -765,6 +779,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getSyncTopics(
@@ -833,6 +849,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     Integer tenantId = 101;
     SyncTopicsList syncTopics =
@@ -911,6 +929,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getReconTopics(
@@ -988,6 +1008,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getSyncTopics(
@@ -1067,6 +1089,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getSyncTopics(
@@ -1116,6 +1140,8 @@ public class TopicSyncControllerServiceTest {
     // from the DB
     when(handleDbRequests.getSyncTopics(eq("1"), eq(null), eq(101))).thenReturn(topics);
     when(manageDatabase.getTeamNameFromTeamId(eq(101), eq(10))).thenReturn("Team1");
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.SYNC_TOPICS))
+        .thenReturn(false);
 
     SyncTopicsList syncTopics =
         topicSyncControllerService.getSyncTopics(
@@ -1202,7 +1228,7 @@ public class TopicSyncControllerServiceTest {
   private void stubUserInfo() {
     when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
     when(userInfo.getTeamId()).thenReturn(101);
-    when(mailService.getUserName(any())).thenReturn(USERNAME);
+    when(mailService.getUserName(userDetails)).thenReturn(USERNAME);
     when(commonUtilsService.getTenantId(eq(USERNAME))).thenReturn(TENANT_ID);
     when(handleDbRequests.getAllTeams(eq(101))).thenReturn(getAvailableTeams());
     /// added

--- a/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UiConfigControllerServiceTest.java
@@ -25,10 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -81,15 +77,7 @@ public class UiConfigControllerServiceTest {
     ReflectionTestUtils.setField(
         envsClustersTenantsControllerService, "commonUtilsService", commonUtilsService);
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
-    loginMock();
-  }
-
-  private void loginMock() {
-    Authentication authentication = Mockito.mock(Authentication.class);
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    when(securityContext.getAuthentication()).thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(userDetails);
-    SecurityContextHolder.setContext(securityContext);
+    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
   }
 
   @Test
@@ -99,7 +87,7 @@ public class UiConfigControllerServiceTest {
     stubUserInfo();
     when(commonUtilsService.getEnvProperty(anyInt(), anyString())).thenReturn("1");
     when(manageDatabase.getKafkaEnvList(anyInt())).thenReturn(getAllEnvs());
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.ADD_EDIT_DELETE_ENVS))
         .thenReturn(false);
     when(manageDatabase.getTenantMap()).thenReturn(tenantMap);
     when(tenantMap.get(anyInt())).thenReturn("1");
@@ -117,7 +105,7 @@ public class UiConfigControllerServiceTest {
   @Order(4)
   public void getSchemaRegEnvs() {
     stubUserInfo();
-    when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class)))
+    when(commonUtilsService.isNotAuthorizedUser(userDetails, PermissionType.ADD_EDIT_DELETE_ENVS))
         .thenReturn(false);
 
     when(handleDbRequests.getAllSchemaRegEnvs(1)).thenReturn(getAllSchemaEnvs());


### PR DESCRIPTION
# Linked issue

Resolves: 6th bullet on getPrincipal refactoring in #1690

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_getPrincipal logic is duplicated in many service class._

# What is the new behavior?

_getPrincipal logic is moved to one common service class._

# Other information

_[CommonUtilsService.isNotAuthorizedUser](https://github.com/khatibtamal/klaw/blob/main/core/src/main/java/io/aiven/klaw/service/CommonUtilsService.java#L150) by default will evaluate false (ie authorized) in tests, therefore in all test classes for before each test, the authorization is configured by default to fail, this allowed for easier and accurate unit test edits as now for each test, the authorization had to be configured based on exactly the permission type needed._

# Requirements (all must be checked before review)

- [X] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [X] Tests for the changes have been added (if relevant)
- [X] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
