### PR TITLE
fix(core): handle concurrent deletion and update of environment

### DIFF
--- a/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
+++ b/core/src/main/java/io/aiven/klaw/service/EnvsClustersTenantsControllerService.java
@@ -458,6 +458,13 @@ public class EnvsClustersTenantsControllerService {
         newEnv.setId(String.valueOf(id));
       }
     } else {
+      Optional<Env> existingEnvOpt =
+          envActualList.stream().filter(env -> env.getId().equals(newEnv.getId())).findFirst();
+      if (existingEnvOpt.isEmpty()) {
+
+        // cannot modify a deleted env
+        return ApiResponse.notOk("Cannot modify a deleted environment.");
+      }
       // modify env
       envActualList =
           envActualList.stream()

--- a/core/src/main/resources/static/js/modifyEnvs.js
+++ b/core/src/main/resources/static/js/modifyEnvs.js
@@ -627,6 +627,9 @@ app.controller("modifyEnvsCtrl", function($scope, $http, $location, $window) {
                              $window.location.href = $window.location.origin + $scope.dashboardDetails.contextPath + "/envs";
                        });
                      }else $scope.showSubmitFailed('','');
+                     setTimeout(function(){
+                        $window.location.href = $window.location.origin + $scope.dashboardDetails.contextPath + "/envs";
+                      }, 1200);
                 }).error(
                     function(error)
                     {


### PR DESCRIPTION
# Linked issue

Resolves: Status: Open. 
#2984

# What kind of change does this PR introduce?

- [x] Bug fix  
- [ ] New feature  
- [ ] Refactor  
- [ ] Docs update  
- [ ] CI update

# What is the current behavior?

Application currently allows a deletion by SUPERADMIN (or a user with permission to edit/delete environments) to be **overwritten** if another user still has the edit form open and clicks save after the delete.

# What is the new behavior?

- When the second user clicks save, a popup appears saying the environment is already deleted.  
- The user is then redirected to the environments list page.  

# Other information

- Added a check before saving an edit to verify the environment still exists.  
- Added regression test in `EnvsClustersTenantsControllerServiceTest` to cover this scenario.  

# Requirements (all must be checked before review)

- [x] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)  
- [x] Tests for the changes have been added (regression test included)  
- [x] The latest changes from the `main` branch have been pulled  
- [x] `pnpm lint` has been run successfully  
