### PR TITLE
fix(core): unsafe expansion of self-closing html tag

### DIFF
--- a/core/src/main/resources/static/lib/jquery-1.10.2.js
+++ b/core/src/main/resources/static/lib/jquery-1.10.2.js
@@ -6566,7 +6566,9 @@ jQuery.extend({
 					tag = ( rtagName.exec( elem ) || ["", ""] )[1].toLowerCase();
 					wrap = wrapMap[ tag ] || wrapMap._default;
 
-					tmp.innerHTML = wrap[1] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[2];
+					var parser = new DOMParser();
+					var parsedDoc = parser.parseFromString(wrap[1] + elem + wrap[2], "text/html");
+					tmp.innerHTML = parsedDoc.body.innerHTML;
 
 					// Descend through wrappers to the right content
 					j = wrap[0];


### PR DESCRIPTION
https://github.com/Aiven-Open/klaw/blob/041f8e63809f96322fe4078dec19ca70c8afa320/core/src/main/resources/static/lib/jquery-1.10.2.js#L6569-L6569


Fix the issue need to ensure that the expansion of self-closing tags does not invalidate prior sanitization. Instead of using a regular expression to perform the transformation, we should use a safer approach, such as parsing the HTML string into a DOM structure and manipulating it programmatically. This avoids the pitfalls of regular expressions and ensures that the resulting HTML is well-formed.

The specific change involves replacing the unsafe `elem.replace(rxhtmlTag, "<$1></$2>")` with a safer alternative. We can use a DOM parser to handle the transformation securely. This approach ensures that the input is treated as HTML and avoids unintended modifications.

--- 
Sanitizing untrusted input for HTML meta-characters is a common technique for preventing cross-site scripting attacks. But even a sanitized input can be dangerous to use if it is modified further before a browser treats it as HTML. A seemingly innocent transformation that expands a self-closing HTML tag from `<div attr="{sanitized}"/>` to `<div attr="{sanitized}"></div>` may in fact cause cross-site scripting vulnerabilities.


#### References
[Security fixes in jQuery 3.5.0](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/)
[DOM based XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html)
[XSS (Cross Site Scripting) Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
[Types of Cross-Site](https://owasp.org/www-community/Types_of_Cross-Site_Scripting)
[Cross-site scripting](http://en.wikipedia.org/wiki/Cross-site_scripting)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-116](https://cwe.mitre.org/data/definitions/116.html)



# What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update


# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [x] Tests for the changes have been added (if relevant)
- [x] The latest changes from the `main` branch have been pulled
- [x] `pnpm lint` has been run successfully
