### PR TITLE
Upgrading database encryption

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -2836,6 +2836,10 @@ export type components = {
             kwValue?: string;
             kwDesc?: string;
         };
+        NotificationModel: {
+            contactFormSubject?: string;
+            contactFormMessage?: string;
+        };
         SyncSchemaUpdates: {
             topicList?: string[];
             topicListForRemoval?: string[];
@@ -4367,15 +4371,16 @@ export interface operations {
     };
     sendMessageToAdmin: {
         parameters: {
-            query: {
-                contactFormSubject: string;
-                contactFormMessage: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotificationModel"];
+            };
+        };
         responses: {
             /** @description OK */
             200: {

--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
@@ -80,7 +80,9 @@ public class SecurityConfigNoSSO {
   }
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain securityFilterChain(
+      HttpSecurity http, AuthenticationConfiguration authenticationConfiguration) throws Exception {
+
     http.csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(
             auth ->
@@ -97,7 +99,8 @@ public class SecurityConfigNoSSO {
                     .failureUrl("/login?error")
                     .loginPage("/login")
                     .permitAll())
-        .logout(logout -> logout.logoutSuccessUrl("/login"));
+        .logout(logout -> logout.logoutSuccessUrl("/login"))
+        .authenticationManager(authenticationManager(authenticationConfiguration));
 
     return http.build();
   }

--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
@@ -4,6 +4,7 @@ import static io.aiven.klaw.error.KlawErrorMessages.SEC_CONFIG_ERR_101;
 import static io.aiven.klaw.error.KlawErrorMessages.SEC_CONFIG_ERR_102;
 import static io.aiven.klaw.model.enums.AuthenticationType.ACTIVE_DIRECTORY;
 import static io.aiven.klaw.model.enums.AuthenticationType.DATABASE;
+import static io.aiven.klaw.service.UsersTeamsControllerService.UNUSED_PASSWD;
 
 import io.aiven.klaw.auth.KwAuthenticationFailureHandler;
 import io.aiven.klaw.auth.KwAuthenticationSuccessHandler;
@@ -13,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.jasypt.util.text.BasicTextEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,6 +44,7 @@ public class SecurityConfigNoSSO {
   @Autowired KwAuthenticationSuccessHandler kwAuthenticationSuccessHandler;
 
   @Autowired KwAuthenticationFailureHandler kwAuthenticationFailureHandler;
+
   @Autowired private ManageDatabase manageTopics;
 
   @Value("${klaw.login.authentication.type}")
@@ -69,6 +72,8 @@ public class SecurityConfigNoSSO {
   private String apiUser;
 
   @Autowired LdapTemplate ldapTemplate;
+
+  public static final String BCRYPT_ENCODING_ID = "{bcrypt}";
 
   private void shutdownApp() {
     // TODO
@@ -100,7 +105,7 @@ public class SecurityConfigNoSSO {
   @Bean
   public AuthenticationManager authenticationManager(
       AuthenticationConfiguration authenticationConfiguration) throws Exception {
-    AuthenticationManager authenticationManager;
+
     if (authenticationType != null && authenticationType.equals(ACTIVE_DIRECTORY.value)) {
       log.info("AD authentication configured.");
       log.info(
@@ -109,13 +114,11 @@ public class SecurityConfigNoSSO {
           adDomain,
           adRootDn,
           adFilter);
-      authenticationManager =
-          new ProviderManager(
-              Collections.singletonList(activeDirectoryLdapAuthenticationProvider()));
+      return new ProviderManager(
+          Collections.singletonList(activeDirectoryLdapAuthenticationProvider()));
     } else {
-      authenticationManager = authenticationConfiguration.getAuthenticationManager();
+      return authenticationConfiguration.getAuthenticationManager();
     }
-    return authenticationManager;
   }
 
   public AuthenticationProvider activeDirectoryLdapAuthenticationProvider() {
@@ -146,46 +149,72 @@ public class SecurityConfigNoSSO {
         throw new Exception(SEC_CONFIG_ERR_102);
       }
 
-      if (users.size() == 0) {
+      if (users.isEmpty()) {
         shutdownApp();
         throw new Exception(SEC_CONFIG_ERR_101);
       }
 
-      Iterator<UserInfo> iter = users.iterator();
-      PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
-      loadAllUsers(globalUsers, iter, encoder);
+      loadAllUsers(globalUsers, users.iterator());
       globalUsers.put(apiUser, ",CACHE_ADMIN,enabled");
     }
     return new InMemoryUserDetailsManager(globalUsers);
   }
 
-  private void loadAllUsers(
-      Properties globalUsers, Iterator<UserInfo> iter, PasswordEncoder encoder) {
+  private void loadAllUsers(Properties globalUsers, Iterator<UserInfo> iter) {
     UserInfo userInfo;
+    PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
     while (iter.hasNext()) {
       userInfo = iter.next();
       try {
         String secPwd = userInfo.getPwd();
-        if (secPwd == null || secPwd.equals("")) {
+        if (StringUtils.isEmpty(secPwd) || secPwd.equals(UNUSED_PASSWD)) {
           continue;
-        } else {
-          secPwd = decodePwd(secPwd);
         }
+
         globalUsers.put(
-            userInfo.getUsername(), encoder.encode(secPwd) + "," + userInfo.getRole() + ",enabled");
+            userInfo.getUsername(),
+            getBcryptPassword(secPwd, encoder) + "," + userInfo.getRole() + ",enabled");
       } catch (Exception e) {
-        log.error("Error : User not loaded {}. Check password.", userInfo.getUsername(), e);
+        log.error(
+            "Error : User not loaded {}. Check password. {}",
+            userInfo.getUsername(),
+            userInfo.getPwd(),
+            e);
       }
     }
   }
 
-  private String decodePwd(String pwd) {
-    if (pwd != null) {
-      BasicTextEncryptor textEncryptor = new BasicTextEncryptor();
-      textEncryptor.setPasswordCharArray(encryptorSecretKey.toCharArray());
-
-      return textEncryptor.decrypt(pwd);
+  /**
+   * Temporary method until BCrypt migration is completed Currently Klaw supports two types of
+   * encryption for database authentication but all use BCrypt at runtime, this method checks the
+   * encryption type already being used and returns the BCrypt encrypted Password
+   *
+   * @param encodedPassword is the password from database already encoded
+   * @return The BCrypt encoded password
+   */
+  private String getBcryptPassword(String encodedPassword, PasswordEncoder encoder) {
+    if (encodedPassword != null) {
+      // All passwords use bcrypt encoding, check here if they have already been encoded so they
+      // don't get double encoded.
+      if (encodedPassword.startsWith(BCRYPT_ENCODING_ID)) {
+        return encodedPassword;
+      } else {
+        // not saved a Bcrypt and should be changed to bcrypt
+        return encodePwd(getJasyptEncryptor().decrypt(encodedPassword), encoder);
+      }
+    } else {
+      return "";
     }
-    return "";
+  }
+
+  private String encodePwd(String pwd, PasswordEncoder encoder) {
+    return encoder.encode(pwd);
+  }
+
+  private BasicTextEncryptor getJasyptEncryptor() {
+    BasicTextEncryptor textEncryptor = new BasicTextEncryptor();
+    textEncryptor.setPasswordCharArray(encryptorSecretKey.toCharArray());
+
+    return textEncryptor;
   }
 }

--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x10x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x10x0.java
@@ -1,0 +1,64 @@
+package io.aiven.klaw.dao.migration;
+
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.KwProperties;
+import io.aiven.klaw.dao.KwTenants;
+import io.aiven.klaw.helpers.KwConstants;
+import io.aiven.klaw.helpers.db.rdbms.InsertDataJdbc;
+import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@DataMigration(version = "2.10.0", order = 5)
+@Slf4j
+@Configuration // Spring will automatically scan and instantiate this class for retrieval.
+public class MigrateData2x10x0 {
+
+  @Autowired private InsertDataJdbc insertDataJdbc;
+  @Autowired private SelectDataJdbc selectDataJdbc;
+
+  @Autowired private ManageDatabase manageDatabase;
+
+  public MigrateData2x10x0() {}
+
+  protected MigrateData2x10x0(
+      SelectDataJdbc selectDataJdbc, ManageDatabase manageDatabase, InsertDataJdbc insertDataJdbc) {
+    this.selectDataJdbc = selectDataJdbc;
+    this.manageDatabase = manageDatabase;
+    this.insertDataJdbc = insertDataJdbc;
+  }
+
+  @MigrationRunner()
+  public boolean migrate() {
+    log.info("Start to migrate 2.10.0 data. Add new user email content property ");
+
+    List<Integer> tenantIds =
+        selectDataJdbc.getTenants().stream().map(KwTenants::getTenantId).toList();
+
+    for (int tenantId : tenantIds) {
+      List<KwProperties> kwPropertiesList =
+          new ArrayList<>(selectDataJdbc.selectAllKwPropertiesPerTenant(tenantId));
+      String newUserV2Content = "klaw.mail.newuseradded.v2.content";
+      if (kwPropertiesList.stream()
+          .noneMatch(kwProperties -> kwProperties.getKwKey().equals(newUserV2Content))) {
+        log.info("Add new property {} to the database", newUserV2Content);
+        KwProperties kwProperties =
+            new KwProperties(
+                newUserV2Content,
+                tenantId,
+                KwConstants.MAIL_NEWUSERADDED_V2_CONTENT,
+                "Email notification body after a new user is added");
+        kwPropertiesList.add(kwProperties);
+
+        insertDataJdbc.insertDefaultKwProperties(List.of(kwProperties));
+        manageDatabase.loadEnvMapForOneTenant(tenantId);
+        manageDatabase.loadKwPropsPerOneTenant(null, tenantId);
+      }
+    }
+
+    return true;
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x10x0.java
+++ b/core/src/main/java/io/aiven/klaw/dao/migration/MigrateData2x10x0.java
@@ -1,5 +1,7 @@
 package io.aiven.klaw.dao.migration;
 
+import static io.aiven.klaw.service.MailUtils.NEW_USER_ADDED_V2_KEY;
+
 import io.aiven.klaw.config.ManageDatabase;
 import io.aiven.klaw.dao.KwProperties;
 import io.aiven.klaw.dao.KwTenants;
@@ -41,13 +43,13 @@ public class MigrateData2x10x0 {
     for (int tenantId : tenantIds) {
       List<KwProperties> kwPropertiesList =
           new ArrayList<>(selectDataJdbc.selectAllKwPropertiesPerTenant(tenantId));
-      String newUserV2Content = "klaw.mail.newuseradded.v2.content";
+
       if (kwPropertiesList.stream()
-          .noneMatch(kwProperties -> kwProperties.getKwKey().equals(newUserV2Content))) {
-        log.info("Add new property {} to the database", newUserV2Content);
+          .noneMatch(kwProperties -> kwProperties.getKwKey().equals(NEW_USER_ADDED_V2_KEY))) {
+        log.info("Add new property {} to the database", NEW_USER_ADDED_V2_KEY);
         KwProperties kwProperties =
             new KwProperties(
-                newUserV2Content,
+                NEW_USER_ADDED_V2_KEY,
                 tenantId,
                 KwConstants.MAIL_NEWUSERADDED_V2_CONTENT,
                 "Email notification body after a new user is added");

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -68,6 +68,8 @@ public class KwConstants {
       "Dear User, \\n These are the topics that require reconciliation:\\n\\nTenant: %s\\nTopics: %s";
   public static final String MAIL_NEWUSERADDED_CONTENT =
       "Dear User,\\n Congratulations, you have been granted access to Klaw.. \\n\\nUser name: %s\\nPassword: %s";
+  public static final String MAIL_NEWUSERADDED_V2_CONTENT =
+      "Dear User,\\n Congratulations, you have been granted access to Klaw.. \\n\\nUser name: %s\\nPlease set your password through the forgot your password link on the login page if you are unable to access it.";
   public static final String MAIL_PASSWORDRESET_CONTENT =
       "Dear User,\\nA password reset for your Klaw account has been requested.\\n\\nUse the Reset Token to update your password: %s\\nIt will be valid for 10 minutes.\\n\\nIf you did not request this change, please ignore this email.";
 

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -161,4 +161,6 @@ public class KwConstants {
 
   public static final String PASSWORD_REGEX_VALIDATION_STR =
       "Password must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character.";
+  public static final String PASSWORD_VALIDATION_AD_STR =
+      "Password should not be sent to the database to be saved as AD has been chosen for authentication.";
 }

--- a/core/src/main/java/io/aiven/klaw/model/requests/RegisterUserInfoModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/RegisterUserInfoModel.java
@@ -1,8 +1,6 @@
 package io.aiven.klaw.model.requests;
 
-import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX;
-import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
-
+import io.aiven.klaw.validation.PasswordValidator;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -23,9 +21,7 @@ public class RegisterUserInfoModel implements Serializable {
   @NotNull(message = "Username cannot be null")
   private String username;
 
-  @Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_REGEX_VALIDATION_STR)
-  @NotNull
-  private String pwd;
+  @PasswordValidator @NotNull private String pwd;
 
   private String team;
 

--- a/core/src/main/java/io/aiven/klaw/model/requests/UserInfoModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/UserInfoModel.java
@@ -1,10 +1,7 @@
 package io.aiven.klaw.model.requests;
 
-import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX;
-import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
-
+import io.aiven.klaw.validation.PasswordValidator;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.Set;
@@ -23,9 +20,7 @@ public class UserInfoModel extends ProfileModel implements Serializable {
 
   @NotNull private String role;
 
-  @Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_REGEX_VALIDATION_STR)
-  @NotNull
-  private String userPassword;
+  @PasswordValidator @NotNull private String userPassword;
 
   @NotNull private Integer teamId;
 

--- a/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
+++ b/core/src/main/java/io/aiven/klaw/service/DefaultDataService.java
@@ -201,7 +201,7 @@ public class DefaultDataService {
             "klaw.mail.newuseradded.content",
             tenantId,
             KwConstants.MAIL_NEWUSERADDED_CONTENT,
-            "Email notification body after a new user is added");
+            "(Deprecated) Email notification body after a new user is added");
     kwPropertiesList.add(kwProperties15);
 
     KwProperties kwProperties16 =
@@ -292,6 +292,15 @@ public class DefaultDataService {
                 + APPROVE_TOPICS_CREATE
                 + " to allow users to create new topics");
     kwPropertiesList.add(kwProperties38);
+
+    KwProperties kwProperties39 =
+        new KwProperties(
+            "klaw.mail.newuseradded.v2.content",
+            tenantId,
+            KwConstants.MAIL_NEWUSERADDED_V2_CONTENT,
+            "Email notification body after a new user is added");
+    kwPropertiesList.add(kwProperties39);
+
     return kwPropertiesList;
   }
 

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -58,7 +58,7 @@ public class MailUtils {
   private static final String ACL_DELETE_REQ_KEY = "klaw.mail.aclrequestdelete.content";
   private static final String ACL_REQ_APPRVL_KEY = "klaw.mail.aclrequestapproval.content";
   private static final String ACL_REQ_DENY_KEY = "klaw.mail.aclrequestdenial.content";
-  private static final String NEW_USER_ADDED_KEY = "klaw.mail.newuseradded.content";
+  private static final String NEW_USER_ADDED_V2_KEY = "klaw.mail.newuseradded.v2.content";
   private static final String PWD_RESET_KEY = "klaw.mail.passwordreset.content";
 
   private static final String PWD_CHANGED_KEY = "klaw.mail.passwordchanged.content";
@@ -134,7 +134,7 @@ public class MailUtils {
     }
   }
 
-  void sendMail(String username, String pwd, HandleDbRequests dbHandle, String loginUrl) {
+  void sendMail(String username, HandleDbRequests dbHandle, String loginUrl) {
     String formattedStr, subject;
     int tenantId =
         manageDatabase
@@ -142,8 +142,8 @@ public class MailUtils {
             .getUsersInfo(
                 getUserName(SecurityContextHolder.getContext().getAuthentication().getPrincipal()))
             .getTenantId();
-    String newUserAdded = manageDatabase.getKwPropertyValue(NEW_USER_ADDED_KEY, tenantId);
-    formattedStr = String.format(newUserAdded, username, pwd);
+    String newUserAdded = manageDatabase.getKwPropertyValue(NEW_USER_ADDED_V2_KEY, tenantId);
+    formattedStr = String.format(newUserAdded, username);
     subject = "Access to Klaw";
 
     sendMail(

--- a/core/src/main/java/io/aiven/klaw/service/MailUtils.java
+++ b/core/src/main/java/io/aiven/klaw/service/MailUtils.java
@@ -58,7 +58,7 @@ public class MailUtils {
   private static final String ACL_DELETE_REQ_KEY = "klaw.mail.aclrequestdelete.content";
   private static final String ACL_REQ_APPRVL_KEY = "klaw.mail.aclrequestapproval.content";
   private static final String ACL_REQ_DENY_KEY = "klaw.mail.aclrequestdenial.content";
-  private static final String NEW_USER_ADDED_V2_KEY = "klaw.mail.newuseradded.v2.content";
+  public static final String NEW_USER_ADDED_V2_KEY = "klaw.mail.newuseradded.v2.content";
   private static final String PWD_RESET_KEY = "klaw.mail.passwordreset.content";
 
   private static final String PWD_CHANGED_KEY = "klaw.mail.passwordchanged.content";

--- a/core/src/main/java/io/aiven/klaw/service/PasswordService.java
+++ b/core/src/main/java/io/aiven/klaw/service/PasswordService.java
@@ -1,0 +1,58 @@
+package io.aiven.klaw.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jasypt.util.text.BasicTextEncryptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/** Handles password encryption for Klaw, including bcrypt migration */
+@Component
+@Slf4j
+public class PasswordService {
+
+  private PasswordEncoder passwordEncoder;
+  public static final String BCRYPT_ENCODING_ID = "{bcrypt}";
+
+  @Value("${klaw.jasypt.encryptor.secretkey}")
+  private String encryptorSecretKey;
+
+  public PasswordService() {
+    this.passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+  /**
+   * Currently Klaw supports two types of encryption for database authentication but all use BCrypt
+   * at runtime, this method checks the encryption type already being used and returns the BCrypt
+   * encrypted Password
+   *
+   * @param encodedPassword is the password from database already encoded
+   * @return The BCrypt encoded password
+   */
+  public String getBcryptPassword(String encodedPassword) {
+    if (encodedPassword != null) {
+      // All passwords use bcrypt encoding, check here if they have already been encoded so they
+      // don't get double encoded.
+      if (encodedPassword.startsWith(BCRYPT_ENCODING_ID)) {
+        return encodedPassword;
+      } else {
+        // not saved a Bcrypt and should be changed to bcrypt
+        return encodePwd(getJasyptEncryptor().decrypt(encodedPassword));
+      }
+    } else {
+      return "";
+    }
+  }
+
+  protected String encodePwd(String pwd) {
+    return passwordEncoder.encode(pwd);
+  }
+
+  private BasicTextEncryptor getJasyptEncryptor() {
+    BasicTextEncryptor textEncryptor = new BasicTextEncryptor();
+    textEncryptor.setPasswordCharArray(encryptorSecretKey.toCharArray());
+
+    return textEncryptor;
+  }
+}

--- a/core/src/main/java/io/aiven/klaw/validation/PasswordValidator.java
+++ b/core/src/main/java/io/aiven/klaw/validation/PasswordValidator.java
@@ -1,0 +1,21 @@
+package io.aiven.klaw.validation;
+
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordValidatorImpl.class)
+public @interface PasswordValidator {
+  String message() default PASSWORD_REGEX_VALIDATION_STR;
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/aiven/klaw/validation/PasswordValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/PasswordValidatorImpl.java
@@ -1,0 +1,44 @@
+package io.aiven.klaw.validation;
+
+import static io.aiven.klaw.error.KlawErrorMessages.*;
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX;
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_VALIDATION_AD_STR;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+public class PasswordValidatorImpl implements ConstraintValidator<PasswordValidator, String> {
+
+  @Value("${klaw.login.authentication.type}")
+  private String authenticationType;
+
+  @Override
+  public boolean isValid(String password, ConstraintValidatorContext constraintValidatorContext) {
+    if (StringUtils.isEmpty(authenticationType) || authenticationType.equalsIgnoreCase("db")) {
+      Matcher matcher = Pattern.compile(PASSWORD_REGEX).matcher(password);
+      if (!matcher.find()) {
+        constraintValidatorContext
+            .buildConstraintViolationWithTemplate(PASSWORD_REGEX_VALIDATION_STR)
+            .addConstraintViolation()
+            .disableDefaultConstraintViolation();
+        return false;
+      }
+    } else {
+      if (StringUtils.isNotEmpty(password)) {
+        constraintValidatorContext
+            .buildConstraintViolationWithTemplate(PASSWORD_VALIDATION_AD_STR)
+            .addConstraintViolation()
+            .disableDefaultConstraintViolation();
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/SsoActiveDirectoryAuthenticationIT.java
+++ b/core/src/test/java/io/aiven/klaw/SsoActiveDirectoryAuthenticationIT.java
@@ -142,6 +142,8 @@ public class SsoActiveDirectoryAuthenticationIT {
           .getResponse();
       RegisterUserInfoModel userInfoModel =
           mockMethods.getRegisterUserInfoModel(nonExistingUserInKlaw, "USER");
+      // ad user should not have a password set
+      userInfoModel.setPwd("");
       String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(userInfoModel);
 
       // Allow the user to signup

--- a/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
+++ b/core/src/test/java/io/aiven/klaw/config/MigrationUtilityTest.java
@@ -130,7 +130,7 @@ class MigrationUtilityTest {
     Reflections reflections = new Reflections(PROD_PACKAGE_TO_SCAN);
     Set<Class<?>> classes = reflections.getTypesAnnotatedWith(DataMigration.class);
     // When adding a new package you will need to increment this by 1.
-    assertThat(classes.size()).isEqualTo(5);
+    assertThat(classes.size()).isEqualTo(6);
     Set<Integer> uniqueOrder = new HashSet<>();
     // Check Order Numbers are correctly assigned
     classes.forEach(

--- a/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x10x0Test.java
+++ b/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x10x0Test.java
@@ -1,0 +1,85 @@
+package io.aiven.klaw.dao.migration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.aiven.klaw.UtilMethods;
+import io.aiven.klaw.config.ManageDatabase;
+import io.aiven.klaw.dao.KwProperties;
+import io.aiven.klaw.helpers.db.rdbms.InsertDataJdbc;
+import io.aiven.klaw.helpers.db.rdbms.SelectDataJdbc;
+import io.aiven.klaw.service.DefaultDataService;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class MigrateData2x10x0Test {
+
+  public static final int TENANT_ID = 101;
+  private MigrateData2x10x0 migrateData2x10x0;
+
+  @Mock private SelectDataJdbc selectDataJdbc;
+
+  @Mock private ManageDatabase manageDatabase;
+  @Mock private InsertDataJdbc insertDataJdbc;
+
+  DefaultDataService dataService = new DefaultDataService();
+
+  private UtilMethods utilMethods;
+
+  @Captor private ArgumentCaptor<List<KwProperties>> kwPropertiesCaptor;
+
+  @BeforeEach
+  public void setUp() {
+    migrateData2x10x0 = new MigrateData2x10x0(selectDataJdbc, manageDatabase, insertDataJdbc);
+    utilMethods = new UtilMethods();
+  }
+
+  @Test
+  public void addEntryToPropertiesWhenItDoesNotAlreadyExist() {
+    String newUserAddedV2 = "klaw.mail.newuseradded.v2.content";
+    when(selectDataJdbc.selectAllKwPropertiesPerTenant(TENANT_ID))
+        .thenReturn(getKWProperties(TENANT_ID, List.of(newUserAddedV2)));
+    when(selectDataJdbc.getTenants()).thenReturn(utilMethods.getTenants());
+
+    boolean success = migrateData2x10x0.migrate();
+    verify(insertDataJdbc, times(1)).insertDefaultKwProperties(kwPropertiesCaptor.capture());
+    assertThat(kwPropertiesCaptor.getValue().size()).isEqualTo(1);
+    kwPropertiesCaptor.getValue().stream()
+        .allMatch(prop -> Objects.equals(prop.getKwKey(), newUserAddedV2));
+    assertThat(success).isTrue();
+  }
+
+  @Test
+  public void skipAddEntryToPropertiesWhenItDoesAlreadyExist() {
+    when(selectDataJdbc.selectAllKwPropertiesPerTenant(TENANT_ID))
+        .thenReturn(getKWProperties(TENANT_ID, List.of()));
+    when(selectDataJdbc.getTenants()).thenReturn(utilMethods.getTenants());
+
+    boolean success = migrateData2x10x0.migrate();
+    verify(insertDataJdbc, times(0)).insertDefaultKwProperties(any());
+    assertThat(success).isTrue();
+  }
+
+  /**
+   * @param propertyKeys A specific set of properties to filter from the existing list of kw
+   *     properties
+   * @return A list of kwProperties
+   */
+  private List<KwProperties> getKWProperties(int tenantId, List<String> propertyKeys) {
+    dataService = new DefaultDataService();
+    return dataService.createDefaultProperties(tenantId, null).stream()
+        .filter(kwProperty -> !propertyKeys.contains(kwProperty.getKwKey()))
+        .toList();
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x10x0Test.java
+++ b/core/src/test/java/io/aiven/klaw/dao/migration/MigrateData2x10x0Test.java
@@ -1,5 +1,6 @@
 package io.aiven.klaw.dao.migration;
 
+import static io.aiven.klaw.service.MailUtils.NEW_USER_ADDED_V2_KEY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -47,16 +48,16 @@ class MigrateData2x10x0Test {
 
   @Test
   public void addEntryToPropertiesWhenItDoesNotAlreadyExist() {
-    String newUserAddedV2 = "klaw.mail.newuseradded.v2.content";
+
     when(selectDataJdbc.selectAllKwPropertiesPerTenant(TENANT_ID))
-        .thenReturn(getKWProperties(TENANT_ID, List.of(newUserAddedV2)));
+        .thenReturn(getKWProperties(TENANT_ID, List.of(NEW_USER_ADDED_V2_KEY)));
     when(selectDataJdbc.getTenants()).thenReturn(utilMethods.getTenants());
 
     boolean success = migrateData2x10x0.migrate();
     verify(insertDataJdbc, times(1)).insertDefaultKwProperties(kwPropertiesCaptor.capture());
     assertThat(kwPropertiesCaptor.getValue().size()).isEqualTo(1);
     kwPropertiesCaptor.getValue().stream()
-        .allMatch(prop -> Objects.equals(prop.getKwKey(), newUserAddedV2));
+        .allMatch(prop -> Objects.equals(prop.getKwKey(), NEW_USER_ADDED_V2_KEY));
     assertThat(success).isTrue();
   }
 

--- a/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
+++ b/core/src/test/java/io/aiven/klaw/service/UsersTeamsControllerServiceTest.java
@@ -3,7 +3,6 @@ package io.aiven.klaw.service;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_102;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_106;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_109;
-import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_111;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_114;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_115;
 import static io.aiven.klaw.error.KlawErrorMessages.TEAMS_ERR_117;
@@ -85,6 +84,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -103,6 +103,7 @@ public class UsersTeamsControllerServiceTest {
   private static final String TEST_NEW_USER_PWD_PLAIN_TEXT = "newUserPwd";
   private static final String TEST_AUTHENTICATED_USER_UNAME = "authenticatedUserName";
   private static final String TEST_LOGIN_URL = "http://klaw.com/login";
+  public static final String BCRYPT_ENCODING_ID = "{bcrypt}";
   private UtilMethods utilMethods;
 
   private static Validator validator;
@@ -112,8 +113,10 @@ public class UsersTeamsControllerServiceTest {
 
   @Mock private HandleDbRequestsJdbc handleDbRequests;
   @Mock private CommonUtilsService commonUtilsService;
+  @Mock private PasswordService passwordService;
   @Mock private UserDetails userDetails;
   @Mock private ManageDatabase manageDatabase;
+  @Mock private BCryptPasswordEncoder bcryptPasswordEncoder;
 
   private UsersTeamsControllerService usersTeamsControllerService;
   private UserInfo userInfo;
@@ -142,12 +145,20 @@ public class UsersTeamsControllerServiceTest {
     ReflectionTestUtils.setField(usersTeamsControllerService, "mailService", mailService);
     ReflectionTestUtils.setField(
         usersTeamsControllerService, "commonUtilsService", commonUtilsService);
+    ReflectionTestUtils.setField(usersTeamsControllerService, "passwordService", passwordService);
+    ReflectionTestUtils.setField(passwordService, "encryptorSecretKey", ENCRYPTOR_SECRET_KEY);
     ReflectionTestUtils.setField(
-        usersTeamsControllerService, "encryptorSecretKey", ENCRYPTOR_SECRET_KEY);
+        passwordService,
+        "passwordEncoder",
+        PasswordEncoderFactories.createDelegatingPasswordEncoder());
     when(manageDatabase.getHandleDbRequests()).thenReturn(handleDbRequests);
     userInfo = utilMethods.getUserInfoMockDao();
+
     when(commonUtilsService.getPrincipal()).thenReturn(userDetails);
     when(commonUtilsService.isNotAuthorizedUser(any(), any(PermissionType.class))).thenReturn(true);
+    when(passwordService.getBcryptPassword(any())).thenCallRealMethod();
+    when(passwordService.encodePwd(any())).thenCallRealMethod();
+    when(commonUtilsService.getJasyptEncryptor()).thenCallRealMethod();
   }
 
   @Test
@@ -1537,6 +1548,9 @@ public class UsersTeamsControllerServiceTest {
         .thenReturn(ApiResultStatus.SUCCESS.value);
     approveNewUserRequestsSetupTest(authType);
 
+    String bcryptPassword = "{bcrypt}$2a$10$Jes55QOFcnStUvsMXyaCu.w8FdpgwOvsbE99EVHS99Ma3mX52GpLC";
+    testNewRegUser.setPwd(bcryptPassword);
+
     ApiResponse response =
         usersTeamsControllerService.approveNewUserRequests(
             testNewRegUser.getUsername(), isExternal, Integer.MIN_VALUE, null);
@@ -1598,32 +1612,6 @@ public class UsersTeamsControllerServiceTest {
   }
 
   @Test
-  public void approveNewUserRequestsFailureWithLDAPAuth() {
-    when(handleDbRequests.addNewUser(userInfoArgCaptor.capture()))
-        .thenReturn(ApiResultStatus.SUCCESS.value);
-    approveNewUserRequestsSetupTest(AuthenticationType.LDAP);
-
-    assertThatExceptionOfType(KlawException.class)
-        .isThrownBy(
-            () ->
-                usersTeamsControllerService.approveNewUserRequests(
-                    testNewRegUser.getUsername(), true, Integer.MIN_VALUE, null))
-        .withMessage(TEAMS_ERR_111);
-
-    verify(commonUtilsService)
-        .updateMetadata(
-            TEST_TENANT_ID,
-            EntityType.USERS,
-            MetadataOperationType.CREATE,
-            testNewRegUser.getUsername());
-    verify(inMemoryUserDetailsManager, never()).createUser(any());
-    verify(handleDbRequests, never()).updateNewUserRequest(anyString(), anyString(), anyBoolean());
-    verify(mailService, never()).sendMail(anyString(), anyString(), any(), anyString());
-
-    approveNewUserRequestsValidateCapturedUserInfo(AuthenticationType.LDAP);
-  }
-
-  @Test
   public void approveNewUserRequestsFailureWithUnAuthorizedUser() throws KlawException {
     ApiResponse response =
         usersTeamsControllerService.approveNewUserRequests(
@@ -1636,7 +1624,7 @@ public class UsersTeamsControllerServiceTest {
     verify(commonUtilsService, never()).getTenantId(anyString());
     verify(commonUtilsService, never()).updateMetadata(anyInt(), any(), any(), anyString());
     verify(commonUtilsService, never()).getLoginUrl();
-    verify(mailService, never()).sendMail(anyString(), anyString(), any(), anyString());
+    verify(mailService, never()).sendMail(anyString(), any(), anyString());
   }
 
   @Test
@@ -1653,12 +1641,7 @@ public class UsersTeamsControllerServiceTest {
     assertThat(response.getMessage()).isEqualTo(ApiResultStatus.FAILURE.value);
 
     verify(inMemoryUserDetailsManager).createUser(userDetailsArgCaptor.capture());
-    verify(mailService)
-        .sendMail(
-            testNewRegUser.getUsername(),
-            TEST_NEW_USER_PWD_PLAIN_TEXT,
-            handleDbRequests,
-            TEST_LOGIN_URL);
+    verify(mailService).sendMail(testNewRegUser.getUsername(), handleDbRequests, TEST_LOGIN_URL);
     verify(commonUtilsService, never()).getTenantId(anyString());
     verify(commonUtilsService, never()).updateMetadata(anyInt(), any(), any(), anyString());
     verify(handleDbRequests, never()).updateNewUserRequest(anyString(), anyString(), anyBoolean());
@@ -1683,7 +1666,7 @@ public class UsersTeamsControllerServiceTest {
 
     verify(inMemoryUserDetailsManager).createUser(userDetailsArgCaptor.capture());
     verify(inMemoryUserDetailsManager).deleteUser(testNewRegUser.getUsername());
-    verify(mailService, never()).sendMail(anyString(), anyString(), any(), anyString());
+    verify(mailService, never()).sendMail(anyString(), any(), anyString());
     verify(commonUtilsService, never()).getTenantId(anyString());
     verify(commonUtilsService, never()).updateMetadata(anyInt(), any(), any(), anyString());
     verify(handleDbRequests, never()).updateNewUserRequest(anyString(), anyString(), anyBoolean());
@@ -1706,7 +1689,7 @@ public class UsersTeamsControllerServiceTest {
     assertThat(response.isSuccess()).isFalse();
     verify(commonUtilsService, never()).getTenantId(anyString());
     verify(inMemoryUserDetailsManager, never()).createUser(any());
-    verify(mailService, never()).sendMail(anyString(), anyString(), any(), anyString());
+    verify(mailService, never()).sendMail(anyString(), any(), anyString());
     verify(handleDbRequests, never()).addNewUser(any());
     verify(commonUtilsService, never()).updateMetadata(anyInt(), any(), any(), anyString());
     verify(inMemoryUserDetailsManager, never()).deleteUser(anyString());
@@ -2044,12 +2027,11 @@ public class UsersTeamsControllerServiceTest {
         .getTenantId(TEST_AUTHENTICATED_USER_UNAME);
     verify(inMemoryUserDetailsManager, never()).deleteUser(anyString());
     if (isExternal) {
-      verify(mailService)
-          .sendMail(testNewRegUser.getUsername(), sentMailPwd, handleDbRequests, TEST_LOGIN_URL);
+      verify(mailService).sendMail(testNewRegUser.getUsername(), handleDbRequests, TEST_LOGIN_URL);
     } else {
       verify(commonUtilsService, never()).isNotAuthorizedUser(any(), any(PermissionType.class));
       verify(commonUtilsService, never()).getLoginUrl();
-      verify(mailService, never()).sendMail(anyString(), anyString(), any(), anyString());
+      verify(mailService, never()).sendMail(anyString(), any(), anyString());
     }
   }
 
@@ -2062,7 +2044,7 @@ public class UsersTeamsControllerServiceTest {
     assertThat(capturedUserInfo.getRole()).isEqualTo(testNewRegUser.getRole());
     assertThat(capturedUserInfo.getFullname()).isEqualTo(testNewRegUser.getFullname());
     if (authType == AuthenticationType.DATABASE) {
-      assertThat(decodePwd(capturedUserInfo.getPwd())).isEqualTo(TEST_NEW_USER_PWD_PLAIN_TEXT);
+      assertThat(capturedUserInfo.getPwd()).startsWith(BCRYPT_ENCODING_ID);
     } else {
       assertThat(capturedUserInfo.getPwd()).isEqualTo(UsersTeamsControllerService.UNUSED_PASSWD);
     }
@@ -2134,8 +2116,6 @@ public class UsersTeamsControllerServiceTest {
             PasswordEncoderFactories.createDelegatingPasswordEncoder()
                 .matches(changePwdRequestModel.getPwd(), stringArgCaptor.getAllValues().get(0)))
         .isTrue();
-    assertThat(decodePwd(stringArgCaptor.getAllValues().get(1)))
-        .isEqualTo(changePwdRequestModel.getPwd());
   }
 
   private void changePwdSetupTest(UserDetails updatePwdUserDetails, ApiResultStatus dbApiResult) {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5900,8 +5900,7 @@
             "type" : "string"
           },
           "userPassword" : {
-            "type" : "string",
-            "pattern" : "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}"
+            "type" : "string"
           },
           "teamId" : {
             "type" : "integer",
@@ -6480,8 +6479,7 @@
             "minLength" : 6
           },
           "pwd" : {
-            "type" : "string",
-            "pattern" : "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}"
+            "type" : "string"
           },
           "team" : {
             "type" : "string"


### PR DESCRIPTION
Upgrading encryption to BCrypt for password storage, also no longer sends plain text passwords to users on initial creation

Also changes emails for new user registration so that they do not get sent a plaintext password in their email.
# Linked issue

Resolves: #xxxxx

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
