### PR TITLE
coral: Update password form for more support and accessibility

### DIFF
--- a/coral/src/app/components/Form.tsx
+++ b/coral/src/app/components/Form.tsx
@@ -122,6 +122,8 @@ function _PasswordInput<T extends FieldValues>({
   const { errors } = form.formState;
   const error = get(errors, name)?.message as string;
 
+  const { onBlur: rhfOnBlur, ...registeredField } = form.register(name);
+
   // if the element is readonly or disabled, we prevent the
   // event from being handled
   const isEditable = !props.disabled && !props.readOnly;
@@ -130,8 +132,14 @@ function _PasswordInput<T extends FieldValues>({
     <BaseInput
       {...props}
       type="password"
-      {...form.register(name)}
+      {...registeredField}
       {...(!isEditable && { onChange: () => null })}
+      onBlur={(e) => {
+        if (isEditable) {
+          props.onBlur?.(e);
+          rhfOnBlur(e);
+        }
+      }}
       valid={error ? false : undefined}
       helperText={error}
     />

--- a/coral/src/app/features/user-information/change-password/ChangePasswordForm.test.tsx
+++ b/coral/src/app/features/user-information/change-password/ChangePasswordForm.test.tsx
@@ -29,17 +29,13 @@ describe("<ChangePasswordForm />", () => {
         aquariumContext: true,
       });
     });
-    afterAll(() => {
-      cleanup();
-    });
+    afterAll(cleanup);
 
     it("shows correct elements", () => {
       const form = screen.getByRole("form", {
         name: "Change your password by entering a new password",
       });
-      const passwordField = within(form).getByLabelText(
-        "New password Entered password should be at least 8 characters long"
-      );
+      const passwordField = within(form).getByLabelText("New password *");
       const confirmPasswordField = within(form).getByLabelText(
         "Confirm new password"
       );
@@ -90,9 +86,7 @@ describe("<ChangePasswordForm />", () => {
       const form = screen.getByRole("form", {
         name: "Change your password by entering a new password",
       });
-      const passwordField = within(form).getByLabelText(
-        "New password Entered password should be at least 8 characters long"
-      );
+      const passwordField = within(form).getByLabelText("New password *");
       const confirmPasswordField = within(form).getByLabelText(
         "Confirm new password"
       );
@@ -138,9 +132,7 @@ describe("<ChangePasswordForm />", () => {
       const form = screen.getByRole("form", {
         name: "Change your password by entering a new password",
       });
-      const passwordField = within(form).getByLabelText(
-        "New password Entered password should be at least 8 characters long"
-      );
+      const passwordField = within(form).getByLabelText("New password *");
       const confirmPasswordField = within(form).getByLabelText(
         "Confirm new password"
       );
@@ -199,9 +191,7 @@ describe("<ChangePasswordForm />", () => {
       const form = screen.getByRole("form", {
         name: "Change your password by entering a new password",
       });
-      const passwordField = within(form).getByLabelText(
-        "New password Entered password should be at least 8 characters long"
-      );
+      const passwordField = within(form).getByLabelText("New password *");
       const confirmPasswordField = within(form).getByLabelText(
         "Confirm new password"
       );
@@ -215,8 +205,7 @@ describe("<ChangePasswordForm />", () => {
 
       const errors = screen.getAllByText("Must be 8 or more characters long");
 
-      expect(confirmPasswordField).toBeInvalid();
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(1);
 
       await userEvent.click(submitButton);
 
@@ -227,13 +216,12 @@ describe("<ChangePasswordForm />", () => {
       expect(confirmModal).not.toBeInTheDocument();
       expect(mockChangePassword).not.toHaveBeenCalled();
     });
+
     it("shows an error when password don't match", async () => {
       const form = screen.getByRole("form", {
         name: "Change your password by entering a new password",
       });
-      const passwordField = within(form).getByLabelText(
-        "New password Entered password should be at least 8 characters long"
-      );
+      const passwordField = within(form).getByLabelText("New password *");
       const confirmPasswordField = within(form).getByLabelText(
         "Confirm new password"
       );
@@ -266,9 +254,7 @@ describe("<ChangePasswordForm />", () => {
       const form = screen.getByRole("form", {
         name: "Change your password by entering a new password",
       });
-      const passwordField = within(form).getByLabelText(
-        "New password Entered password should be at least 8 characters long"
-      );
+      const passwordField = within(form).getByLabelText("New password *");
       const confirmPasswordField = within(form).getByLabelText(
         "Confirm new password"
       );
@@ -312,6 +298,44 @@ describe("<ChangePasswordForm />", () => {
         success: false,
         message: "error",
       });
+    });
+  });
+
+  describe("shows information about password strength to user", () => {
+    beforeEach(() => {
+      customRender(<ChangePasswordForm />, {
+        queryClient: true,
+        aquariumContext: true,
+      });
+    });
+    afterEach(cleanup);
+
+    it("renders PasswordStrengthMeter and announces lowercase rule as met when typing a lowercase password", async () => {
+      const passwordField = screen.getByLabelText("New password *");
+
+      await userEvent.type(passwordField, "abcd");
+
+      const announcement = await screen.findByRole("alert");
+
+      expect(announcement).toHaveTextContent(/Lowercase letter: Met/i);
+      expect(announcement).toHaveTextContent(/8\+ characters: Not met/i);
+      expect(announcement).toHaveTextContent(/Uppercase letter: Not met/i);
+      expect(announcement).toHaveTextContent(/Number: Not met/i);
+      expect(announcement).toHaveTextContent(/Special character: Not met/i);
+    });
+
+    it("removes password strength announcement when user leaves field", async () => {
+      const passwordField = screen.getByLabelText("New password *");
+
+      await userEvent.type(passwordField, "abcd");
+
+      const announcement = await screen.findByRole("alert");
+
+      expect(announcement).toHaveTextContent(/Lowercase letter: Met/i);
+
+      await userEvent.tab();
+
+      expect(announcement).not.toBeVisible();
     });
   });
 });

--- a/coral/src/app/features/user-information/change-password/PasswordStrengthMeter.test.tsx
+++ b/coral/src/app/features/user-information/change-password/PasswordStrengthMeter.test.tsx
@@ -1,0 +1,110 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { PasswordStrengthMeter } from "src/app/features/user-information/change-password/PasswordStrengthMeter";
+
+describe("<PasswordStrengthMeter />", () => {
+  beforeEach(() => {
+    // making sure there's no leftover DOM
+    // from previous render with timeout
+    jest.clearAllTimers();
+    cleanup();
+
+    jest.useFakeTimers();
+  });
+
+  it("does not render the alert to announce when prop active is false", async () => {
+    render(<PasswordStrengthMeter active={false} password="xx" />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const announcement = screen.queryByRole("alert");
+
+    expect(announcement).not.toBeInTheDocument();
+  });
+
+  it("announces nothing while no password is set met", async () => {
+    render(<PasswordStrengthMeter active={true} password="" />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const announcement = screen.queryByRole("alert");
+
+    expect(announcement).not.toBeInTheDocument();
+  });
+
+  it("announces lowercase met", async () => {
+    render(<PasswordStrengthMeter active={true} password="xx" />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const announcement = await screen.findByRole("alert");
+
+    expect(announcement).toHaveTextContent(/Lowercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/8\+ characters: Not met/i);
+    expect(announcement).toHaveTextContent(/Uppercase letter: Not met/i);
+    expect(announcement).toHaveTextContent(/Number: Not met/i);
+    expect(announcement).toHaveTextContent(/Special character: Not met/i);
+  });
+
+  it("announces lowercase and number met", async () => {
+    render(<PasswordStrengthMeter active={true} password="pass1" />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const announcement = await screen.findByRole("alert");
+
+    expect(announcement).toHaveTextContent(/Lowercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/Number: Met/i);
+    expect(announcement).toHaveTextContent(/8\+ characters: Not met/i);
+    expect(announcement).toHaveTextContent(/Uppercase letter: Not met/i);
+    expect(announcement).toHaveTextContent(/Special character: Not met/i);
+  });
+
+  it("announces lowercase, uppercase, number", async () => {
+    render(<PasswordStrengthMeter active={true} password="Pass1" />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const announcement = await screen.findByRole("alert");
+
+    expect(announcement).toHaveTextContent(/Uppercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/Lowercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/Number: Met/i);
+    expect(announcement).toHaveTextContent(/8\+ characters: Not met/i);
+    expect(announcement).toHaveTextContent(/Special character: Not met/i);
+  });
+
+  it("announces lowercase, uppercase, number, special char'", async () => {
+    render(<PasswordStrengthMeter active={true} password="Pass1!" />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const announcement = await screen.findByRole("alert");
+
+    expect(announcement).toHaveTextContent(/Uppercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/Lowercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/Number: Met/i);
+    expect(announcement).toHaveTextContent(/Special character: Met/i);
+    expect(announcement).toHaveTextContent(/8\+ characters: Not met/i);
+  });
+
+  it("announces all requirements met", async () => {
+    render(<PasswordStrengthMeter active={true} password="Pass1!more" />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const announcement = await screen.findByRole("alert");
+
+    expect(announcement).toHaveTextContent(/8\+ characters: Met/i);
+    expect(announcement).toHaveTextContent(/Uppercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/Lowercase letter: Met/i);
+    expect(announcement).toHaveTextContent(/Number: Met/i);
+    expect(announcement).toHaveTextContent(/Special character: Met/i);
+  });
+});

--- a/coral/src/app/features/user-information/change-password/PasswordStrengthMeter.tsx
+++ b/coral/src/app/features/user-information/change-password/PasswordStrengthMeter.tsx
@@ -1,0 +1,68 @@
+import { Box, Typography } from "@aivenio/aquarium";
+import { getFulfilledPasswordRules } from "src/app/features/user-information/change-password/password-requirement";
+import { useEffect, useMemo, useState } from "react";
+
+type Props = {
+  password: string;
+  active: boolean;
+};
+
+function PasswordStrengthMeter({ password, active }: Props) {
+  const fulfilledRules = getFulfilledPasswordRules(password);
+
+  const accessibleSummaryText = useMemo(() => {
+    const summaryParts = fulfilledRules.reduce(
+      (acc, rule) => {
+        const text = `${rule.label}: ${rule.fulfilled ? "Met" : "Not met"}`;
+        if (rule.fulfilled) {
+          acc.met.push(text);
+        } else {
+          acc.notMet.push(text);
+        }
+        return acc;
+      },
+      { met: [] as string[], notMet: [] as string[] }
+    );
+
+    return [...summaryParts.met, ...summaryParts.notMet].join(". ");
+  }, [fulfilledRules]);
+
+  const [announcement, setAnnouncement] = useState("");
+
+  useEffect(() => {
+    if (password) {
+      // Delay announcing to help screen readers catch the change
+      const timeout = setTimeout(() => {
+        setAnnouncement(accessibleSummaryText);
+      }, 100);
+      return () => clearTimeout(timeout);
+    } else {
+      setAnnouncement("");
+    }
+  }, [accessibleSummaryText, password]);
+
+  return (
+    <>
+      <Box.Flex gap="2" aria-hidden="true">
+        {fulfilledRules.map((rule, index) => (
+          <Box key={index} flex="1">
+            <Box
+              backgroundColor={rule.fulfilled ? "success-60" : "grey-40"}
+              height={"3"}
+              width={"full"}
+              marginBottom={"1"}
+            />
+            <Typography.Caption>{rule.label}</Typography.Caption>
+          </Box>
+        ))}
+      </Box.Flex>
+      {active && announcement && (
+        <div role="alert" className="visually-hidden">
+          {announcement}
+        </div>
+      )}
+    </>
+  );
+}
+
+export { PasswordStrengthMeter };

--- a/coral/src/app/features/user-information/change-password/changePasswordFormSchema.ts
+++ b/coral/src/app/features/user-information/change-password/changePasswordFormSchema.ts
@@ -1,19 +1,10 @@
 import { z } from "zod";
+import { buildPasswordSchema } from "src/app/features/user-information/change-password/password-requirement";
 
 const changePasswordFormSchema = z
   .object({
-    password: z
-      .string()
-      .min(8, { message: "Must be 8 or more characters long" })
-      .regex(/[A-Z]/, { message: "Must include at least one uppercase letter" })
-      .regex(/[a-z]/, { message: "Must include at least one lowercase letter" })
-      .regex(/\d/, { message: "Must include at least one number" })
-      .regex(/[\W_]/, {
-        message: "Must include at least one special character",
-      }),
-    confirmPassword: z
-      .string()
-      .min(8, { message: "Must be 8 or more characters long" }),
+    password: buildPasswordSchema(),
+    confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords don't match",
@@ -22,4 +13,5 @@ const changePasswordFormSchema = z
 
 type ChangePasswordFormSchema = z.infer<typeof changePasswordFormSchema>;
 
-export { changePasswordFormSchema, type ChangePasswordFormSchema };
+export { changePasswordFormSchema };
+export type { ChangePasswordFormSchema };

--- a/coral/src/app/features/user-information/change-password/password-requirement.ts
+++ b/coral/src/app/features/user-information/change-password/password-requirement.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const passwordRequirements = [
+  {
+    regex: /.{8,}/,
+    errorMessage: "Must be 8 or more characters long",
+    label: "8+ characters",
+  },
+  {
+    regex: /[A-Z]/,
+    errorMessage: "Must include at least one uppercase letter",
+    label: "Uppercase letter",
+  },
+  {
+    regex: /[a-z]/,
+    errorMessage: "Must include at least one lowercase letter",
+    label: "Lowercase letter",
+  },
+  {
+    regex: /\d/,
+    errorMessage: "Must include at least one number",
+    label: "Number",
+  },
+  {
+    regex: /[\W_]/,
+    errorMessage: "Must include at least one special character",
+    label: "Special character",
+  },
+];
+
+const buildPasswordSchema = () => {
+  return passwordRequirements.reduce(
+    (schema, req) => schema.regex(req.regex, { message: req.errorMessage }),
+    z.string()
+  );
+};
+
+const getFulfilledPasswordRules = (password: string) => {
+  return passwordRequirements.map((req) => ({
+    label: req.label,
+    fulfilled: req.regex.test(password),
+  }));
+};
+
+export { passwordRequirements, buildPasswordSchema, getFulfilledPasswordRules };


### PR DESCRIPTION
# Linked issue

Resolves: https://aiven.atlassian.net/browse/GOV-987

# Description

With BE change https://github.com/Aiven-Open/klaw/pull/2842 we now apply the same validation rules to passwords as we do in Coral when user changes their password. 

Our form to change the password is not very helpful though - while it does show the correct errors, the user should get help _before_ filling out the form how to do so. 

## This PR:

- adds a copy in the page informing users about the rules for password
- adds a "password strength meter" that shows which rules is fullfilled
- adds (visually hidden) an alert with a small timeout to make this information available for e.g. screenreaders in a timely manner



## Recording

(the little grey box at the bottom of the video shows the screen reader output)


https://github.com/user-attachments/assets/bfe2ba10-6c36-488d-9343-eaec5dd42228

