### PR TITLE
Enabling csrf

### DIFF
--- a/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
+++ b/core/src/main/java/io/aiven/klaw/config/SecurityConfigNoSSO.java
@@ -26,12 +26,12 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 
 @EnableWebSecurity
 @ConditionalOnProperty(name = "klaw.enable.sso", havingValue = "false")
@@ -76,7 +76,11 @@ public class SecurityConfigNoSSO {
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(AbstractHttpConfigurer::disable)
+    http.csrf(
+            csrf -> {
+              csrf.ignoringRequestMatchers("/logout");
+              csrf.csrfTokenRepository(new HttpSessionCsrfTokenRepository());
+            })
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(ConfigUtils.getStaticResources(coralEnabled))

--- a/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/EnvsClustersTenantsControllerIT.java
@@ -2,6 +2,7 @@ package io.aiven.klaw;
 
 import static io.aiven.klaw.error.KlawErrorMessages.ENV_CLUSTER_TNT_110;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -60,6 +61,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTenants")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -82,6 +84,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addTenantId")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -97,6 +100,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTenants")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -119,6 +123,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewCluster")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -134,6 +139,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -160,6 +166,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -182,6 +189,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewCluster")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -196,6 +204,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -223,6 +232,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusterDetails")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterId", "1")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -247,6 +257,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewCluster")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -261,6 +272,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -278,6 +290,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteCluster")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterId", "" + hashMap.get("clusterId"))
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -293,6 +306,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -317,6 +331,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -332,6 +347,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -356,6 +372,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -378,6 +395,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -403,6 +421,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -418,6 +437,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -445,6 +465,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -459,6 +480,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -489,6 +511,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -505,6 +528,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteEnvironmentRequest")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("envId", "2")
                     .param("envType", KafkaClustersType.KAFKA.value)
                     .content(jsonReq)
@@ -527,6 +551,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvDetails")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("envSelected", "1")
                     .param("envType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -549,6 +574,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvParams")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("envSelected", "1")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -573,6 +599,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -587,6 +614,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -602,6 +630,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteEnvironmentRequest")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("envId", "1")
                     .param("envType", KafkaClustersType.KAFKA.value)
                     .content(jsonReq)
@@ -625,6 +654,7 @@ public class EnvsClustersTenantsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getStandardEnvNames")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())

--- a/core/src/test/java/io/aiven/klaw/RolesPermissionsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/RolesPermissionsControllerIT.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -54,6 +55,7 @@ public class RolesPermissionsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addRoleId")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("roleId", testRole)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -68,6 +70,7 @@ public class RolesPermissionsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getRolesFromDb")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -88,6 +91,7 @@ public class RolesPermissionsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getPermissions")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -111,6 +115,7 @@ public class RolesPermissionsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/updatePermissions")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -125,6 +130,7 @@ public class RolesPermissionsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getPermissions")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -151,6 +157,7 @@ public class RolesPermissionsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteRole")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("roleId", testRole)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -165,6 +172,7 @@ public class RolesPermissionsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getRolesFromDb")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())

--- a/core/src/test/java/io/aiven/klaw/SecurityConfigNoSSOIT.java
+++ b/core/src/test/java/io/aiven/klaw/SecurityConfigNoSSOIT.java
@@ -1,0 +1,83 @@
+package io.aiven.klaw;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = UiapiApplication.class)
+@TestPropertySource(locations = "classpath:test-application-rdbms1.properties")
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DirtiesContext
+class SecurityConfigNoSSOIT {
+
+  @Autowired private MockMvc mockMvc;
+
+  // CSRF should prevent unauthorized POSTs to secure endpoints
+  @Test
+  void testCsrfProtection() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.post("/updateProfile"))
+        .andExpect(status().isForbidden());
+  }
+
+  // Logout should be allowed without CSRF
+  @Test
+  void testCsrfIgnoredForLogout() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.post("/logout")).andExpect(status().is3xxRedirection());
+  }
+
+  // Logout is not allowed as it's secured
+  @Test
+  void testLogout() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.post("/logout").with(csrf()))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/login"));
+  }
+
+  // Static resources should be permitted without login
+  @Test
+  void testStaticResourcesAreAccessible() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/css/style.css")).andExpect(status().isOk());
+  }
+
+  // Should be accessible to un-authenticated users
+  @Test
+  void testEndpointWithoutAuthentication() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/getRoles")).andExpect(status().isOk());
+  }
+
+  // Should be accessible to authenticated users
+  @Test
+  @WithMockUser
+  void testAuthenticatedEndpoint() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/getRequestTypeStatuses"))
+        .andExpect(status().isOk());
+  }
+
+  // Redirect to login for secured end point
+  @Test
+  void testUnauthorizedAccess() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/getRequestTypeStatuses"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrlPattern("**/login"));
+  }
+}

