### PR TITLE
perf(validation): precompile PASSWORD_REGEX in password validators (~1.7-2.0x faster)

### DIFF
--- a/core/src/main/java/io/aiven/klaw/validation/PasswordUpdateValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/PasswordUpdateValidatorImpl.java
@@ -16,6 +16,10 @@ import org.springframework.beans.factory.annotation.Value;
 public class PasswordUpdateValidatorImpl
     implements ConstraintValidator<PasswordUpdateValidator, String> {
 
+  // Precompiled once: Pattern.compile() was previously called on every validation,
+  // which is expensive on the hot path (every user password update).
+  private static final Pattern PASSWORD_PATTERN = Pattern.compile(PASSWORD_REGEX);
+
   @Value("${klaw.login.authentication.type}")
   private String authenticationType;
 
@@ -26,7 +30,7 @@ public class PasswordUpdateValidatorImpl
       return true;
     }
     if (StringUtils.isEmpty(authenticationType) || authenticationType.equalsIgnoreCase("db")) {
-      Matcher matcher = Pattern.compile(PASSWORD_REGEX).matcher(password);
+      Matcher matcher = PASSWORD_PATTERN.matcher(password);
       if (!matcher.find()) {
         constraintValidatorContext
             .buildConstraintViolationWithTemplate(PASSWORD_REGEX_VALIDATION_STR)

--- a/core/src/main/java/io/aiven/klaw/validation/PasswordValidatorImpl.java
+++ b/core/src/main/java/io/aiven/klaw/validation/PasswordValidatorImpl.java
@@ -16,13 +16,17 @@ import org.springframework.beans.factory.annotation.Value;
 @Slf4j
 public class PasswordValidatorImpl implements ConstraintValidator<PasswordValidator, String> {
 
+  // Precompiled once: Pattern.compile() was previously called on every validation,
+  // which is expensive on the hot path (every user registration / password change).
+  private static final Pattern PASSWORD_PATTERN = Pattern.compile(PASSWORD_REGEX);
+
   @Value("${klaw.login.authentication.type}")
   private String authenticationType;
 
   @Override
   public boolean isValid(String password, ConstraintValidatorContext constraintValidatorContext) {
     if (StringUtils.isEmpty(authenticationType) || authenticationType.equalsIgnoreCase("db")) {
-      Matcher matcher = Pattern.compile(PASSWORD_REGEX).matcher(password);
+      Matcher matcher = PASSWORD_PATTERN.matcher(password);
       if (!matcher.find()) {
         constraintValidatorContext
             .buildConstraintViolationWithTemplate(PASSWORD_REGEX_VALIDATION_STR)


### PR DESCRIPTION
## Summary

The password validators compiled the `PASSWORD_REGEX` pattern on **every** validation call:

- `core/src/main/java/io/aiven/klaw/validation/PasswordValidatorImpl.java`
- `core/src/main/java/io/aiven/klaw/validation/PasswordUpdateValidatorImpl.java`

Both called `Pattern.compile(PASSWORD_REGEX).matcher(password)` inside `isValid(...)`. That method runs on the hot path — every user registration and every password update. `Pattern.compile` is comparatively expensive (parses the regex AST each time), so this was wasteful.

The change moves the compiled pattern into a `private static final Pattern PASSWORD_PATTERN = Pattern.compile(PASSWORD_REGEX);` field, mirroring the pattern already used in `UsersTeamsControllerService` (`emailUsernamePattern`, `defaultPattern`).

## Measured speedup

A standalone microbenchmark reproducing the exact pre/post logic (`Pattern.compile` per call vs precompiled static pattern) over 20,000,000 operations:

| Variant | Time (ns / op) | vs baseline |
| --- | --- | --- |
| Before (compile each call) | ~950 ns/op | baseline |
| After (precompiled) | ~485 ns/op | **~1.97x faster** |

Across repeated runs the speedup was consistently **1.7x–2.0x (41–49% faster)** on the validation hot path — comfortably above the 20% target.

```
BEFORE (compile each call): 19,095,410,100 ns total (954.771 ns/op)
AFTER  (precompiled)     :  9,691,967,900 ns total (484.598 ns/op)
Speedup: 1.97x (49.2% faster)
```

## Risk

- No behavioral change: `PASSWORD_REGEX` is unchanged (`(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}`), only moved from a per-call compile to a one-time static init.
- Validation results (`true`/`false`) are identical; only the cost drops.
- Thread-safe: `Pattern` instances are immutable and safe for concurrent `matcher()` use.

## Test plan

- [x] Logic equivalence preserved (same regex, same matcher logic).
- [x] Standalone benchmark shows 41–49% faster on the hot path.
- [ ] Existing klaw validation tests still pass (CI).
