### PR TITLE
Superadmin adding permissions

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -185,16 +185,8 @@ public class UsersTeamsControllerService {
 
     // Only a user with permission FULL_ACCESS_USERS_TEAMS_ROLES or UPDATE_PERMISSIONS
     // should be able to update other user who has permissions FULL_ACCESS_USERS_TEAMS_ROLES or
-    // UPDATE_PERMISSIONS or
-    // role SUPERADMIN_ROLE
-    if ((newUser.getRole().equals(SUPERADMIN_ROLE)
-            || (permissions != null
-                && (permissions.contains(PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name())
-                    || permissions.contains(PermissionType.UPDATE_PERMISSIONS.name()))))
-        && (commonUtilsService.isNotAuthorizedUser(
-                getUserName(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES)
-            && commonUtilsService.isNotAuthorizedUser(
-                getUserName(), PermissionType.UPDATE_PERMISSIONS))) {
+    // UPDATE_PERMISSIONS or role SUPERADMIN_ROLE
+    if (verifySuperAdminAccess(newUser, permissions)) {
       return ApiResponse.notOk(TEAMS_ERR_102);
     }
 
@@ -598,14 +590,7 @@ public class UsersTeamsControllerService {
             .getRolesPermissionsPerTenant(tenantId)
             .getOrDefault(newUser.getRole(), Collections.emptySet());
 
-    if ((newUser.getRole().equals(SUPERADMIN_ROLE)
-            || (permissions != null
-                && (permissions.contains(PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name())
-                    || permissions.contains(PermissionType.UPDATE_PERMISSIONS.name()))))
-        && (commonUtilsService.isNotAuthorizedUser(
-                getUserName(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES)
-            && commonUtilsService.isNotAuthorizedUser(
-                getUserName(), PermissionType.UPDATE_PERMISSIONS))) {
+    if (verifySuperAdminAccess(newUser, permissions)) {
       return ApiResponse.notOk(TEAMS_ERR_102);
     }
 
@@ -678,6 +663,20 @@ public class UsersTeamsControllerService {
         throw new KlawException(TEAMS_ERR_111);
       }
     }
+  }
+
+  // Only a user with permission FULL_ACCESS_USERS_TEAMS_ROLES or UPDATE_PERMISSIONS
+  // should be able to update other user who has permissions FULL_ACCESS_USERS_TEAMS_ROLES or
+  // UPDATE_PERMISSIONS or role SUPERADMIN_ROLE
+  private boolean verifySuperAdminAccess(UserInfoModel newUser, Set<String> permissions) {
+    return (newUser.getRole().equals(SUPERADMIN_ROLE)
+            || (permissions != null
+                && (permissions.contains(PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES.name())
+                    || permissions.contains(PermissionType.UPDATE_PERMISSIONS.name()))))
+        && (commonUtilsService.isNotAuthorizedUser(
+                getUserName(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES)
+            && commonUtilsService.isNotAuthorizedUser(
+                getUserName(), PermissionType.UPDATE_PERMISSIONS));
   }
 
   private Pair<Boolean, String> validateSwitchTeams(UserInfoModel sourceUser) {

--- a/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
@@ -192,7 +192,7 @@ public class UsersTeamsControllerServiceTest {
   }
 
   @Test
-  public void updateUserNotAuthorizedToUpdateUserWithSpecificPermissions() throws KlawException {
+  public void notAuthorizedToUpdateUserWithSpecificPermissions() throws KlawException {
     final String userName = "testUser";
     UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
     when(commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_USERS))
@@ -208,7 +208,7 @@ public class UsersTeamsControllerServiceTest {
   }
 
   @Test
-  public void updateUserNotAuthorizedToUpdateSuperAdmin() throws KlawException {
+  public void notAuthorizedToUpdateSuperAdmin() throws KlawException {
     final String userName = "testUser";
     UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
     userInfoModel.setRole(SUPERADMIN_ROLE);

--- a/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.service;
 
+import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_102;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_106;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_109;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_111;
@@ -9,6 +10,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_117;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_119;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_120;
 import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
+import static io.aiven.klaw.helpers.KwConstants.SUPERADMIN_ROLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -190,7 +192,7 @@ public class UsersTeamsControllerServiceTest {
   }
 
   @Test
-  public void updateUserNotAuthorizedToUpdateSuperAdmin() throws KlawException {
+  public void updateUserNotAuthorizedToUpdateUserWithSpecificPermissions() throws KlawException {
     final String userName = "testUser";
     UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
     when(commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_USERS))
@@ -203,6 +205,38 @@ public class UsersTeamsControllerServiceTest {
     ApiResponse apiResponse = usersTeamsControllerService.updateUser(userInfoModel);
     assertThat(apiResponse.getMessage())
         .isEqualTo("Not Authorized to update another SUPERADMIN user.");
+  }
+
+  @Test
+  public void updateUserNotAuthorizedToUpdateSuperAdmin() throws KlawException {
+    final String userName = "testUser";
+    UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
+    userInfoModel.setRole(SUPERADMIN_ROLE);
+    when(commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_USERS))
+        .thenReturn(false);
+    when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
+    when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
+    when(mailService.getUserName(userDetails)).thenReturn(userName);
+    ApiResponse apiResponse = usersTeamsControllerService.updateUser(userInfoModel);
+    assertThat(apiResponse.getMessage()).isEqualTo(TEAMS_ERR_102);
+  }
+
+  @Test
+  public void updateSuperAdminSuccessWithPermissions() throws KlawException {
+    final String userName = "testUser";
+    UserInfoModel userInfoModel = utilMethods.getUserInfoMock();
+    userInfoModel.setRole(SUPERADMIN_ROLE);
+    when(commonUtilsService.isNotAuthorizedUser(userName, PermissionType.ADD_EDIT_DELETE_USERS))
+        .thenReturn(false);
+    when(commonUtilsService.isNotAuthorizedUser(userName, PermissionType.UPDATE_PERMISSIONS))
+        .thenReturn(false);
+    when(handleDbRequests.getUsersInfo(anyString())).thenReturn(userInfo);
+    when(commonUtilsService.getTenantId(anyString())).thenReturn(101);
+    when(mailService.getUserName(userDetails)).thenReturn(userName);
+
+    when(handleDbRequests.updateUser(any())).thenReturn(ApiResultStatus.SUCCESS.value);
+    ApiResponse apiResponse = usersTeamsControllerService.updateUser(userInfoModel);
+    assertThat(apiResponse.getMessage()).isEqualTo(ApiResponse.SUCCESS.getMessage());
   }
 
   @Test
@@ -726,6 +760,49 @@ public class UsersTeamsControllerServiceTest {
     when(handleDbRequests.addNewUser(any())).thenReturn(ApiResultStatus.SUCCESS.value);
     ApiResponse apiResponse = usersTeamsControllerService.addNewUser(newUser, false);
     assertThat(apiResponse.getMessage()).isEqualTo(ApiResponse.SUCCESS.getMessage());
+  }
+
+  @Test
+  public void addNewUserSuperAdminFailure() throws KlawException {
+    UserInfoModel newUser = utilMethods.getUserInfoMock();
+    newUser.setRole(SUPERADMIN_ROLE);
+    when(handleDbRequests.addNewUser(any())).thenReturn(ApiResultStatus.SUCCESS.value);
+    ApiResponse apiResponse = usersTeamsControllerService.addNewUser(newUser, false);
+    assertThat(apiResponse.getMessage()).isEqualTo(TEAMS_ERR_102);
+  }
+
+  @Test
+  public void addNewUserSuperAdminSuccess() throws KlawException {
+    UserInfoModel newUser = utilMethods.getUserInfoMock();
+    newUser.setRole(SUPERADMIN_ROLE);
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails.getUsername(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES))
+        .thenReturn(false);
+    when(handleDbRequests.addNewUser(any())).thenReturn(ApiResultStatus.SUCCESS.value);
+    ApiResponse apiResponse = usersTeamsControllerService.addNewUser(newUser, false);
+    assertThat(apiResponse.getMessage()).isEqualTo(ApiResultStatus.SUCCESS.value);
+  }
+
+  @Test
+  public void addNewUserWithPermissionsFailure() throws KlawException {
+    UserInfoModel newUser = utilMethods.getUserInfoMock();
+    when(manageDatabase.getRolesPermissionsPerTenant(anyInt()))
+        .thenReturn(utilMethods.getRolesPermsMapForSuperuser());
+    ApiResponse apiResponse = usersTeamsControllerService.addNewUser(newUser, false);
+    assertThat(apiResponse.getMessage()).isEqualTo(TEAMS_ERR_102);
+  }
+
+  @Test
+  public void addNewUserWithPermissionsSuccess() throws KlawException {
+    UserInfoModel newUser = utilMethods.getUserInfoMock();
+    when(handleDbRequests.addNewUser(any())).thenReturn(ApiResultStatus.SUCCESS.value);
+    when(commonUtilsService.isNotAuthorizedUser(
+            userDetails.getUsername(), PermissionType.FULL_ACCESS_USERS_TEAMS_ROLES))
+        .thenReturn(false);
+    when(manageDatabase.getRolesPermissionsPerTenant(anyInt()))
+        .thenReturn(utilMethods.getRolesPermsMapForSuperuser());
+    ApiResponse apiResponse = usersTeamsControllerService.addNewUser(newUser, false);
+    assertThat(apiResponse.getMessage()).isEqualTo(ApiResultStatus.SUCCESS.value);
   }
 
   @Test
@@ -1465,7 +1542,11 @@ public class UsersTeamsControllerServiceTest {
             testNewRegUser.getUsername(), isExternal, Integer.MIN_VALUE, null);
 
     assertThat(response.isSuccess()).isTrue();
-    approveNewUserRequestsVerifyServiceInteractions(authType, isExternal, 1);
+    int tenantIdCalls = 0;
+    if (!isExternal) {
+      tenantIdCalls = 1;
+    }
+    approveNewUserRequestsVerifyServiceInteractions(authType, isExternal, tenantIdCalls);
     approveNewUserRequestsValidateCapturedUserInfo(authType);
     if (authType == AuthenticationType.DATABASE) {
       approveNewUserRequestsValidateCapturedUserDetails();
@@ -1493,7 +1574,7 @@ public class UsersTeamsControllerServiceTest {
             testNewRegUser.getUsername(), true, Integer.MIN_VALUE, null);
 
     assertThat(response.isSuccess()).isTrue();
-    approveNewUserRequestsVerifyServiceInteractions(AuthenticationType.DATABASE, true, 1);
+    approveNewUserRequestsVerifyServiceInteractions(AuthenticationType.DATABASE, true, 0);
     approveNewUserRequestsValidateCapturedUserInfo(AuthenticationType.DATABASE);
     approveNewUserRequestsValidateCapturedUserDetails();
   }
@@ -1511,7 +1592,7 @@ public class UsersTeamsControllerServiceTest {
 
     assertThat(response.isSuccess()).isTrue();
     testNewRegUser.setTenantId(TEST_TENANT_ID);
-    approveNewUserRequestsVerifyServiceInteractions(AuthenticationType.DATABASE, true, 2);
+    approveNewUserRequestsVerifyServiceInteractions(AuthenticationType.DATABASE, true, 1);
     approveNewUserRequestsValidateCapturedUserInfo(AuthenticationType.DATABASE);
     approveNewUserRequestsValidateCapturedUserDetails();
   }
@@ -1535,7 +1616,6 @@ public class UsersTeamsControllerServiceTest {
             EntityType.USERS,
             MetadataOperationType.CREATE,
             testNewRegUser.getUsername());
-    verify(commonUtilsService).getTenantId(TEST_AUTHENTICATED_USER_UNAME);
     verify(inMemoryUserDetailsManager, never()).createUser(any());
     verify(handleDbRequests, never()).updateNewUserRequest(anyString(), anyString(), anyBoolean());
     verify(mailService, never()).sendMail(anyString(), anyString(), any(), anyString());


### PR DESCRIPTION
# Linked issue

Resolves: #xxxxx
- Only user with superadmin access (role or permissions) should be able to add and update other super admin users.

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
