### PR TITLE
Fix error when topic is deleted and recreated 

### DIFF
--- a/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
+++ b/cluster-api/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
@@ -307,7 +307,7 @@ public class ApacheKafkaTopicService {
 
       // delete associated schema if requested
       String schemaDeletionStatus = "";
-      if (clusterTopicRequest.getDeleteAssociatedSchema()) {
+      if (Boolean.TRUE.equals(clusterTopicRequest.getDeleteAssociatedSchema())) {
         schemaDeletionStatus = schemaService.deleteSchema(clusterTopicRequest).getMessage();
         log.info("Schema deletion status : {}", schemaDeletionStatus);
       }

--- a/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicServiceTest.java
+++ b/cluster-api/src/test/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicServiceTest.java
@@ -396,6 +396,39 @@ class ApacheKafkaTopicServiceTest {
   }
 
   @Test
+  void deleteTopicWithoutDeleteAssociatedSchemaFlagSucceeds() throws Exception {
+    // Regression: when updateTopic decreases partitions it falls into the
+    // delete+recreate branch and forwards the original ClusterTopicRequest to
+    // deleteTopic with deleteAssociatedSchema unset (null). It must not NPE.
+    ClusterTopicRequest clusterTopicRequest =
+        ClusterTopicRequest.builder()
+            .env(TestConstants.ENVIRONMENT)
+            .clusterName(TestConstants.CLUSTER_IDENTIFICATION)
+            .protocol(protocol)
+            .topicName(TestConstants.TOPIC_NAME)
+            .partitions(TestConstants.SINGLE_PARTITION)
+            .replicationFactor(TestConstants.REPLICATION_FACTOR)
+            .advancedTopicConfiguration(TestConstants.ADVANCED_TOPIC_CONFIGURATION)
+            .build();
+
+    Mockito.when(
+            clusterApiUtils.getAdminClient(
+                TestConstants.ENVIRONMENT, protocol, TestConstants.CLUSTER_IDENTIFICATION))
+        .thenReturn(adminClient);
+    Mockito.when(clusterApiUtils.getAdminClientProperties()).thenReturn(adminClientProperties);
+    Mockito.when(adminClientProperties.getTopicsTimeoutSecs()).thenReturn(10L);
+    Mockito.when(adminClient.deleteTopics(any(Collection.class))).thenReturn(deleteTopicsResult);
+    Mockito.when(deleteTopicsResult.values())
+        .thenReturn(Map.of(TestConstants.TOPIC_NAME, KafkaFuture.completedFuture(null)));
+
+    ApiResponse response = apacheKafkaTopicService.deleteTopic(clusterTopicRequest);
+
+    Assertions.assertThat(response.isSuccess()).isTrue();
+    Assertions.assertThat(response.getMessage()).isEqualTo(ApiResultStatus.SUCCESS.value);
+    Mockito.verifyNoInteractions(schemaService);
+  }
+
+  @Test
   void deleteTopicUnknownTopicOrPartitionException() throws Exception {
     ClusterTopicRequest clusterTopicRequest =
         ClusterTopicRequest.builder()


### PR DESCRIPTION
# Linked issue

Resolves: #xxxxx

# What kind of change does this PR introduce?

When a user requests to decrease the topic partitions, topic will be deleted and recreated. In this process there is an error and this PR fixes that NPE

- Create new Kafka topic request via Klaw with partition count=3
- Approve the request
- Make topic update request with partition count=1
- Approve the request => Error

```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "io.aiven.klaw.clusterapi.models.ClusterTopicRequest.getDeleteAssociatedSchema()" is null
	at io.aiven.klaw.clusterapi.services.ApacheKafkaTopicService.deleteTopic(ApacheKafkaTopicService.java:310)
	at io.aiven.klaw.clusterapi.services.ApacheKafkaTopicService.updateTopic(ApacheKafkaTopicService.java:251)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs update
- [ ] CI update

# What is the current behavior?

_Describe the state of the application before this PR. Illustrations appreciated (videos, gifs, screenshots)._

# What is the new behavior?

_Describe the state of the application after this PR. Illustrations appreciated (videos, gifs, screenshots)._

# Other information

_Additional changes, explanations of the approach taken, unresolved issues, necessary follow ups, etc._

# Requirements (all must be checked before review)

- [ ] The pull request title follows [our guidelines](https://github.com/Aiven-Open/klaw/blob/main/CONTRIBUTING.md#guideline-commit-messages)
- [ ] Tests for the changes have been added (if relevant)
- [ ] The latest changes from the `main` branch have been pulled
- [ ] `pnpm lint` has been run successfully
