### PR TITLE
coral: Mark plaintext as insecure and let user confirm choice when adding new Cluster

### DIFF
--- a/core/src/main/resources/static/js/envs.js
+++ b/core/src/main/resources/static/js/envs.js
@@ -664,8 +664,8 @@ app.controller("envsCtrl", function($scope, $http, $location, $window) {
 
                         if($scope.addNewCluster.protocol === "PLAINTEXT"){
                             swal({
-                                title: "PLAINTEXT protocol is unsecure!",
-                                text: "Would you like to proceed anyways?",
+                                title: "PLAINTEXT is not secure",
+                                text: "Are you sure you want to continue with PLAINTEXT?",
                                 type: "warning",
                                 showCancelButton: true,
                                 confirmButtonColor: "#DD6B55",


### PR DESCRIPTION
# Linked issue

Resolves: https://aiven.atlassian.net/browse/GOV-981

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# This PR

Changes to the "Add new Cluster" form:

- adds `SSL` as default protocol 
- marks `PLAINTEXT` as not recommended
- if user chooses `PLAINTEXT`, shows warning
- if user wants to submit with `PLAINTEXT`, shows confirmation modal where user needs to confirm this choice to add a new Cluster

- updates the copy in Angular to be consistent


## Recording


https://github.com/user-attachments/assets/98b6de38-d500-4d66-a121-b4c3010881b4

