### PR TITLE
Fix topic promotion in coral ui

### DIFF
--- a/coral/src/app/components/InternalLinkButton.tsx
+++ b/coral/src/app/components/InternalLinkButton.tsx
@@ -1,6 +1,7 @@
 import { Link, ButtonProps, Button, LinkProps } from "@aivenio/aquarium";
 import { ResolveIntersectionTypes } from "types/utils";
 import { ReactNode } from "react";
+import { useHref } from "react-router-dom";
 
 type InternalLinkButtonProps = ResolveIntersectionTypes<
   {
@@ -10,6 +11,8 @@ type InternalLinkButtonProps = ResolveIntersectionTypes<
   } & LinkProps
 >;
 function InternalLinkButton({ children, ...props }: InternalLinkButtonProps) {
+  const resolvedHref = useHref(props.href ?? "");
+
   if (props.disabled) {
     // a Link cannot really be disabled semantically. Adding an empty ref
     // with aria-disabled would solve this, but that there are no styles
@@ -26,7 +29,11 @@ function InternalLinkButton({ children, ...props }: InternalLinkButtonProps) {
       </Button>
     );
   }
-  return <Link.Button {...props}>{children}</Link.Button>;
+  return (
+    <Link.Button {...props} href={resolvedHref}>
+      {children}
+    </Link.Button>
+  );
 }
 
 export { InternalLinkButton };

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.test.tsx
@@ -455,7 +455,9 @@ describe("<TopicPromotionRequest />", () => {
 
       expect(mockPromoteTopic).toHaveBeenCalled();
       await waitFor(() => {
-        expect(mockedUsedNavigate).toHaveBeenCalledWith(-1);
+        expect(mockedUsedNavigate).toHaveBeenCalledWith(
+          "/requests/topics?status=CREATED&requestType=PROMOTE"
+        );
       });
 
       expect(mockedUseToast).toHaveBeenCalledWith({

--- a/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
+++ b/coral/src/app/features/topics/request/TopicPromotionRequest.tsx
@@ -157,7 +157,7 @@ function TopicPromotionRequest() {
     error: promoteError,
   } = useMutation(requestTopicPromotion, {
     onSuccess: () => {
-      navigate(-1);
+      navigate("/requests/topics?status=CREATED&requestType=PROMOTE");
       toast({
         message: "Topic promotion request successfully created",
         position: "bottom-left",


### PR DESCRIPTION
# Linked issue

Resolves: https://github.com/Aiven-Open/klaw/issues/3024

# What kind of change does this PR introduce?

- Bug fix

# What is the current behavior?

when topic is being promoted from coral env, we notice 404 issue.

# What is the new behavior?

Topic promotion request should be successfull

# Other information

The "Promote" button is a regular HTML link. When the app runs under /coral/, the link was missing that prefix 

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
