### PR TITLE
Upgrade kafka client to 3.8.0 and spring kafka test

### DIFF
--- a/cluster-api/pom.xml
+++ b/cluster-api/pom.xml
@@ -22,9 +22,9 @@
         <java.version>17</java.version>
         <!-- the list is sorted-->
         <apache.commons.lang.version>3.17.0</apache.commons.lang.version>
-        <kafka.version>3.7.1</kafka.version>
+        <kafka.version>3.8.0</kafka.version>
         <mockserver.version>5.15.0</mockserver.version>
-        <spring-kafka-test.version>3.2.4</spring-kafka-test.version>
+        <spring-kafka-test.version>3.3.0</spring-kafka-test.version>
     </properties>
 
     <dependencies>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6004,7 +6004,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "description", "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
+        "required" : [ "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
       },
       "KwTenantModel" : {
         "properties" : {
@@ -6658,7 +6658,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "description", "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
+        "required" : [ "environment", "replicationfactor", "requestOperationType", "topicname", "topicpartitions" ]
       },
       "TopicDeleteRequestModel" : {
         "properties" : {
@@ -6713,6 +6713,8 @@
           },
           "description" : {
             "type" : "string",
+            "maxLength" : 100,
+            "minLength" : 1,
             "pattern" : "^[a-zA-Z 0-9_.,-]{3,}$"
           },
           "teamId" : {


### PR DESCRIPTION
# Linked issue

With spring kafka test 3.3.0, we can now upgrade kafka clients to 3.8.0

Resolves: #xxxxx

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

We could not upgrade kafka client beyond 3.7.x
_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?
With spring kafka test 3.3.0, we can now upgrde kafka client

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