--- a/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/TopicAclControllerIT.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -108,6 +109,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -127,6 +129,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -144,6 +147,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -165,6 +169,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewCluster")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -180,6 +185,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -203,6 +209,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewCluster")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -218,6 +225,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.KAFKA.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -241,6 +249,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -256,6 +265,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -279,6 +289,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -294,6 +305,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -328,6 +340,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/updateKwCustomProperty")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -351,6 +364,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -371,6 +385,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTopicRequests")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .accept(MediaType.APPLICATION_JSON))
@@ -397,6 +412,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -417,6 +433,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/topic/request/1001")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -446,6 +463,8 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/execTopicRequests")
                     .with(user(user2).password(PASSWORD))
+                    .with(csrf())
+                    .with(csrf())
                     .param("topicId", topicId1 + "")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -461,6 +480,8 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getActivityLogPerEnv")
                     .with(user(user2).password(PASSWORD))
+                    .with(csrf())
+                    .with(csrf())
                     .param("env", "1")
                     .param("pageNo", "1")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -486,6 +507,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -506,6 +528,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -521,6 +544,8 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/execTopicRequestsDecline")
                     .with(user(user2).password(PASSWORD))
+                    .with(csrf())
+                    .with(csrf())
                     .param("topicId", topicIdLocal + "")
                     .param("reasonForDecline", "reason")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -542,6 +567,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTopicTeam")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .param("topicName", topicName + topicId1)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -564,6 +590,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -579,6 +606,7 @@ public class TopicAclControllerIT {
                 MockMvcRequestBuilders.post("/deleteTopicRequests")
                     .param("topicId", "1003")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -607,6 +635,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTopics")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .param("env", "1")
                     .param("pageNo", "1")
                     .param("topicnamesearch", topicName)
@@ -639,6 +668,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTopicsOnly")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .param("env", "1")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -668,6 +698,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getAclRequestsForApprover")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .accept(MediaType.APPLICATION_JSON))
@@ -691,6 +722,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createAcl")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -711,6 +743,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getAclRequestsForApprover")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .accept(MediaType.APPLICATION_JSON))
@@ -762,6 +795,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/execAclRequest")
                     .with(user(user2).password(PASSWORD))
+                    .with(csrf())
                     .param("req_no", "" + reqNo)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -783,6 +817,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createAcl")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -815,6 +850,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createAcl")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -830,6 +866,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/execAclRequestDecline")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .param("req_no", "" + reqNo)
                     .param("reasonForDecline", "reason")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -850,6 +887,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getAclRequests")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .accept(MediaType.APPLICATION_JSON))
@@ -865,6 +903,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteAclRequests")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .param("req_no", "" + hMap.get("req_no"))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -889,6 +928,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getTopicOverview")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .param("topicName", topicName + topicId1)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -915,6 +955,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getSyncAcls")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("env", "1")
                     .param("pageNo", "1")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -939,6 +980,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getAclRequests")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .accept(MediaType.APPLICATION_JSON))
@@ -954,6 +996,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteAclRequests")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .param("req_no", "" + hMap.get("req_no"))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -981,6 +1024,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopicDeleteRequest")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -996,6 +1040,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTopicRequests")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .param("order", "DESC_REQUESTED_TIME")
@@ -1027,6 +1072,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createAcl")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1059,6 +1105,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createDeleteAclSubscriptionRequest")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1117,6 +1164,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/createTopics")
                 .with(user(user1).password(PASSWORD).roles("USER"))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1145,6 +1193,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/execTopicRequests")
                 .with(user(user3).password(PASSWORD))
+                .with(csrf())
                 .param("topicId", topicID + "")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1168,6 +1217,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1183,6 +1233,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -1206,6 +1257,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1232,6 +1284,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/createTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1258,6 +1311,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewCluster")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReqSch)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1273,6 +1327,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getClusters")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterType", KafkaClustersType.SCHEMA_REGISTRY.value)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1301,6 +1356,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewEnv")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReqSch)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1331,6 +1387,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/updateKwCustomProperty")
                 .with(user(superAdmin).password(superAdminPwd))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1344,6 +1401,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getSchemaRegEnvs")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -1382,6 +1440,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/uploadSchema")
                 .with(user(user1).password(PASSWORD).roles("USER"))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1419,6 +1478,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/uploadSchema")
                 .with(user(user2).password(PASSWORD).roles("USER"))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1456,6 +1516,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/uploadSchema")
                 .with(user(user1).password(PASSWORD).roles("USER"))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1485,6 +1546,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/execSchemaRequests")
                 .with(user(user2).password(PASSWORD).roles("USER"))
