### PR TITLE
Update user no longer requires password change

### DIFF
--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -2718,6 +2718,20 @@ export type components = {
             /** Format: int32 */
             tenantId?: number;
         };
+        UserUpdateInfoModel: {
+            fullname: string;
+            mailid?: string;
+            username: string;
+            role: string;
+            userPassword: string;
+            /** Format: int32 */
+            teamId: number;
+            switchTeams: boolean;
+            switchAllowedTeamIds?: number[];
+            switchAllowedTeamNames?: string[];
+            /** Format: int32 */
+            tenantId?: number;
+        };
         TopicConfigEntry: {
             configKey?: string;
             configValue?: string;
@@ -4066,7 +4080,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UserInfoModel"];
+                "application/json": components["schemas"]["UserUpdateInfoModel"];
             };
         };
         responses: {

--- a/coral/types/api.d.ts
+++ b/coral/types/api.d.ts
@@ -2723,7 +2723,7 @@ export type components = {
             mailid?: string;
             username: string;
             role: string;
-            userPassword: string;
+            userPassword?: string;
             /** Format: int32 */
             teamId: number;
             switchTeams: boolean;

--- a/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
+++ b/core/src/main/java/io/aiven/klaw/controller/UsersTeamsController.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw.controller;
 
 import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX;
+import static org.springframework.beans.BeanUtils.copyProperties;
 
 import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.error.KlawNotAuthorizedException;
@@ -11,6 +12,7 @@ import io.aiven.klaw.model.requests.ProfileModel;
 import io.aiven.klaw.model.requests.RegisterUserInfoModel;
 import io.aiven.klaw.model.requests.TeamModel;
 import io.aiven.klaw.model.requests.UserInfoModel;
+import io.aiven.klaw.model.requests.UserUpdateInfoModel;
 import io.aiven.klaw.model.response.RegisterUserInfoModelResponse;
 import io.aiven.klaw.model.response.ResetPasswordInfo;
 import io.aiven.klaw.model.response.TeamModelResponse;
@@ -98,10 +100,11 @@ public class UsersTeamsController {
   @PostMapping(
       value = "/updateUser",
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<ApiResponse> updateUser(@Valid @RequestBody UserInfoModel updateUserObj)
-      throws KlawException {
-    return new ResponseEntity<>(
-        usersTeamsControllerService.updateUser(updateUserObj), HttpStatus.OK);
+  public ResponseEntity<ApiResponse> updateUser(
+      @Valid @RequestBody UserUpdateInfoModel updateUserObj) throws KlawException {
+    UserInfoModel userInfoObj = new UserInfoModel();
+    copyProperties(updateUserObj, userInfoObj);
+    return new ResponseEntity<>(usersTeamsControllerService.updateUser(userInfoObj), HttpStatus.OK);
   }
 
   @PostMapping(

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -159,9 +159,6 @@ public class KwConstants {
 
   public static final String PASSWORD_REGEX = "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}";
 
-  public static final String PASSWORD_UPDATE_REGEX =
-      "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}|(?=.*[*]).{8}";
-
   public static final String PASSWORD_REGEX_VALIDATION_STR =
       "Password must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character.";
   public static final String PASSWORD_VALIDATION_AD_STR =

--- a/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
+++ b/core/src/main/java/io/aiven/klaw/helpers/KwConstants.java
@@ -159,6 +159,9 @@ public class KwConstants {
 
   public static final String PASSWORD_REGEX = "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}";
 
+  public static final String PASSWORD_UPDATE_REGEX =
+      "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}|(?=.*[*]).{8}";
+
   public static final String PASSWORD_REGEX_VALIDATION_STR =
       "Password must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character.";
   public static final String PASSWORD_VALIDATION_AD_STR =

--- a/core/src/main/java/io/aiven/klaw/model/requests/UserUpdateInfoModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/UserUpdateInfoModel.java
@@ -1,10 +1,7 @@
 package io.aiven.klaw.model.requests;
 
-import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
-import static io.aiven.klaw.helpers.KwConstants.PASSWORD_UPDATE_REGEX;
-
+import io.aiven.klaw.validation.PasswordUpdateValidator;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import java.io.Serializable;
 import java.util.Set;
 import lombok.Getter;
@@ -22,9 +19,7 @@ public class UserUpdateInfoModel extends ProfileModel implements Serializable {
   @NotNull private String role;
 
   // Update regex check also allows the masked pw tobe sent.
-  @Pattern(regexp = PASSWORD_UPDATE_REGEX, message = PASSWORD_REGEX_VALIDATION_STR)
-  @NotNull
-  private String userPassword;
+  @PasswordUpdateValidator private String userPassword;
 
   @NotNull private Integer teamId;
 

--- a/core/src/main/java/io/aiven/klaw/model/requests/UserUpdateInfoModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/UserUpdateInfoModel.java
@@ -1,0 +1,38 @@
+package io.aiven.klaw.model.requests;
+
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_UPDATE_REGEX;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.io.Serializable;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+public class UserUpdateInfoModel extends ProfileModel implements Serializable {
+  // Can't be changed in update so no need to require a more restrictive check.
+  @NotNull(message = "Username cannot be null")
+  private String username;
+
+  @NotNull private String role;
+
+  // Update regex check also allows the masked pw tobe sent.
+  @Pattern(regexp = PASSWORD_UPDATE_REGEX, message = PASSWORD_REGEX_VALIDATION_STR)
+  @NotNull
+  private String userPassword;
+
+  @NotNull private Integer teamId;
+
+  @NotNull private boolean switchTeams;
+
+  private Set<Integer> switchAllowedTeamIds;
+
+  private Set<String> switchAllowedTeamNames;
+
+  private int tenantId;
+}

--- a/core/src/main/java/io/aiven/klaw/model/requests/UserUpdateInfoModel.java
+++ b/core/src/main/java/io/aiven/klaw/model/requests/UserUpdateInfoModel.java
@@ -18,7 +18,7 @@ public class UserUpdateInfoModel extends ProfileModel implements Serializable {
 
   @NotNull private String role;
 
-  // Update regex check also allows the masked pw tobe sent.
+  // Update regex check also allows no password to be sent and then no password update occurs.
   @PasswordUpdateValidator private String userPassword;
 
   @NotNull private Integer teamId;

--- a/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/UsersTeamsControllerService.java
@@ -196,12 +196,12 @@ public class UsersTeamsControllerService {
       UserInfoModel newUser, UserInfo existingUserInfo, int tenantId) throws KlawException {
     String pwdUpdated = newUser.getUserPassword();
     String existingPwd;
-    if (MASKED_PWD.equals(pwdUpdated) && DATABASE.value.equals(authenticationType)) {
+    if (StringUtils.isEmpty(pwdUpdated) && DATABASE.value.equals(authenticationType)) {
       existingPwd = existingUserInfo.getPwd();
       if (!"".equals(existingPwd)) {
         newUser.setUserPassword(passwordService.getBcryptPassword(existingPwd));
       }
-    } else if (!MASKED_PWD.equals(pwdUpdated) && DATABASE.value.equals(authenticationType)) {
+    } else if (!StringUtils.isEmpty(pwdUpdated) && DATABASE.value.equals(authenticationType)) {
       newUser.setUserPassword(passwordService.encodePwd(pwdUpdated));
     }
 

--- a/core/src/main/java/io/aiven/klaw/validation/PasswordUpdateValidator.java
+++ b/core/src/main/java/io/aiven/klaw/validation/PasswordUpdateValidator.java
@@ -1,0 +1,21 @@
+package io.aiven.klaw.validation;
+
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordUpdateValidatorImpl.class)
+public @interface PasswordUpdateValidator {
+  String message() default PASSWORD_REGEX_VALIDATION_STR;
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/io/aiven/klaw/validation/PasswordUpdateValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/PasswordUpdateValidatorImpl.java
@@ -1,0 +1,48 @@
+package io.aiven.klaw.validation;
+
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX;
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_REGEX_VALIDATION_STR;
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_VALIDATION_AD_STR;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+public class PasswordUpdateValidatorImpl
+    implements ConstraintValidator<PasswordUpdateValidator, String> {
+
+  @Value("${klaw.login.authentication.type}")
+  private String authenticationType;
+
+  @Override
+  public boolean isValid(String password, ConstraintValidatorContext constraintValidatorContext) {
+    if (StringUtils.isEmpty(password)) {
+      //      This is an update so we dont always have a password to change
+      return true;
+    }
+    if (StringUtils.isEmpty(authenticationType) || authenticationType.equalsIgnoreCase("db")) {
+      Matcher matcher = Pattern.compile(PASSWORD_REGEX).matcher(password);
+      if (!matcher.find()) {
+        constraintValidatorContext
+            .buildConstraintViolationWithTemplate(PASSWORD_REGEX_VALIDATION_STR)
+            .addConstraintViolation()
+            .disableDefaultConstraintViolation();
+        return false;
+      }
+    } else {
+      if (StringUtils.isNotEmpty(password)) {
+        constraintValidatorContext
+            .buildConstraintViolationWithTemplate(PASSWORD_VALIDATION_AD_STR)
+            .addConstraintViolation()
+            .disableDefaultConstraintViolation();
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/core/src/main/resources/static/js/modifyUser.js
+++ b/core/src/main/resources/static/js/modifyUser.js
@@ -193,7 +193,9 @@ app.controller("modifyUserCtrl", function($scope, $http, $location, $window) {
 
             serviceInput['username'] = $scope.userDetails.username;
             serviceInput['fullname'] = $scope.userDetails.fullname;
-            serviceInput['userPassword'] = $scope.userDetails.userPassword;
+            if($scope.userDetails.userPassword !== '********') {
+                serviceInput['userPassword'] = $scope.userDetails.userPassword;
+            }
             serviceInput['teamId'] = $scope.userDetails.teamId;
             serviceInput['role'] = $scope.userDetails.role;
             serviceInput['mailid'] = $scope.userDetails.mailid;

--- a/core/src/main/resources/templates/modifyUser.html
+++ b/core/src/main/resources/templates/modifyUser.html
@@ -508,7 +508,7 @@
 												<input type="password" class="form-control"
 													   required
 													   ng-model="userDetails.userPassword"
-													   pattern="(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}"
+													   pattern="(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}|\\*\\*\\*\\*\\*\\*\\*\\*"
 													   title="Password must be at least 8 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character."
 												/>
 											</div>

--- a/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
+++ b/core/src/test/java/io/aiven/klaw/UsersTeamsControllerIT.java
@@ -1,6 +1,7 @@
 package io.aiven.klaw;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.beans.BeanUtils.copyProperties;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +14,7 @@ import io.aiven.klaw.model.requests.ProfileModel;
 import io.aiven.klaw.model.requests.RegisterUserInfoModel;
 import io.aiven.klaw.model.requests.TeamModel;
 import io.aiven.klaw.model.requests.UserInfoModel;
+import io.aiven.klaw.model.requests.UserUpdateInfoModel;
 import io.aiven.klaw.model.response.ConnectivityStatus;
 import io.aiven.klaw.model.response.TeamModelResponse;
 import io.aiven.klaw.model.response.UserInfoModelResponse;
@@ -573,8 +575,10 @@ public class UsersTeamsControllerIT {
     UserInfoModel userInfoModel =
         mockMethods.getUserInfoModelSwitchTeams(
             user2, role, 1001, 2); // add switch teams 1001, 1002
+    UserUpdateInfoModel updateModel = new UserUpdateInfoModel();
     userInfoModel.setTeamId(1001);
-    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(userInfoModel);
+    copyProperties(userInfoModel, updateModel);
+    String jsonReq = OBJECT_MAPPER.writer().writeValueAsString(updateModel);
 
     String response =
         mvc.perform(

--- a/core/src/test/java/io/aiven/klaw/controller/UserTeamsControllerTest.java
+++ b/core/src/test/java/io/aiven/klaw/controller/UserTeamsControllerTest.java
@@ -1,13 +1,18 @@
 package io.aiven.klaw.controller;
 
+import static io.aiven.klaw.helpers.KwConstants.PASSWORD_UPDATE_REGEX;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.aiven.klaw.error.KlawException;
 import io.aiven.klaw.model.response.ResetPasswordInfo;
 import io.aiven.klaw.service.UsersTeamsControllerService;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -60,5 +65,18 @@ public class UserTeamsControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().is(expectedStatus));
+  }
+
+  @ParameterizedTest
+  @Order(2)
+  @CsvSource({
+    "invalidpwd, false", // Invalid password -> Expect 4xx Client Error
+    "Invalidpwd321@, true", // Valid password -> Expect 200 OK
+    "********, true",
+    "******, false",
+  })
+  public void updateUserPasswordTest(String password, boolean expectedStatus) throws KlawException {
+    Matcher matcher = Pattern.compile(PASSWORD_UPDATE_REGEX).matcher(password);
+    assertThat(matcher.find()).isEqualTo(expectedStatus);
   }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -113,7 +113,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/UserInfoModel"
+                "$ref" : "#/components/schemas/UserUpdateInfoModel"
               }
             }
           },
@@ -5901,6 +5901,56 @@
           },
           "userPassword" : {
             "type" : "string"
+          },
+          "teamId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "switchTeams" : {
+            "type" : "boolean"
+          },
+          "switchAllowedTeamIds" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "format" : "int32"
+            },
+            "uniqueItems" : true
+          },
+          "switchAllowedTeamNames" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            },
+            "uniqueItems" : true
+          },
+          "tenantId" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        },
+        "required" : [ "fullname", "role", "switchTeams", "teamId", "userPassword", "username" ]
+      },
+      "UserUpdateInfoModel" : {
+        "properties" : {
+          "fullname" : {
+            "type" : "string",
+            "maxLength" : 50,
+            "minLength" : 5,
+            "pattern" : "^[A-Za-zÀ-ÖØ-öø-ÿ' ]*$"
+          },
+          "mailid" : {
+            "type" : "string"
+          },
+          "username" : {
+            "type" : "string"
+          },
+          "role" : {
+            "type" : "string"
+          },
+          "userPassword" : {
+            "type" : "string",
+            "pattern" : "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}|(?=.*[*]).{8}"
           },
           "teamId" : {
             "type" : "integer",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5949,8 +5949,7 @@
             "type" : "string"
           },
           "userPassword" : {
-            "type" : "string",
-            "pattern" : "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}|(?=.*[*]).{8}"
+            "type" : "string"
           },
           "teamId" : {
             "type" : "integer",
@@ -5979,7 +5978,7 @@
             "format" : "int32"
           }
         },
-        "required" : [ "fullname", "role", "switchTeams", "teamId", "userPassword", "username" ]
+        "required" : [ "fullname", "role", "switchTeams", "teamId", "username" ]
       },
       "TopicConfigEntry" : {
         "properties" : {


### PR DESCRIPTION
When altering a users information this change allows them not to be required to also update the password.

This bug was introduced when checks were added on the UserInfoModel to ensure passwords always met minimum standards but when updating a user, the password isn't always updated so the masked password is required to be allowed here.

# Linked issue

Resolves: #xxxxx

# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