+                .with(csrf())
                 .param("avroSchemaReqId", "1001")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1504,6 +1566,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getSchemaOfTopic")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .param("topicName", topicName + topicId1)
                     .param("kafkaEnvId", "1")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -1529,6 +1592,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getTopicOverview")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .param("topicName", topicName + topicId1)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1574,6 +1638,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/operationalRequest/reqId/" + 1001 + "/delete")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -1605,6 +1670,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/operationalRequest/reqId/" + 1002 + "/decline")
                     .with(user(user2).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .param("reasonForDecline", "not required")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1644,6 +1710,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/operationalRequest/reqId/" + 1003 + "/approve")
                     .with(user(user2).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -1670,6 +1737,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/updateTopics")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -1696,6 +1764,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/deleteTopicRequests")
                 .with(user(superAdmin).password(superAdminPwd))
+                .with(csrf())
                 .param("topicId", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1725,6 +1794,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/updateKwCustomProperty")
                 .with(user(superAdmin).password(superAdminPwd))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1742,6 +1812,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/createTopics")
                 .with(user(superAdmin).password(superAdminPwd))
+                .with(csrf())
                 .content(topicReq)
                 .param("topicId", "1")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -1764,6 +1835,7 @@ public class TopicAclControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/updateTopics")
                 .with(user(superAdmin).password(superAdminPwd))
+                .with(csrf())
                 .content(topicReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1774,6 +1846,7 @@ public class TopicAclControllerIT {
     return mvc.perform(
             MockMvcRequestBuilders.get("/schema/request/" + schemaRequestId)
                 .with(user(user1).password(PASSWORD).roles("USER"))
+                .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -1790,6 +1863,7 @@ public class TopicAclControllerIT {
     return mvc.perform(
             MockMvcRequestBuilders.post("/operationalRequest/consumerOffsetsReset/create")
                 .with(user(user1).password(PASSWORD).roles("USER"))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1805,6 +1879,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/operationalRequests/requestsFor/myTeam")
                     .with(user(user1).password(PASSWORD).roles("USER"))
+                    .with(csrf())
                     .param("pageNo", "1")
                     .param("requestStatus", status)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -1822,6 +1897,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getAclRequests")
                     .with(user(user1).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .accept(MediaType.APPLICATION_JSON))
@@ -1838,6 +1914,7 @@ public class TopicAclControllerIT {
         mvc.perform(
                 get("/getAclRequests")
                     .with(user(user3).password(PASSWORD))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .param("pageNo", "1")
                     .param("order", "DESC_REQUESTED_TIME")

--- a/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -78,6 +79,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -93,6 +95,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -113,6 +116,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewTeam")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -128,6 +132,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTeamDetails")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("teamId", "1003")
                     .param("tenantName", "default")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -152,6 +157,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewTeam")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -175,6 +181,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewTeam")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -200,6 +207,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/updateTeam")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -214,6 +222,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTeamDetails")
                     .with(user(superAdmin).password(superAdmin))
+                    .with(csrf())
                     .param("teamId", "1003")
                     .param("tenantName", "default")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -238,6 +247,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewTeam")
                     .with(user(user1).password(userPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -261,6 +271,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewTeam")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -275,6 +286,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteTeamRequest")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("teamId", "1004")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -290,6 +302,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getTeamDetails")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("teamId", "1004")
                     .param("tenantName", "default")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -310,6 +323,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteTeamRequest")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("teamId", INFRATEAM_ID)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -331,6 +345,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/deleteUserRequest")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("userId", user1)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -355,6 +370,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getAllTeamsSU")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -381,6 +397,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -428,6 +445,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -450,6 +468,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -472,6 +491,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/addNewUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -495,6 +515,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/user/updateTeam")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -528,6 +549,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/user/updateTeam")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -558,6 +580,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/updateUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -600,6 +623,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/showUserList")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -679,6 +703,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/execNewUserRequestDecline")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("username", user4)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -723,6 +748,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/testClusterApiConnection")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("clusterApiUrl", "http://localhost:9343")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -749,6 +775,7 @@ public class UsersTeamsControllerIT {
     mvc.perform(
             MockMvcRequestBuilders.post("/updateProfile")
                 .with(user(superAdmin).password(superAdminPwd))
+                .with(csrf())
                 .content(jsonReq)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
@@ -758,6 +785,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getMyProfileInfo")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -778,6 +806,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/execNewUserRequestApprove")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("username", userToApprove)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -796,6 +825,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.post("/registerUser")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .content(jsonReq)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
@@ -813,6 +843,7 @@ public class UsersTeamsControllerIT {
         mvc.perform(
                 MockMvcRequestBuilders.get("/getUserDetails")
                     .with(user(superAdmin).password(superAdminPwd))
+                    .with(csrf())
                     .param("userId", user)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
# Linked issue

Resolves: #xxxxx

With this csrf enabling with csrf token (https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-token-repository-httpsession) is stored in http session.

- Enable csrf and ignore logout.
- If we don't ignore logout in csrf, JSESSIONID cookie still exists, and user can access klaw without login, as csrf http token is now being created. So logout functionality would become redundant.
- Alternatively, on logout, we can delete the token from session in FE. But I preferred to do it in backend.

# What kind of change does this PR introduce?

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
